### PR TITLE
Add configurable logging options

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,6 +5,7 @@
   "scales": [0.88, 0.92, 0.96, 1.0, 1.04, 1.08, 1.12],
   "loop_minutes": 6,
   "debug": false,
+  "verbose_logging": false,
   "keys": {
     "idle_vill": ".",
     "build_menu": "b",

--- a/config.sample.json
+++ b/config.sample.json
@@ -5,6 +5,7 @@
   "scales": [0.88, 0.92, 0.96, 1.0, 1.04, 1.08, 1.12],
   "loop_minutes": 6,
   "debug": false,
+  "verbose_logging": false,
   "keys": {
     "idle_vill": ".",
     "build_menu": "b",


### PR DESCRIPTION
## Summary
- configure logging with INFO/DEBUG levels based on `verbose_logging` flag
- replace prints with logging calls in wait_hud, econ_loop, and main
- document new `verbose_logging` option in config files

## Testing
- `python -m py_compile campaign_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a680956e408325b9fee5b121b0520f