### PR TITLE
Decouple HUD capture from minimap bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,15 @@
 
 If neither option is provided, `pytesseract` will attempt to find `tesseract` on the system `PATH`.
 
+## Configuration notes
+
+The bot locates the minimap on the screen to establish an anchor for HUD
+offset calculations. This anchor no longer limits the capture area—frames are
+grabbed from the whole screen unless a different region is explicitly
+requested.
+
+HUD-related coordinates, such as `areas.pop_box`, are specified as
+``[x, y, width, height]`` fractions of the full screen. These values are
+interpreted relative to the screen; the minimap anchor is only used to adjust
+offsets when necessary.
+

--- a/config.json
+++ b/config.json
@@ -22,7 +22,8 @@
     "house_spot": [0.47, 0.72],
     "granary_spot": [0.44, 0.66],
     "storage_spot": [0.58, 0.52],
-    "pop_box": [0.93, 0.02, 0.05, 0.04]
+    "pop_box": [0.93, 0.02, 0.05, 0.04],
+    "//pop_box": "[x, y, w, h] normalizados na tela inteira; a posição do minimapa serve apenas como âncora."
   },
   "timers": {
     "house_interval": 45.0,

--- a/config.sample.json
+++ b/config.sample.json
@@ -22,7 +22,8 @@
     "house_spot": [0.47, 0.72],
     "granary_spot": [0.44, 0.66],
     "storage_spot": [0.58, 0.52],
-    "pop_box": [0.93, 0.02, 0.05, 0.04]
+    "pop_box": [0.93, 0.02, 0.05, 0.04],
+    "//pop_box": "[x, y, w, h] normalizados na tela inteira; a posição do minimapa serve apenas como âncora."
   },
   "timers": {
     "house_interval": 45.0,

--- a/tests/test_population_roi.py
+++ b/tests/test_population_roi.py
@@ -33,20 +33,16 @@ import campaign_bot as cb
 
 
 class TestPopulationROI(TestCase):
-    def test_population_roi_outside_hud_does_not_raise(self):
-        cb.HUD_REGION = {"left": 0, "top": 0, "width": 100, "height": 100}
-
-        small_frame = np.zeros((100, 100, 3), dtype=np.uint8)
+    def test_population_roi_outside_screen_does_not_raise(self):
         big_frame = np.zeros((200, 200, 3), dtype=np.uint8)
 
-        def fake_grab_frame(bbox=None):
-            if bbox is cb.MONITOR:
-                return big_frame
-            return small_frame
-
-        with patch("campaign_bot._grab_frame", side_effect=fake_grab_frame), \
+        with patch("campaign_bot._grab_frame", return_value=big_frame), \
             patch("campaign_bot._screen_size", return_value=(200, 200)), \
-            patch("campaign_bot.pytesseract.image_to_data", return_value={"text": [""], "conf": ["-1"]}):
+            patch.dict(cb.CFG["areas"], {"pop_box": [2.0, 2.0, 0.1, 0.1]}), \
+            patch(
+                "campaign_bot.pytesseract.image_to_data",
+                return_value={"text": [""], "conf": ["-1"]},
+            ):
             try:
                 cb.read_population_from_hud(retries=1)
             except Exception as exc:  # pragma: no cover


### PR DESCRIPTION
## Summary
- Store minimap position as `HUD_ANCHOR` used for offset calculations
- Always capture full-screen frames and compute population box via absolute screen coords
- Document `pop_box` as screen-relative and adjusted via minimap anchor

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a692a4a7b48325abd62a9a18fdbbe6