### PR TITLE
Tie population ROI to HUD anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ grabbed from the whole screen unless a different region is explicitly
 requested.
 
 HUD-related coordinates, such as `areas.pop_box`, are specified as
-``[x, y, width, height]`` fractions of the full screen. These values are
-interpreted relative to the screen; the minimap anchor is only used to adjust
-offsets when necessary.
+``[dx, dy, width, height]`` fractions relative to this anchor. The minimap
+position serves as the reference origin for these offsets.
 

--- a/campaign_bot.py
+++ b/campaign_bot.py
@@ -135,11 +135,23 @@ def read_population_from_hud(retries=3, conf_threshold=60):
     for attempt in range(retries):
         frame = _grab_frame()
 
-        W_screen, H_screen = _screen_size()
-        abs_left = int(x * W_screen)
-        abs_top = int(y * H_screen)
-        pw = int(w * W_screen)
-        ph = int(h * H_screen)
+        if HUD_ANCHOR:
+            ax, ay, aw, ah = (
+                HUD_ANCHOR["left"],
+                HUD_ANCHOR["top"],
+                HUD_ANCHOR["width"],
+                HUD_ANCHOR["height"],
+            )
+            abs_left = int(ax + x * aw)
+            abs_top = int(ay + y * ah)
+            pw = int(w * aw)
+            ph = int(h * ah)
+        else:
+            W_screen, H_screen = _screen_size()
+            abs_left = int(x * W_screen)
+            abs_top = int(y * H_screen)
+            pw = int(w * W_screen)
+            ph = int(h * H_screen)
 
         h_frame, w_frame = frame.shape[:2]
         x1 = max(0, abs_left)

--- a/config.json
+++ b/config.json
@@ -22,8 +22,8 @@
     "house_spot": [0.47, 0.72],
     "granary_spot": [0.44, 0.66],
     "storage_spot": [0.58, 0.52],
-    "pop_box": [0.93, 0.02, 0.05, 0.04],
-    "//pop_box": "[x, y, w, h] normalizados na tela inteira; a posição do minimapa serve apenas como âncora."
+    "pop_box": [0.15, -0.88, 0.05, 0.04],
+    "//pop_box": "[dx, dy, w, h] offsets a partir do âncora do minimapa, normalizados pela largura/altura do âncora."
   },
   "timers": {
     "house_interval": 45.0,

--- a/config.sample.json
+++ b/config.sample.json
@@ -22,8 +22,8 @@
     "house_spot": [0.47, 0.72],
     "granary_spot": [0.44, 0.66],
     "storage_spot": [0.58, 0.52],
-    "pop_box": [0.93, 0.02, 0.05, 0.04],
-    "//pop_box": "[x, y, w, h] normalizados na tela inteira; a posição do minimapa serve apenas como âncora."
+    "pop_box": [0.15, -0.88, 0.05, 0.04],
+    "//pop_box": "[dx, dy, w, h] offsets a partir do âncora do minimapa, normalizados pela largura/altura do âncora."
   },
   "timers": {
     "house_interval": 45.0,

--- a/tests/test_population_roi.py
+++ b/tests/test_population_roi.py
@@ -48,3 +48,42 @@ class TestPopulationROI(TestCase):
             except Exception as exc:  # pragma: no cover
                 self.fail(f"read_population_from_hud raised {exc}")
 
+    def test_population_roi_respects_anchor_offsets(self):
+        frame = np.arange(200 * 200 * 3, dtype=np.uint8).reshape(200, 200, 3)
+        pop_box = [0.1, 0.2, 0.5, 0.4]
+
+        anchors = [
+            {"left": 10, "top": 20, "width": 50, "height": 50},
+            {"left": 30, "top": 40, "width": 50, "height": 50},
+        ]
+
+        for anchor in anchors:
+            recorded = {}
+
+            def fake_cvtColor(src, code):
+                recorded["roi"] = src
+                return src
+
+            with patch("campaign_bot._grab_frame", return_value=frame), \
+                patch.object(cb, "HUD_ANCHOR", anchor), \
+                patch.dict(cb.CFG["areas"], {"pop_box": pop_box}), \
+                patch("campaign_bot.cv2.cvtColor", side_effect=fake_cvtColor), \
+                patch("campaign_bot.cv2.resize", side_effect=lambda img, *a, **k: img), \
+                patch("campaign_bot.cv2.threshold", side_effect=lambda img, *a, **k: (None, img)), \
+                patch(
+                    "campaign_bot.pytesseract.image_to_data",
+                    return_value={"text": ["12/34"], "conf": ["70"]},
+                ):
+                cb.read_population_from_hud(retries=1)
+
+            roi = recorded["roi"]
+            expected_left = anchor["left"] + int(pop_box[0] * anchor["width"])
+            expected_top = anchor["top"] + int(pop_box[1] * anchor["height"])
+            expected_w = int(pop_box[2] * anchor["width"])
+            expected_h = int(pop_box[3] * anchor["height"])
+            expected_roi = frame[
+                expected_top : expected_top + expected_h,
+                expected_left : expected_left + expected_w,
+            ]
+            self.assertTrue(np.array_equal(roi, expected_roi))
+


### PR DESCRIPTION
## Summary
- anchor population HUD reading to minimap position when HUD_ANCHOR is set
- store population ROI as offsets from the minimap anchor
- document HUD coordinate system and test anchor-relative ROI calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a699e97f948325a0e29236cc547c7f