### PR TITLE
Resolve HUD template paths from repository root

### DIFF
--- a/campaign_bot.py
+++ b/campaign_bot.py
@@ -90,7 +90,7 @@ def wait_hud(timeout=60):
     while time.time() - t0 < timeout:
         frame = _grab_frame()
         for name in CFG["look_for"]:
-            tmpl = _load_gray(ASSETS / name)
+            tmpl = _load_gray(ROOT / name)
             box, score, heat = _find_template(
                 frame, tmpl, threshold=CFG["threshold"], scales=CFG["scales"]
             )

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "profile": "aoe1de",
-  "look_for": ["ui_minimap.png", "hud_resources.png"],
+  "look_for": ["../campaigns/Ascent_of_Egypt/Hunting_startscreen.png"],
   "threshold": 0.82,
   "scales": [0.88, 0.92, 0.96, 1.0, 1.04, 1.08, 1.12],
   "loop_minutes": 6,


### PR DESCRIPTION
## Summary
- Look for the Hunting campaign start screen when detecting the HUD
- Load HUD templates relative to the repository root instead of the assets folder

## Testing
- `python - <<'PY'
import types, sys
import numpy as np

dummy_pg = types.SimpleNamespace(
    PAUSE=0,
    FAILSAFE=False,
    size=lambda: (200, 200),
    click=lambda *a, **k: None,
    moveTo=lambda *a, **k: None,
    press=lambda *a, **k: None,
)

class DummyMSS:
    monitors = [{}, {"left": 0, "top": 0, "width": 200, "height": 200}]
    def grab(self, region):
        h, w = region["height"], region["width"]
        return np.zeros((h, w, 4), dtype=np.uint8)

dummy_pytesseract = types.SimpleNamespace(
    pytesseract=types.SimpleNamespace(tesseract_cmd=""),
    image_to_data=lambda *a, **k: {"text": [""], "conf": ["0"]},
)

sys.modules.setdefault("pyautogui", dummy_pg)
sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
sys.modules.setdefault("pytesseract", dummy_pytesseract)

import cv2, pathlib
import campaign_bot
from unittest.mock import patch
frame = cv2.imread(str(pathlib.Path('../campaigns/Ascent_of_Egypt/Hunting_startscreen.png')))
with patch('campaign_bot._grab_frame', return_value=frame):
    hud, name = campaign_bot.wait_hud(timeout=2)
    print('hud', hud, 'name', name)
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a69c6b02748325af5670a0da2927c3