### PR TITLE
Use minimap template for HUD anchor

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "profile": "aoe1de",
-  "look_for": ["campaigns/Ascent_of_Egypt/Hunting_startscreen.png"],
+  "look_for": ["assets/ui_minimap.png"],
   "threshold": 0.82,
   "scales": [0.88, 0.92, 0.96, 1.0, 1.04, 1.08, 1.12],
   "loop_minutes": 6,


### PR DESCRIPTION
## Summary
- Anchor HUD detection on the minimap by switching to `assets/ui_minimap.png`.
- Keep population box offsets tuned for minimap reference.

## Testing
- `pytest`
- `xvfb-run -a timeout 5 python campaign_bot.py` *(fails: waits for HUD; unable to verify population values without a game display)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a7efa97883259a49b8ff60bc2afc