### PR TITLE
Fix population HUD box coordinates

### DIFF
--- a/config.json
+++ b/config.json
@@ -22,7 +22,7 @@
     "house_spot": [0.47, 0.72],
     "granary_spot": [0.44, 0.66],
     "storage_spot": [0.58, 0.52],
-    "pop_box": [0.15, -0.88, 0.05, 0.04],
+    "pop_box": [-2.84, -4.67, 0.16, 0.14],
     "//pop_box": "[dx, dy, w, h] offsets a partir do âncora do minimapa, normalizados pela largura/altura do âncora."
   },
   "timers": {

--- a/config.sample.json
+++ b/config.sample.json
@@ -22,7 +22,7 @@
     "house_spot": [0.47, 0.72],
     "granary_spot": [0.44, 0.66],
     "storage_spot": [0.58, 0.52],
-    "pop_box": [0.15, -0.88, 0.05, 0.04],
+    "pop_box": [-2.84, -4.67, 0.16, 0.14],
     "//pop_box": "[dx, dy, w, h] offsets a partir do âncora do minimapa, normalizados pela largura/altura do âncora."
   },
   "timers": {


### PR DESCRIPTION
## Summary
- refine `areas.pop_box` ROI fractions so the population numbers sit inside the crop

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6ad8107b08325b1c196ff77d196e1