### PR TITLE
Validate population ROI bounds before OCR

### DIFF
--- a/tests/test_population_roi.py
+++ b/tests/test_population_roi.py
@@ -43,8 +43,13 @@ class TestPopulationROI(TestCase):
                 "campaign_bot.pytesseract.image_to_data",
                 return_value={"text": [""], "conf": ["-1"]},
             ):
-            with self.assertRaises(cb.PopulationReadError):
+            with self.assertRaises(cb.PopulationReadError) as ctx:
                 cb.read_population_from_hud(retries=1, conf_threshold=cb.CFG["ocr_conf_threshold"])
+            msg = str(ctx.exception).lower()
+            self.assertIn("recalibrate areas.pop_box", msg)
+            self.assertIn("left=", msg)
+            self.assertIn("top=", msg)
+            self.assertIn("hud_anchor", msg)
 
     def test_read_population_raises_when_no_digits(self):
         frame = np.zeros((200, 200, 3), dtype=np.uint8)


### PR DESCRIPTION
## Summary
- Compute population ROI absolute coordinates once and check screen bounds before attempting OCR
- Provide detailed PopulationReadError with coordinates and HUD anchor when ROI is invalid
- Ensure tests validate ROI bound handling and message contents

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a774fe44b483259d06557e0f54f521