### PR TITLE
Skip OCR when population ROI invalid

### DIFF
--- a/campaign_bot.py
+++ b/campaign_bot.py
@@ -185,6 +185,15 @@ def read_population_from_hud(retries=3, conf_threshold=None):
     last_text = ""
 
     for attempt in range(retries):
+        if x2 <= x1 or y2 <= y1:
+            logging.warning(
+                "population ROI invalid: x1=%s, x2=%s, y1=%s, y2=%s",
+                x1,
+                x2,
+                y1,
+                y2,
+            )
+            continue
         frame = _grab_frame()
 
         roi = frame[y1:y2, x1:x2]


### PR DESCRIPTION
## Summary
- skip population OCR when ROI dimensions are invalid
- warn and retry without delay when population ROI is invalid
- cover invalid population ROI case with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7787d5d2083258629e12ca4923655