### PR TITLE
Clarify pop_box screen fraction config and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,17 @@ If neither option is provided, `pytesseract` will attempt to find `tesseract` on
 
 ## Configuration notes
 
-The bot locates the minimap on the screen to establish an anchor for HUD
-offset calculations. This anchor no longer limits the capture area—frames are
-grabbed from the whole screen unless a different region is explicitly
-requested.
+The bot locates HUD elements (such as the minimap or resource bar) only to
+confirm that the interface is visible. Frames are captured from the whole
+screen unless a different region is explicitly requested.
 
-HUD-related coordinates, such as `areas.pop_box`, are specified as
-``[dx, dy, width, height]`` fractions relative to this anchor. The minimap
-position serves as the reference origin for these offsets.
+HUD-related coordinates, such as `areas.pop_box`, use ``[x, y, width, height]``
+fractions of the entire screen. The default values in `config.json` are
+placeholders and should be calibrated for your setup.
 
 ## Capturing `hud_resources.png`
 
-Some HUD layouts place the minimap and the resource bar at different offsets.
+Some HUD layouts place the minimap and the resource bar at different positions.
 The bot now searches for either element, so a suitable `hud_resources.png`
 template is required for your configuration.
 
@@ -36,13 +35,13 @@ template is required for your configuration.
 
 ## Calibration helper
 
-To recalculate the `areas.pop_box` offsets interactively, run:
+To calibrate the `areas.pop_box` fractions interactively, run:
 
 ```
 python tools/calibrate_pop_box.py
 ```
 
 The script waits for the HUD to be detected, shows a screenshot, and lets you
-draw the population box. The normalized `[dx, dy, width, height]` values are
+draw the population box. The normalized `[x, y, width, height]` values are
 printed and you can choose to write them back to `config.json` automatically.
 

--- a/campaign_bot.py
+++ b/campaign_bot.py
@@ -38,7 +38,7 @@ CURRENT_POP = 3
 # Instância única do mss para reutilização
 SCT = mss()
 MONITOR = SCT.monitors[1]  # tela principal
-# Posição do minimapa utilizada apenas como referência
+# Posição detectada do HUD usada apenas como referência
 HUD_ANCHOR = None
 
 
@@ -52,9 +52,9 @@ def _grab_frame(bbox=None):
     """Captura um frame da tela.
 
     Se ``bbox`` for fornecido, captura apenas a região especificada.
-    Caso contrário, captura a tela inteira. A posição do minimapa
-    (``HUD_ANCHOR``) não limita a área capturada; ela é utilizada apenas
-    como referência para cálculos de offset.
+    Caso contrário, captura a tela inteira. A detecção do HUD
+    (``HUD_ANCHOR``) serve apenas como confirmação visual e não
+    restringe a área capturada.
     """
     region = bbox or MONITOR
     img = np.array(SCT.grab(region))[:, :, :3]  # BGRA -> BGR

--- a/config.json
+++ b/config.json
@@ -23,8 +23,8 @@
     "house_spot": [0.47, 0.72],
     "granary_spot": [0.44, 0.66],
     "storage_spot": [0.58, 0.52],
-    "pop_box": [-2.84, -4.67, 0.16, 0.14],
-    "//pop_box": "[dx, dy, w, h] offsets a partir do âncora do minimapa, normalizados pela largura/altura do âncora."
+    "pop_box": [0.0, 0.0, 0.1, 0.1],
+    "//pop_box": "[x, y, w, h] como frações da tela; calibrar depois."
   },
   "timers": {
     "house_interval": 45.0,

--- a/config.sample.json
+++ b/config.sample.json
@@ -23,8 +23,8 @@
     "house_spot": [0.47, 0.72],
     "granary_spot": [0.44, 0.66],
     "storage_spot": [0.58, 0.52],
-    "pop_box": [-2.84, -4.67, 0.16, 0.14],
-    "//pop_box": "[dx, dy, w, h] offsets a partir do âncora do minimapa, normalizados pela largura/altura do âncora."
+    "pop_box": [0.0, 0.0, 0.1, 0.1],
+    "//pop_box": "[x, y, w, h] como frações da tela; calibrar depois."
   },
   "timers": {
     "house_interval": 45.0,


### PR DESCRIPTION
## Summary
- define `areas.pop_box` using screen fractions with placeholder values
- explain screen-based coordinates and calibration in README
- remove leftover minimap-offset references in code comments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a785d1d584832588abbb51e15f3600