### PR TITLE
Enable right-click building with population update

### DIFF
--- a/script/common.py
+++ b/script/common.py
@@ -330,10 +330,10 @@ def _to_px(nx, ny):
     W, H = _screen_size()
     return int(nx * W), int(ny * H)
 
-def _click_norm(nx, ny):
+def _click_norm(nx, ny, button="left"):
     x, y = _to_px(nx, ny)
     try:
-        pg.click(x, y)
+        pg.click(x, y, button=button)
     except pg.FailSafeException:
         logging.warning(
             "Fail-safe triggered during click at (%s, %s). Moving cursor to center.",
@@ -341,7 +341,7 @@ def _click_norm(nx, ny):
             y,
         )
         _move_cursor_safe()
-        pg.click(x, y)
+        pg.click(x, y, button=button)
 
 def _move_cursor_safe():
     W, H = _screen_size()

--- a/script/villager.py
+++ b/script/villager.py
@@ -46,6 +46,7 @@ def build_house():
         common._press_key_safe(common.CFG["keys"]["build_menu"], 0.05)
         common._press_key_safe(house_key, 0.15)
         common._click_norm(hx, hy)
+        common._click_norm(hx, hy, button="right")
         time.sleep(0.5)
 
         try:

--- a/tests/test_build_house.py
+++ b/tests/test_build_house.py
@@ -1,0 +1,58 @@
+import os
+import sys
+import types
+from unittest import TestCase
+from unittest.mock import patch
+
+import numpy as np
+
+# Stub modules that require a GUI/display before importing the bot modules
+
+dummy_pg = types.SimpleNamespace(
+    PAUSE=0,
+    FAILSAFE=False,
+    size=lambda: (200, 200),
+    click=lambda *a, **k: None,
+    moveTo=lambda *a, **k: None,
+    press=lambda *a, **k: None,
+)
+
+
+class DummyMSS:
+    monitors = [{}, {"left": 0, "top": 0, "width": 200, "height": 200}]
+
+    def grab(self, region):
+        h, w = region["height"], region["width"]
+        return np.zeros((h, w, 4), dtype=np.uint8)
+
+
+sys.modules.setdefault("pyautogui", dummy_pg)
+sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import script.common as common
+import script.villager as villager
+
+
+class TestClickAndBuildHouse(TestCase):
+    def test_click_norm_passes_button(self):
+        with patch("script.common.pg.click") as click_mock:
+            common._click_norm(0.5, 0.5, button="right")
+        click_mock.assert_called_once_with(100, 100, button="right")
+
+    def test_build_house_uses_right_click_and_updates_population(self):
+        common.POP_CAP = 4
+        expected_coords = tuple(common.CFG["areas"]["house_spot"])
+        with patch("script.common.read_resources_from_hud", return_value={"wood": 100}), \
+            patch("script.common._press_key_safe"), \
+            patch("script.common._click_norm") as click_mock, \
+            patch("script.common.read_population_from_hud", return_value=(0, 8)) as read_pop_mock, \
+            patch("script.villager.time.sleep"):
+            result = villager.build_house()
+        self.assertTrue(result)
+        self.assertEqual(common.POP_CAP, 8)
+        self.assertEqual(click_mock.call_count, 2)
+        self.assertEqual(click_mock.call_args_list[0].args, expected_coords)
+        self.assertEqual(click_mock.call_args_list[1].args, expected_coords)
+        self.assertEqual(click_mock.call_args_list[1].kwargs["button"], "right")
+        read_pop_mock.assert_called_once()


### PR DESCRIPTION
## Summary
- allow `_click_norm` to specify mouse button and handle fail-safe
- build houses with an extra right-click to start construction
- add tests for right-click building and population cap updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7bda56a388325a8c6578f39e2c831