### PR TITLE
Handle missing resource bar errors

### DIFF
--- a/script/common.py
+++ b/script/common.py
@@ -323,8 +323,8 @@ def read_resources_from_hud():
             regions[name] = (left, top, width, height)
 
     if not regions:
-        logging.warning("No resource regions located on HUD; returning zeros")
-        return {k: 0 for k in ["food", "wood", "gold", "stone", "population", "idle_villager"]}
+        logging.error("Resource bar not located on HUD")
+        return None
 
     results = {}
     for name, (x, y, w, h) in regions.items():

--- a/script/town_center.py
+++ b/script/town_center.py
@@ -11,6 +11,9 @@ def train_villagers(target_pop: int):
 
     while common.CURRENT_POP < target_pop:
         resources = common.read_resources_from_hud()
+        if resources is None:
+            logging.error("Resource bar not located; stopping villager training")
+            break
         if resources.get("food", 0) < 50:
             logging.info(
                 "Comida insuficiente (%s) para treinar aldeões.",

--- a/script/villager.py
+++ b/script/villager.py
@@ -25,6 +25,9 @@ def build_house():
 
     wood_needed = 30
     resources = common.read_resources_from_hud()
+    if resources is None:
+        logging.error("Resource bar not located; cannot build house")
+        return False
     if resources.get("wood", 0) < wood_needed:
         logging.warning(
             "Madeira insuficiente (%s) para construir casa.",
@@ -61,6 +64,9 @@ def build_house():
 
         logging.warning("Tentativa %s de construir casa falhou.", idx)
         resources = common.read_resources_from_hud()
+        if resources is None:
+            logging.error("Resource bar not located; aborting house construction")
+            return False
         if resources.get("wood", 0) < wood_needed:
             logging.warning(
                 "Madeira insuficiente após tentativa (%s).", resources.get("wood", 0)
@@ -121,13 +127,17 @@ def econ_loop(minutes=5):
 
         if common.CURRENT_POP >= common.POP_CAP - 2:
             resources = common.read_resources_from_hud()
+            if resources is None:
+                logging.error("Resource bar not located; ending economic loop")
+                break
             idle_before = resources.get("idle_villager", 0)
             took_from_wood = False
 
             if idle_before > 0:
                 select_idle_villager()
                 time.sleep(0.1)
-                idle_after = common.read_resources_from_hud().get("idle_villager", 0)
+                idle_after_res = common.read_resources_from_hud()
+                idle_after = idle_after_res.get("idle_villager", 0) if idle_after_res else 0
                 if idle_after >= idle_before:
                     common._click_norm(wood_x, wood_y)
                     took_from_wood = True

--- a/tests/test_missing_resource_bar.py
+++ b/tests/test_missing_resource_bar.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import types
+from unittest import TestCase
+from unittest.mock import patch
+
+import numpy as np
+
+# Stub modules that require a GUI/display before importing the bot modules
+
+dummy_pg = types.SimpleNamespace(
+    PAUSE=0,
+    FAILSAFE=False,
+    size=lambda: (200, 200),
+    click=lambda *a, **k: None,
+    moveTo=lambda *a, **k: None,
+    press=lambda *a, **k: None,
+)
+
+
+class DummyMSS:
+    monitors = [{}, {"left": 0, "top": 0, "width": 200, "height": 200}]
+
+    def grab(self, region):
+        h, w = region["height"], region["width"]
+        return np.zeros((h, w, 4), dtype=np.uint8)
+
+
+sys.modules.setdefault("pyautogui", dummy_pg)
+sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import script.common as common
+import script.town_center as tc
+import script.villager as villager
+
+
+class TestMissingResourceBar(TestCase):
+    def test_train_villagers_handles_missing_bar(self):
+        common.CURRENT_POP = 3
+        common.POP_CAP = 5
+        with patch("script.common.read_resources_from_hud", return_value=None), \
+             patch("script.town_center.select_idle_villager"), \
+             patch("script.town_center.build_house"):
+            tc.train_villagers(5)
+        self.assertEqual(common.CURRENT_POP, 3)
+
+    def test_build_house_handles_missing_bar(self):
+        common.POP_CAP = 4
+        with patch("script.common.read_resources_from_hud", return_value=None):
+            self.assertFalse(villager.build_house())


### PR DESCRIPTION
## Summary
- Log an error when the resource bar cannot be found and return `None`
- Handle missing resource bar in villager training and house building routines
- Test that training and house building abort gracefully when the resource bar is absent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7c2de3234832582a075d6ba4fa278