### PR TITLE
Improve resource panel detection reliability

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
   "profile": "aoe1de",
   "look_for": ["assets/resources_population.png", "assets/ui_minimap.png"],
   "threshold": 0.82,
+  "threshold_fallback": 0.7,
   "scales": [0.88, 0.92, 0.96, 1.0, 1.04, 1.08, 1.12],
   "loop_minutes": 6,
   "debug": false,

--- a/config.sample.json
+++ b/config.sample.json
@@ -2,6 +2,7 @@
   "profile": "aoe1de",
   "look_for": ["ui_minimap.png", "assets/resources_population.png"],
   "threshold": 0.82,
+  "threshold_fallback": 0.7,
   "scales": [0.88, 0.92, 0.96, 1.0, 1.04, 1.08, 1.12],
   "loop_minutes": 6,
   "debug": false,

--- a/script/town_center.py
+++ b/script/town_center.py
@@ -10,8 +10,14 @@ def train_villagers(target_pop: int):
     common._press_key_safe(common.CFG["keys"]["select_tc"], 0.10)
 
     while common.CURRENT_POP < target_pop:
-        resources = common.read_resources_from_hud()
-        if resources is None:
+        try:
+            resources = common.read_resources_from_hud()
+        except common.ResourceReadError as exc:
+            logging.error(
+                "Resource bar not located; stopping villager training: %s", exc
+            )
+            break
+        if not resources:
             logging.error("Resource bar not located; stopping villager training")
             break
         if resources.get("food", 0) < 50:


### PR DESCRIPTION
## Summary
- Save debug frame and heatmap when resource panel template matching fails and retry with configurable fallback threshold
- Raise `ResourceReadError` when resource values can't be read, avoiding silent zeroed resources
- Handle new exception in villager and town center logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7c70b0af0832589df71c93b5f77fd