### PR TITLE
refactor: centralize template matching util

### DIFF
--- a/script/common.py
+++ b/script/common.py
@@ -11,6 +11,7 @@ import cv2
 from mss import mss
 import pyautogui as pg
 import pytesseract
+from .template_utils import find_template
 
 # =========================
 # CONFIGURAÇÃO
@@ -110,35 +111,6 @@ def _load_gray(path):
 
 HUD_TEMPLATES = {name: _load_gray(ROOT / name) for name in CFG.get("look_for", [])}
 
-def _find_template(frame_bgr, tmpl_gray, threshold=0.82, scales=None):
-    frame_gray = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2GRAY)
-    h0, w0 = tmpl_gray.shape[:2]
-    best = (None, -1, None)  # (box, score, heatmap)
-    for s in (scales or [1.0]):
-        th, tw = int(h0 * s), int(w0 * s)
-        if th < 10 or tw < 10:
-            continue
-        if th > frame_gray.shape[0] or tw > frame_gray.shape[1]:
-            logging.debug(
-                "Template %sx%s exceeds frame %sx%s at scale %.2f, skipping",
-                tw,
-                th,
-                frame_gray.shape[1],
-                frame_gray.shape[0],
-                s,
-            )
-            continue
-        tmpl = cv2.resize(tmpl_gray, (tw, th), interpolation=cv2.INTER_AREA)
-        res = cv2.matchTemplate(frame_gray, tmpl, cv2.TM_CCOEFF_NORMED)
-        _, max_val, _, max_loc = cv2.minMaxLoc(res)
-        if max_val > best[1]:
-            x, y = max_loc
-            best = ((x, y, tw, th), max_val, res)
-    box, score, heat = best
-    if score >= threshold:
-        return box, score, heat
-    return None, score, heat
-
 def wait_hud(timeout=60):
     logging.info("Aguardando HUD por até %ss...", timeout)
     t0 = time.time()
@@ -146,7 +118,7 @@ def wait_hud(timeout=60):
     while time.time() - t0 < timeout:
         frame = _grab_frame()
         for name, tmpl in HUD_TEMPLATES.items():
-            box, score, heat = _find_template(
+            box, score, heat = find_template(
                 frame, tmpl, threshold=CFG["threshold"], scales=CFG["scales"]
             )
             if score > last_best[0]:
@@ -289,7 +261,7 @@ def locate_resource_panel(frame):
                 str(debug_dir / f"resource_panel_heat_{ts}.png"), hm.astype("uint8")
             )
 
-    box, score, heat = _find_template(
+    box, score, heat = find_template(
         frame, tmpl, threshold=CFG["threshold"], scales=CFG["scales"]
     )
     if not box:
@@ -299,7 +271,7 @@ def locate_resource_panel(frame):
         _save_debug(frame, heat)
         fallback = CFG.get("threshold_fallback")
         if fallback is not None:
-            box, score, heat = _find_template(
+            box, score, heat = find_template(
                 frame, tmpl, threshold=fallback, scales=CFG["scales"]
             )
             if not box:

--- a/script/template_utils.py
+++ b/script/template_utils.py
@@ -1,0 +1,54 @@
+import logging
+import cv2
+
+
+def find_template(frame_bgr, tmpl_gray, threshold=0.82, scales=None):
+    """Locate ``tmpl_gray`` within ``frame_bgr``.
+
+    Parameters
+    ----------
+    frame_bgr : np.ndarray
+        Source image in BGR color space.
+    tmpl_gray : np.ndarray
+        Grayscale template to match against ``frame_bgr``.
+    threshold : float, optional
+        Minimum normalized correlation score to consider a match valid.
+    scales : Iterable[float], optional
+        Scales at which to search for the template. If ``None`` a single
+        search at 1.0 scale is performed.
+
+    Returns
+    -------
+    tuple
+        ``(box, score, heatmap)`` where ``box`` is ``(x, y, w, h)`` of the best
+        match or ``None`` if ``score`` falls below ``threshold``.
+    """
+    frame_gray = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2GRAY)
+    h0, w0 = tmpl_gray.shape[:2]
+    best = (None, -1, None)
+
+    for s in (scales or [1.0]):
+        th, tw = int(h0 * s), int(w0 * s)
+        if th < 10 or tw < 10:
+            continue
+        if th > frame_gray.shape[0] or tw > frame_gray.shape[1]:
+            logging.debug(
+                "Template %sx%s exceeds frame %sx%s at scale %.2f, skipping",
+                tw,
+                th,
+                frame_gray.shape[1],
+                frame_gray.shape[0],
+                s,
+            )
+            continue
+        tmpl = cv2.resize(tmpl_gray, (tw, th), interpolation=cv2.INTER_AREA)
+        res = cv2.matchTemplate(frame_gray, tmpl, cv2.TM_CCOEFF_NORMED)
+        _, max_val, _, max_loc = cv2.minMaxLoc(res)
+        if max_val > best[1]:
+            x, y = max_loc
+            best = ((x, y, tw, th), max_val, res)
+
+    box, score, heat = best
+    if score >= threshold:
+        return box, score, heat
+    return None, score, heat


### PR DESCRIPTION
## Summary
- centralize `_find_template` as `find_template` in `script/template_utils.py`
- use shared `find_template` in `script/common.py` and `tools/campaign_bot.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7cb50850c8325882c57fbf078c02f