### PR TITLE
Handle resource anchor panel

### DIFF
--- a/script/common.py
+++ b/script/common.py
@@ -336,40 +336,66 @@ def read_resources_from_hud():
     regions = locate_resource_panel(frame)
 
     if not regions and HUD_ANCHOR:
-        # Fallback: estimate the resource bar position from the previously
-        # detected HUD anchor.  The anchor is assumed to sit at the top of the
-        # screen and the resource panel spans to its right.  The original
-        # template ``resources.png`` measured 568x59 px on a
-        # 1920x1080 display.  Offsets are configurable via
-        # ``resource_panel`` entries in ``config.json``.
-        W, H = _screen_size()
-        margin = int(0.01 * W)  # ~1% horizontal gap between anchor and panel
-        panel_w = int(568 / 1920 * W)
-        panel_h = int(59 / 1080 * H)
-        x = HUD_ANCHOR["left"] + HUD_ANCHOR["width"] + margin
-        y = HUD_ANCHOR["top"]
+        if HUD_ANCHOR.get("asset") == "assets/resources.png":
+            x = HUD_ANCHOR["left"]
+            y = HUD_ANCHOR["top"]
+            w = HUD_ANCHOR["width"]
+            h = HUD_ANCHOR["height"]
 
-        res_cfg = CFG.get("resource_panel", {})
-        top_pct = res_cfg.get("anchor_top_pct", 0.15)
-        height_pct = res_cfg.get("anchor_height_pct", 0.70)
-        icon_trims = res_cfg.get(
-            "anchor_icon_trim_pct", [0.42, 0.42, 0.35, 0.35, 0.35, 0.35]
-        )
-        if not isinstance(icon_trims, (list, tuple)):
-            icon_trims = [icon_trims] * 6
-        right_trim = res_cfg.get("anchor_right_trim_pct", 0.02)
+            slice_w = w / 6
+            res_cfg = CFG.get("resource_panel", {})
+            top_pct = res_cfg.get("top_pct", 0.08)
+            height_pct = res_cfg.get("height_pct", 0.84)
+            icon_trims = res_cfg.get("icon_trim_pct", 0.18)
+            if not isinstance(icon_trims, (list, tuple)):
+                icon_trims = [icon_trims] * 6
+            right_trim = res_cfg.get("right_trim_pct", 0.02)
 
-        slice_w = panel_w / 6
-        top = y + int(top_pct * panel_h)
-        height = int(height_pct * panel_h)
-        names = ["food", "wood", "gold", "stone", "population", "idle_villager"]
-        regions = {}
-        for idx, name in enumerate(names):
-            icon_trim = icon_trims[idx] if idx < len(icon_trims) else icon_trims[-1]
-            left = x + int(idx * slice_w + icon_trim * slice_w)
-            right_limit = x + int((idx + 1) * slice_w - right_trim * slice_w)
-            width = max(10, right_limit - left)
-            regions[name] = (left, top, width, height)
+            top = y + int(top_pct * h)
+            height = int(height_pct * h)
+            names = ["food", "wood", "gold", "stone", "population", "idle_villager"]
+            regions = {}
+            for idx, name in enumerate(names):
+                icon_trim = icon_trims[idx] if idx < len(icon_trims) else icon_trims[-1]
+                left = x + int(idx * slice_w + icon_trim * slice_w)
+                right_limit = x + int((idx + 1) * slice_w - right_trim * slice_w)
+                width = max(18, right_limit - left)
+                regions[name] = (left, top, width, height)
+        else:
+            # Fallback: estimate the resource bar position from the previously
+            # detected HUD anchor.  The anchor is assumed to sit at the top of the
+            # screen and the resource panel spans to its right.  The original
+            # template ``resources.png`` measured 568x59 px on a
+            # 1920x1080 display.  Offsets are configurable via
+            # ``resource_panel`` entries in ``config.json``.
+            W, H = _screen_size()
+            margin = int(0.01 * W)  # ~1% horizontal gap between anchor and panel
+            panel_w = int(568 / 1920 * W)
+            panel_h = int(59 / 1080 * H)
+            x = HUD_ANCHOR["left"] + HUD_ANCHOR["width"] + margin
+            y = HUD_ANCHOR["top"]
+
+            res_cfg = CFG.get("resource_panel", {})
+            top_pct = res_cfg.get("anchor_top_pct", 0.15)
+            height_pct = res_cfg.get("anchor_height_pct", 0.70)
+            icon_trims = res_cfg.get(
+                "anchor_icon_trim_pct", [0.42, 0.42, 0.35, 0.35, 0.35, 0.35]
+            )
+            if not isinstance(icon_trims, (list, tuple)):
+                icon_trims = [icon_trims] * 6
+            right_trim = res_cfg.get("anchor_right_trim_pct", 0.02)
+
+            slice_w = panel_w / 6
+            top = y + int(top_pct * panel_h)
+            height = int(height_pct * panel_h)
+            names = ["food", "wood", "gold", "stone", "population", "idle_villager"]
+            regions = {}
+            for idx, name in enumerate(names):
+                icon_trim = icon_trims[idx] if idx < len(icon_trims) else icon_trims[-1]
+                left = x + int(idx * slice_w + icon_trim * slice_w)
+                right_limit = x + int((idx + 1) * slice_w - right_trim * slice_w)
+                width = max(10, right_limit - left)
+                regions[name] = (left, top, width, height)
 
     if not regions:
         raise ResourceReadError("Resource bar not located on HUD")


### PR DESCRIPTION
## Summary
- Handle HUD anchor when using `assets/resources.png` by slicing counters directly from anchor coordinates
- Preserve original right-side fallback for other HUD anchor assets

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7e93ca0fc83259f4619a07286654b