### PR TITLE
Handle resource anchor in tools HUD utilities

### DIFF
--- a/tests/test_hud_anchor.py
+++ b/tests/test_hud_anchor.py
@@ -6,6 +6,10 @@ from unittest.mock import patch
 
 import numpy as np
 
+# Ensure template loading succeeds even if asset files are missing
+import cv2
+cv2.imread = lambda *a, **k: np.zeros((1, 1), dtype=np.uint8)
+
 # Stub modules that require a GUI/display
 
 dummy_pg = types.SimpleNamespace(
@@ -31,6 +35,7 @@ sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
+import tools.campaign_bot as cb
 
 
 class TestHudAnchor(TestCase):
@@ -66,6 +71,61 @@ class TestHudAnchor(TestCase):
              patch("script.common._grab_frame", side_effect=fake_grab_frame), \
              patch("script.common._ocr_digits_better", side_effect=fake_ocr):
             result = common.read_resources_from_hud()
+
+        expected = {
+            "food": 100,
+            "wood": 200,
+            "gold": 300,
+            "stone": 400,
+            "population": 500,
+            "idle_villager": 600,
+        }
+        self.assertEqual(result, expected)
+
+        expected_boxes = [
+            {"left": 28, "top": 24, "width": 80, "height": 50},
+            {"left": 128, "top": 24, "width": 80, "height": 50},
+            {"left": 228, "top": 24, "width": 80, "height": 50},
+            {"left": 328, "top": 24, "width": 80, "height": 50},
+            {"left": 428, "top": 24, "width": 80, "height": 50},
+            {"left": 528, "top": 24, "width": 80, "height": 50},
+        ]
+        self.assertEqual(grab_calls, expected_boxes)
+
+
+class TestHudAnchorTools(TestCase):
+    def test_wait_hud_sets_asset(self):
+        cb.HUD_ANCHOR = None
+        fake_frame = np.zeros((100, 100, 3), dtype=np.uint8)
+        with patch("tools.campaign_bot._grab_frame", return_value=fake_frame), \
+             patch("tools.campaign_bot.find_template", return_value=((10, 20, 30, 40), 0.9, None)):
+            anchor, asset = cb.wait_hud(timeout=1)
+        self.assertEqual(asset, "assets/ui_minimap.png")
+        self.assertEqual(anchor["asset"], "assets/ui_minimap.png")
+        self.assertEqual(cb.HUD_ANCHOR["asset"], "assets/ui_minimap.png")
+
+    def test_read_resources_uses_anchor_slices(self):
+        anchor = {"left": 10, "top": 20, "width": 600, "height": 60, "asset": "assets/resources.png"}
+        cb.HUD_ANCHOR = anchor.copy()
+
+        digits_iter = iter(["100", "200", "300", "400", "500", "600"])
+        grab_calls = []
+
+        def fake_grab_frame(bbox=None):
+            if bbox:
+                grab_calls.append(bbox.copy())
+                h, w = bbox["height"], bbox["width"]
+                return np.zeros((h, w, 3), dtype=np.uint8)
+            return np.zeros((200, 200, 3), dtype=np.uint8)
+
+        def fake_ocr(gray):
+            d = next(digits_iter)
+            return d, {"text": [d]}
+
+        with patch("tools.campaign_bot.locate_resource_panel", return_value={}), \
+             patch("tools.campaign_bot._grab_frame", side_effect=fake_grab_frame), \
+             patch("tools.campaign_bot._ocr_digits_better", side_effect=fake_ocr):
+            result = cb.read_resources_from_hud()
 
         expected = {
             "food": 100,


### PR DESCRIPTION
## Summary
- Store detected HUD template asset name in `HUD_ANCHOR` for `tools.campaign_bot.wait_hud`
- Support resource-only HUD anchors in `tools.campaign_bot.read_resources_from_hud`
- Extend HUD anchor tests to cover `tools.campaign_bot`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7eb14d11c8325816133404fe68408