### PR TITLE
Gracefully handle missing area config entries

### DIFF
--- a/config.json
+++ b/config.json
@@ -19,15 +19,24 @@
     "storage_pit": "s"
   },
   "resource_panel": {
-    "debug_failed_ocr": true,
-    "top_pct": 0.18,
-    "height_pct": 0.70,
-    "icon_trim_pct": [0.42, 0.42, 0.35, 0.35, 0.35, 0.35],
-    "right_trim_pct": 0.05,
-    "anchor_top_pct": 0.20,
+    "top_pct": 0.08,
+    "height_pct": 0.84,
+    "icon_trim_pct": [0.18, 0.18, 0.18, 0.18, 0.18, 0.18],
+    "right_trim_pct": 0.02,
+    "anchor_top_pct": 0.15,
     "anchor_height_pct": 0.70,
     "anchor_icon_trim_pct": [0.42, 0.42, 0.35, 0.35, 0.35, 0.35],
-    "anchor_right_trim_pct": 0.05
+    "anchor_right_trim_pct": 0.02,
+    "debug_failed_ocr": false
+  },
+  "areas": {
+    "hunt_food": [0.46, 0.7],
+    "wood": [0.62, 0.55],
+    "house_spot": [0.47, 0.72],
+    "granary_spot": [0.44, 0.66],
+    "storage_spot": [0.58, 0.52],
+    "pop_box": [0.0, 0.0, 0.1, 0.1],
+    "//pop_box": "[x, y, w, h] como frações da tela; calibrar depois."
   },
   "timers": {
     "house_interval": 45.0,

--- a/script/common.py
+++ b/script/common.py
@@ -353,7 +353,7 @@ def read_resources_from_hud():
 
             top = y + int(top_pct * h)
             height = int(height_pct * h)
-            names = ["wood", "food", "gold", "stone", "population", "idle_villager"]
+            names = ["food", "wood", "gold", "stone", "population", "idle_villager"]
             regions = {}
             for idx, name in enumerate(names):
                 icon_trim = icon_trims[idx] if idx < len(icon_trims) else icon_trims[-1]
@@ -388,7 +388,7 @@ def read_resources_from_hud():
             slice_w = panel_w / 6
             top = y + int(top_pct * panel_h)
             height = int(height_pct * panel_h)
-            names = ["wood", "food", "gold", "stone", "population", "idle_villager"]
+            names = ["food", "wood", "gold", "stone", "population", "idle_villager"]
             regions = {}
             for idx, name in enumerate(names):
                 icon_trim = icon_trims[idx] if idx < len(icon_trims) else icon_trims[-1]

--- a/script/villager.py
+++ b/script/villager.py
@@ -45,8 +45,13 @@ def build_house():
         logging.warning("Tecla de construção de casa não configurada.")
         return False
 
-    spots = [common.CFG["areas"]["house_spot"]]
-    alt_spot = common.CFG["areas"].get("house_spot_alt")
+    areas = common.CFG.get("areas", {})
+    main_spot = areas.get("house_spot")
+    if not main_spot:
+        logging.warning("House spot not configured.")
+        return False
+    spots = [main_spot]
+    alt_spot = areas.get("house_spot_alt")
     if alt_spot:
         spots.append(alt_spot)
 
@@ -95,8 +100,13 @@ def build_granary():
     if not g_key:
         logging.warning("Tecla de construção de Granary não configurada.")
         return False
+    areas = common.CFG.get("areas", {})
+    spot = areas.get("granary_spot")
+    if not spot:
+        logging.warning("Granary spot not configured.")
+        return False
     common._press_key_safe(g_key, 0.15)
-    gx, gy = common.CFG["areas"]["granary_spot"]
+    gx, gy = spot
     common._click_norm(gx, gy)
     return True
 
@@ -108,8 +118,13 @@ def build_storage_pit():
     if not s_key:
         logging.warning("Tecla de construção de Storage Pit não configurada.")
         return False
+    areas = common.CFG.get("areas", {})
+    spot = areas.get("storage_spot")
+    if not spot:
+        logging.warning("Storage spot not configured.")
+        return False
     common._press_key_safe(s_key, 0.15)
-    sx, sy = common.CFG["areas"]["storage_spot"]
+    sx, sy = spot
     common._click_norm(sx, sy)
     return True
 
@@ -134,8 +149,17 @@ def econ_loop(minutes=5):
         logging.warning("Falha ao posicionar Storage Pit")
     time.sleep(0.5)
 
-    hunt_x, hunt_y = common.CFG["areas"]["hunt_food"]
-    wood_x, wood_y = common.CFG["areas"]["wood"]
+    areas = common.CFG.get("areas", {})
+    hunt_spot = areas.get("hunt_food")
+    if not hunt_spot:
+        logging.warning("Hunt food spot not configured.")
+        return False
+    wood_spot = areas.get("wood")
+    if not wood_spot:
+        logging.warning("Wood spot not configured.")
+        return False
+    hunt_x, hunt_y = hunt_spot
+    wood_x, wood_y = wood_spot
 
     t0 = time.time()
     while time.time() - t0 < minutes * 60:


### PR DESCRIPTION
## Summary
- Avoid KeyErrors in villager routines by safely reading area coordinates and logging warnings
- Define default area and resource panel settings and fix resource reading order

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7f2cd6d8c832592f0e1654c284f0e