### PR TITLE
Align resource name order across modules

### DIFF
--- a/script/common.py
+++ b/script/common.py
@@ -388,7 +388,7 @@ def read_resources_from_hud():
 
             top = y + int(top_pct * h)
             height = int(height_pct * h)
-            names = ["food", "wood", "gold", "stone", "population", "idle_villager"]
+            names = ["wood", "food", "gold", "stone", "population", "idle_villager"]
             regions = {}
             for idx, name in enumerate(names):
                 icon_trim = icon_trims[idx] if idx < len(icon_trims) else icon_trims[-1]
@@ -423,7 +423,7 @@ def read_resources_from_hud():
             slice_w = panel_w / 6
             top = y + int(top_pct * panel_h)
             height = int(height_pct * panel_h)
-            names = ["food", "wood", "gold", "stone", "population", "idle_villager"]
+            names = ["wood", "food", "gold", "stone", "population", "idle_villager"]
             regions = {}
             for idx, name in enumerate(names):
                 icon_trim = icon_trims[idx] if idx < len(icon_trims) else icon_trims[-1]

--- a/tests/test_hud_anchor.py
+++ b/tests/test_hud_anchor.py
@@ -73,8 +73,8 @@ class TestHudAnchor(TestCase):
             result = common.read_resources_from_hud()
 
         expected = {
-            "food": 100,
-            "wood": 200,
+            "wood": 100,
+            "food": 200,
             "gold": 300,
             "stone": 400,
             "population": 500,
@@ -128,8 +128,8 @@ class TestHudAnchorTools(TestCase):
             result = cb.read_resources_from_hud()
 
         expected = {
-            "food": 100,
-            "wood": 200,
+            "wood": 100,
+            "food": 200,
             "gold": 300,
             "stone": 400,
             "population": 500,

--- a/tools/campaign_bot.py
+++ b/tools/campaign_bot.py
@@ -283,7 +283,7 @@ def read_resources_from_hud():
 
             top = y + int(top_pct * h)
             height = int(height_pct * h)
-            names = ["food", "wood", "gold", "stone", "population", "idle_villager"]
+            names = ["wood", "food", "gold", "stone", "population", "idle_villager"]
             regions = {}
             for idx, name in enumerate(names):
                 icon_trim = icon_trims[idx] if idx < len(icon_trims) else icon_trims[-1]
@@ -312,7 +312,7 @@ def read_resources_from_hud():
             slice_w = panel_w / 6
             top = y + int(top_pct * panel_h)
             height = int(height_pct * panel_h)
-            names = ["food", "wood", "gold", "stone", "population", "idle_villager"]
+            names = ["wood", "food", "gold", "stone", "population", "idle_villager"]
             regions = {}
             for idx, name in enumerate(names):
                 icon_trim = icon_trims[idx] if idx < len(icon_trims) else icon_trims[-1]


### PR DESCRIPTION
## Summary
- Ensure fallback HUD resource lists start with wood instead of food
- Keep campaign tools consistent with new resource order
- Update HUD anchor tests for the new resource ordering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7ff53c00483259c7bc422d7495389