### PR TITLE
Use icon templates to detect resource ROIs

### DIFF
--- a/config.json
+++ b/config.json
@@ -19,14 +19,13 @@
     "storage_pit": "s"
   },
   "resource_panel": {
+    "match_threshold": 0.8,
+    "scales": [0.9, 0.95, 1.0, 1.05, 1.1],
+    "roi_padding_left": 2,
+    "roi_padding_right": 2,
+    "min_width": 18,
     "top_pct": 0.08,
     "height_pct": 0.84,
-    "icon_trim_pct": [0.59, 0.59, 0.59, 0.59, 0.18, 0.18],
-    "right_trim_pct": 0.01,
-    "anchor_top_pct": 0.15,
-    "anchor_height_pct": 0.70,
-    "anchor_icon_trim_pct": [0.42, 0.42, 0.35, 0.35, 0.35, 0.35],
-    "anchor_right_trim_pct": 0.02,
     "debug_failed_ocr": true
   },
   "areas": {

--- a/tests/test_hud_anchor.py
+++ b/tests/test_hud_anchor.py
@@ -73,8 +73,8 @@ class TestHudAnchor(TestCase):
             result = common.read_resources_from_hud()
 
         expected = {
-            "wood_stockpile": 100,
-            "food_stockpile": 200,
+            "wood": 100,
+            "food": 200,
             "gold": 300,
             "stone": 400,
             "population": 500,
@@ -83,12 +83,12 @@ class TestHudAnchor(TestCase):
         self.assertEqual(result, expected)
 
         expected_boxes = [
-            {"left": 69, "top": 24, "width": 40, "height": 50},
-            {"left": 169, "top": 24, "width": 40, "height": 50},
-            {"left": 269, "top": 24, "width": 40, "height": 50},
-            {"left": 369, "top": 24, "width": 40, "height": 50},
-            {"left": 428, "top": 24, "width": 81, "height": 50},
-            {"left": 528, "top": 24, "width": 81, "height": 50},
+            {"left": 28, "top": 24, "width": 80, "height": 50},
+            {"left": 128, "top": 24, "width": 80, "height": 50},
+            {"left": 228, "top": 24, "width": 80, "height": 50},
+            {"left": 328, "top": 24, "width": 80, "height": 50},
+            {"left": 428, "top": 24, "width": 80, "height": 50},
+            {"left": 528, "top": 24, "width": 80, "height": 50},
         ]
         self.assertEqual(grab_calls, expected_boxes)
 


### PR DESCRIPTION
## Summary
- Detect individual resource icons in the HUD to derive ROIs instead of fixed slices
- Configure new resource panel matching parameters such as match threshold, scales and ROI paddings
- Update tests for new ROI defaults

## Testing
- `pytest tests/test_hud_anchor.py tests/test_population_roi.py`

------
https://chatgpt.com/codex/tasks/task_e_68a8ef644b748325ac40482d81e8e8e7