### PR TITLE
Add retry logic for HUD resource reads

### DIFF
--- a/script/town_center.py
+++ b/script/town_center.py
@@ -10,12 +10,23 @@ def train_villagers(target_pop: int):
     common._press_key_safe(common.CFG["keys"]["select_tc"], 0.10)
 
     while common.CURRENT_POP < target_pop:
-        try:
-            resources = common.read_resources_from_hud()
-        except common.ResourceReadError as exc:
-            logging.error(
-                "Resource read error while training villagers: %s", exc
+        resources = None
+        for attempt in range(1, 4):
+            logging.debug(
+                "Attempt %s to read resources while training villagers", attempt
             )
+            try:
+                resources = common.read_resources_from_hud()
+                break
+            except common.ResourceReadError as exc:
+                logging.error(
+                    "Resource read error while training villagers (attempt %s/3): %s",
+                    attempt,
+                    exc,
+                )
+                time.sleep(0.1)
+        if resources is None:
+            logging.error("Failed to read resources after 3 attempts; stopping villager training")
             break
         food = resources.get("food_stockpile")
         if food is None:

--- a/tests/test_resource_read_retry.py
+++ b/tests/test_resource_read_retry.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import types
+from unittest import TestCase
+from unittest.mock import patch
+
+import numpy as np
+
+# Stub modules that require a GUI/display before importing the bot modules
+
+dummy_pg = types.SimpleNamespace(
+    PAUSE=0,
+    FAILSAFE=False,
+    size=lambda: (200, 200),
+    click=lambda *a, **k: None,
+    moveTo=lambda *a, **k: None,
+    press=lambda *a, **k: None,
+)
+
+
+class DummyMSS:
+    monitors = [{}, {"left": 0, "top": 0, "width": 200, "height": 200}]
+
+    def grab(self, region):
+        h, w = region["height"], region["width"]
+        return np.zeros((h, w, 4), dtype=np.uint8)
+
+
+sys.modules.setdefault("pyautogui", dummy_pg)
+sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import script.common as common
+import script.town_center as tc
+
+
+class TestResourceReadRetry(TestCase):
+    def test_train_villagers_retries_before_stopping(self):
+        common.CURRENT_POP = 3
+        common.POP_CAP = 10
+        side_effect = [
+            common.ResourceReadError("fail1"),
+            common.ResourceReadError("fail2"),
+            {"food_stockpile": 100},
+        ]
+        with patch(
+            "script.common.read_resources_from_hud",
+            side_effect=side_effect,
+        ) as read_mock, \
+             patch("script.town_center.select_idle_villager"), \
+             patch("script.town_center.build_house"):
+            tc.train_villagers(4)
+        self.assertEqual(common.CURRENT_POP, 4)
+        self.assertEqual(read_mock.call_count, 3)


### PR DESCRIPTION
## Summary
- Add retry logic with debug logging when reading HUD resources in villager training and economic loop
- Break routines only after exhausting retries
- Add unit test for resource read retries

## Testing
- `pytest tests/test_missing_resource_bar.py tests/test_internal_population.py tests/test_resource_read_retry.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tools')*

------
https://chatgpt.com/codex/tasks/task_e_68a8feb12870832588aa483bf3e6b6bc