### PR TITLE
Add HUD detection helper and tool

### DIFF
--- a/script/resources.py
+++ b/script/resources.py
@@ -36,12 +36,12 @@ _RESOURCE_CACHE_TTL = 1.5
 _LAST_REGION_BOUNDS = None
 
 
-def locate_resource_panel(frame):
-    """Locate the resource panel and return bounding boxes for each value."""
+def detect_hud(frame):
+    """Locate the resource panel and return its bounding box."""
 
     tmpl = screen_utils.HUD_TEMPLATES.get("assets/resources.png")
     if tmpl is None:
-        return {}
+        return None
 
     def _save_debug(img, heatmap):
         debug_dir = ROOT / "debug"
@@ -73,9 +73,19 @@ def locate_resource_panel(frame):
                     score,
                 )
                 _save_debug(frame, heat)
-                return {}
+                return None
         else:
-            return {}
+            return None
+
+    return box
+
+
+def locate_resource_panel(frame):
+    """Locate the resource panel and return bounding boxes for each value."""
+
+    box = detect_hud(frame)
+    if not box:
+        return {}
 
     x, y, w, h = box
     panel_gray = cv2.cvtColor(frame[y : y + h, x : x + w], cv2.COLOR_BGR2GRAY)

--- a/tools/detect_hud.py
+++ b/tools/detect_hud.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import script.screen_utils as screen_utils
+import script.resources as resources
+
+
+def main():
+    frame = screen_utils._grab_frame()
+    box = resources.detect_hud(frame)
+    print(box)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- extract resource panel template matching into new `detect_hud` helper that returns only bounding box
- update `locate_resource_panel` to use `detect_hud`
- add `tools/detect_hud.py` utility to capture the screen and print HUD bounds

## Testing
- `pytest` *(fails: KeyboardInterrupt after ~55s, 3 tests passed, remaining tests timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68aa57a8dca08325b2643e8614f5a9c4