### PR TITLE
Simplify HUD template detection

### DIFF
--- a/script/hud.py
+++ b/script/hud.py
@@ -27,39 +27,31 @@ logger = logging.getLogger(__name__)
 def wait_hud(timeout=60):
     logger.info("Aguardando HUD por até %ss...", timeout)
     t0 = time.time()
-    last_best = (-1, None)
+    tmpl = cv2.imread(str(ROOT / "assets/resources.png"), cv2.IMREAD_GRAYSCALE)
     while time.time() - t0 < timeout:
         frame = screen_utils._grab_frame()
-        for name, tmpl in screen_utils.HUD_TEMPLATES.items():
-            if tmpl is None:
-                continue
-            box, score, heat = find_template(
-                frame, tmpl, threshold=CFG["threshold"], scales=CFG["scales"]
-            )
-            if score > last_best[0]:
-                last_best = (score, name)
-            if box:
-                if CFG["debug"]:
-                    cv2.imwrite(f"debug_hud_{name}.png", frame)
-                x, y, w, h = box
-                logger.info("HUD detectada com template '%s'", name)
-                common.HUD_ANCHOR = {
-                    "left": x,
-                    "top": y,
-                    "width": w,
-                    "height": h,
-                    "asset": name,
-                }
-                return common.HUD_ANCHOR, name
+        box, score, heat = find_template(
+            frame, tmpl, threshold=CFG["threshold"], scales=CFG["scales"]
+        )
+        if box:
+            if CFG["debug"]:
+                cv2.imwrite("debug_hud_resources.png", frame)
+            x, y, w, h = box
+            logger.info("HUD detectada com template 'assets/resources.png'")
+            common.HUD_ANCHOR = {
+                "left": x,
+                "top": y,
+                "width": w,
+                "height": h,
+                "asset": "assets/resources.png",
+            }
+            return common.HUD_ANCHOR, "assets/resources.png"
         time.sleep(0.25)
     logger.error(
-        "HUD não encontrada. Melhor score=%.3f no template '%s'. Re-capture o asset e verifique ESCALA 100%%.",
-        last_best[0],
-        last_best[1],
+        "HUD não encontrada usando assets/resources.png. Re-capture o asset e verifique ESCALA 100%."
     )
     raise RuntimeError(
-        f"HUD não encontrada. Melhor score={last_best[0]:.3f} no template '{last_best[1]}'. "
-        "Re-capture o asset (recorte mais justo) e verifique ESCALA 100%."
+        "HUD não encontrada usando assets/resources.png. Re-capture o asset e verifique ESCALA 100%."
     )
 
 

--- a/tests/test_hud_anchor.py
+++ b/tests/test_hud_anchor.py
@@ -112,9 +112,9 @@ class TestHudAnchorTools(TestCase):
         with patch("tools.campaign_bot._grab_frame", return_value=fake_frame), \
              patch("tools.campaign_bot.find_template", return_value=((10, 20, 30, 40), 0.9, None)):
             anchor, asset = cb.wait_hud(timeout=1)
-        self.assertEqual(asset, "assets/ui_minimap.png")
-        self.assertEqual(anchor["asset"], "assets/ui_minimap.png")
-        self.assertEqual(cb.HUD_ANCHOR["asset"], "assets/ui_minimap.png")
+        self.assertEqual(asset, "assets/resources.png")
+        self.assertEqual(anchor["asset"], "assets/resources.png")
+        self.assertEqual(cb.HUD_ANCHOR["asset"], "assets/resources.png")
 
     def test_read_resources_uses_anchor_slices(self):
         anchor = {"left": 10, "top": 20, "width": 600, "height": 60, "asset": "assets/resources.png"}

--- a/tools/campaign_bot.py
+++ b/tools/campaign_bot.py
@@ -11,7 +11,7 @@ import numpy as np
 
 # Public API expected by the tests
 HUD_ANCHOR = common.HUD_ANCHOR
-HUD_TEMPLATES = {"assets/ui_minimap.png": np.zeros((1, 1), dtype=np.uint8)}
+HUD_TEMPLATES = {"assets/resources.png": np.zeros((1, 1), dtype=np.uint8)}
 
 # Default helpers (can be monkeypatched in tests)
 _grab_frame = screen_utils._grab_frame


### PR DESCRIPTION
## Summary
- use a single resource template for HUD anchoring
- update tests and campaign helper to expect the fixed asset path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa5aa5c1a0832594e2487c478a0221