### PR TITLE
refactor: simplify HUD template handling

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,5 @@
 {
   "profile": "aoe1de",
-  "look_for": ["assets/resources.png"],
   "threshold": 0.80,
   "threshold_fallback": 0.68,
   "scales": [0.84, 0.88, 0.92, 0.96, 1.0, 1.04, 1.08, 1.12, 1.16],

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,6 +1,5 @@
 {
   "profile": "aoe1de",
-  "look_for": ["ui_minimap.png", "assets/resources_population.png"],
   "threshold": 0.82,
   "threshold_fallback": 0.7,
   "scales": [0.88, 0.92, 0.96, 1.0, 1.04, 1.08, 1.12],

--- a/script/resources.py
+++ b/script/resources.py
@@ -39,7 +39,7 @@ _LAST_REGION_BOUNDS = None
 def detect_hud(frame):
     """Locate the resource panel and return its bounding box."""
 
-    tmpl = screen_utils.HUD_TEMPLATES.get("assets/resources.png")
+    tmpl = screen_utils.HUD_TEMPLATE
     if tmpl is None:
         return None
 

--- a/script/screen_utils.py
+++ b/script/screen_utils.py
@@ -74,11 +74,7 @@ def _load_gray(path):
     return im
 
 
-HUD_TEMPLATES = {
-    name: tmpl
-    for name in CFG.get("look_for", [])
-    if (tmpl := _load_gray(ROOT / name)) is not None
-}
+HUD_TEMPLATE = _load_gray(ROOT / "assets/resources.png")
 
 ICON_NAMES = [
     "wood_stockpile",

--- a/tests/test_hud_anchor.py
+++ b/tests/test_hud_anchor.py
@@ -112,9 +112,9 @@ class TestHudAnchorTools(TestCase):
         with patch("tools.campaign_bot._grab_frame", return_value=fake_frame), \
              patch("tools.campaign_bot.find_template", return_value=((10, 20, 30, 40), 0.9, None)):
             anchor, asset = cb.wait_hud(timeout=1)
-        self.assertEqual(asset, "assets/ui_minimap.png")
-        self.assertEqual(anchor["asset"], "assets/ui_minimap.png")
-        self.assertEqual(cb.HUD_ANCHOR["asset"], "assets/ui_minimap.png")
+        self.assertEqual(asset, "assets/resources.png")
+        self.assertEqual(anchor["asset"], "assets/resources.png")
+        self.assertEqual(cb.HUD_ANCHOR["asset"], "assets/resources.png")
 
     def test_read_resources_uses_anchor_slices(self):
         anchor = {"left": 10, "top": 20, "width": 600, "height": 60, "asset": "assets/resources.png"}

--- a/tests/test_resource_rois.py
+++ b/tests/test_resource_rois.py
@@ -65,7 +65,7 @@ class TestResourceROIs(TestCase):
             patch("script.resources.cv2.matchTemplate", lambda *a, **k: np.zeros((100, 200), dtype=np.float32)), \
             patch("script.resources.cv2.minMaxLoc", side_effect=fake_minmax), \
             patch.object(screen_utils, "_load_icon_templates", lambda: None), \
-            patch.dict(screen_utils.HUD_TEMPLATES, {"assets/resources.png": np.zeros((1, 1), dtype=np.uint8)}, clear=True), \
+            patch.object(screen_utils, "HUD_TEMPLATE", np.zeros((1, 1), dtype=np.uint8)), \
             patch.dict(screen_utils.ICON_TEMPLATES, {name: np.zeros((5, 5), dtype=np.uint8) for name in icons}, clear=True), \
             patch.dict(common.CFG["resource_panel"], {
                 "roi_padding_left": pad_left,

--- a/tools/campaign_bot.py
+++ b/tools/campaign_bot.py
@@ -11,7 +11,7 @@ import numpy as np
 
 # Public API expected by the tests
 HUD_ANCHOR = common.HUD_ANCHOR
-HUD_TEMPLATES = {"assets/ui_minimap.png": np.zeros((1, 1), dtype=np.uint8)}
+HUD_TEMPLATE = np.zeros((1, 1), dtype=np.uint8)
 
 # Default helpers (can be monkeypatched in tests)
 _grab_frame = screen_utils._grab_frame
@@ -21,8 +21,8 @@ _read_population_from_roi = resources._read_population_from_roi
 
 def wait_hud(timeout=60):
     """Delegate to :func:`script.hud.wait_hud` using patched helpers."""
-    original_templates = screen_utils.HUD_TEMPLATES
-    screen_utils.HUD_TEMPLATES = HUD_TEMPLATES
+    original_template = screen_utils.HUD_TEMPLATE
+    screen_utils.HUD_TEMPLATE = HUD_TEMPLATE
     original_grab = screen_utils._grab_frame
     original_find = hud.find_template
     screen_utils._grab_frame = _grab_frame
@@ -35,7 +35,7 @@ def wait_hud(timeout=60):
     finally:
         screen_utils._grab_frame = original_grab
         hud.find_template = original_find
-        screen_utils.HUD_TEMPLATES = original_templates
+        screen_utils.HUD_TEMPLATE = original_template
 
 def _ocr_digits_better(gray):
     """Delegate to resource helper; patched in tests."""


### PR DESCRIPTION
## Summary
- load a single resources HUD template instead of mapping from config
- update HUD consumers and test helpers to use the new template constant
- drop obsolete `look_for` configuration option

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa5cfe1220832583e53ef07a9e3c45