### PR TITLE
Use detected idle villager ROI with fallback

### DIFF
--- a/script/resources.py
+++ b/script/resources.py
@@ -209,22 +209,23 @@ def detect_resource_regions(frame, required_icons):
     """Detect resource value regions on the HUD."""
 
     regions = locate_resource_panel(frame)
-    idle_cfg = CFG.get("idle_villager_roi")
-    if idle_cfg:
-        W, H = input_utils._screen_size()
-        left = int(idle_cfg.get("left_pct", 0) * W)
-        top = int(idle_cfg.get("top_pct", 0) * H)
-        width = int(idle_cfg.get("width_pct", 0) * W)
-        height = int(idle_cfg.get("height_pct", 0) * H)
-        regions["idle_villager"] = (
-            left,
-            top,
-            max(40, width),
-            max(20, height),
-        )
-        logger.debug(
-            "Custom ROI aplicada para idle_villager: %s", regions["idle_villager"]
-        )
+    if "idle_villager" not in regions:
+        idle_cfg = CFG.get("idle_villager_roi")
+        if idle_cfg:
+            W, H = input_utils._screen_size()
+            left = int(idle_cfg.get("left_pct", 0) * W)
+            top = int(idle_cfg.get("top_pct", 0) * H)
+            width = int(idle_cfg.get("width_pct", 0) * W)
+            height = int(idle_cfg.get("height_pct", 0) * H)
+            regions["idle_villager"] = (
+                left,
+                top,
+                max(40, width),
+                max(20, height),
+            )
+            logger.debug(
+                "Custom ROI aplicada para idle_villager: %s", regions["idle_villager"]
+            )
     missing = [name for name in required_icons if name not in regions]
 
     if missing and common.HUD_ANCHOR:

--- a/tests/test_idle_villager_custom_roi.py
+++ b/tests/test_idle_villager_custom_roi.py
@@ -37,7 +37,7 @@ import script.resources as resources
 
 
 class TestIdleVillagerCustomROI(TestCase):
-    def test_roi_matches_configured_percentages(self):
+    def test_roi_matches_configured_percentages_when_missing(self):
         frame = np.zeros((100, 200, 3), dtype=np.uint8)
         cfg = {
             "left_pct": 0.2,


### PR DESCRIPTION
## Summary
- Prefer ROI detected by `locate_resource_panel` for idle villager
- Use configured `idle_villager_roi` only as fallback when icon is missing
- Adjust idle villager tests for new behavior

## Testing
- `pytest`
- `pytest tests/test_idle_villager_custom_roi.py tests/test_idle_villager_roi.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa79c882f88325b3640356c34acae0