### PR TITLE
Ensure minimum resource ROI width

### DIFF
--- a/script/resources.py
+++ b/script/resources.py
@@ -155,18 +155,17 @@ def locate_resource_panel(frame):
                 )
                 continue
             if width < min_width:
-                extra = min_width - width
-                left = max(left - extra // 2, x)
-                left = max(left, x + xi + wi)
-                width = min(min_width, right - left)
-                if width <= 0:
-                    logger.warning(
-                        "Skipping ROI for icon '%s' after min-width shift due to non-positive width (left=%d, right=%d)",
-                        name,
-                        left,
-                        right,
-                    )
-                    continue
+                panel_left = x
+                panel_right = x + w - pad_right
+                center = (left + right) // 2
+                left = max(panel_left, center - min_width // 2)
+                right = left + min_width
+                if right > panel_right:
+                    right = panel_right
+                    left = right - min_width
+                    if left < panel_left:
+                        left = panel_left
+                width = right - left
 
         logger.debug("ROI for '%s': left=%d width=%d", name, left, width)
         regions[name] = (left, top_i, width, height_i)


### PR DESCRIPTION
## Summary
- Expand resource value regions symmetrically to guarantee `min_width`, clamping within the HUD panel
- Allow overlaps when icons are close and add regression tests for tight spacing and panel-edge icons

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa8cd87d6c8325bab9360cd2a85074