### PR TITLE
Allow configurable HUD icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,23 @@ used.
 food stockpile, gold stockpile, stone stockpile, population limit, and idle
 villager.
 
+### Customizing required icons
+
+The bot determines which HUD icons must be read through the `hud_icons`
+section in `config.json`:
+
+```json
+"hud_icons": {
+  "required": ["wood_stockpile", "food_stockpile", "gold_stockpile", "stone_stockpile", "population_limit", "idle_villager"],
+  "optional": []
+}
+```
+
+Entries in `required` cause the bot to raise an error when any of those icons
+cannot be detected or read. Icons listed under `optional` are attempted but do
+not stop execution if they are missing. Adjust these lists to match the
+resources shown in your game profile.
+
 ## Calibration helper
 
 To calibrate the `areas.pop_box` fractions interactively, run:

--- a/campaign_bot.py
+++ b/campaign_bot.py
@@ -57,7 +57,12 @@ def main():
         common.TARGET_POP = info.objective_villagers
         for attempt in range(3):
             try:
-                res, (cur_pop, pop_cap) = resources.gather_hud_stats(force_delay=0.1)
+                icon_cfg = common.CFG.get("hud_icons", {})
+                res, (cur_pop, pop_cap) = resources.gather_hud_stats(
+                    force_delay=0.1,
+                    required_icons=icon_cfg.get("required"),
+                    optional_icons=icon_cfg.get("optional"),
+                )
                 logger.info(
                     "Recursos detectados: madeira=%s, comida=%s, ouro=%s, pedra=%s",
                     res.get("wood_stockpile"),

--- a/config.json
+++ b/config.json
@@ -33,13 +33,24 @@
     "right_trim_pct": 0.02,
     "debug_failed_ocr": true
   },
-    "idle_villager_roi": {
+  "hud_icons": {
+    "required": [
+      "wood_stockpile",
+      "food_stockpile",
+      "gold_stockpile",
+      "stone_stockpile",
+      "population_limit",
+      "idle_villager"
+    ],
+    "optional": []
+  },
+  "idle_villager_roi": {
     "top_pct": 0.10,
     "height_pct": 0.06,
     "left_pct": 0.84,
     "width_pct": 0.05
   },
-    "profiles": {
+  "profiles": {
       "aoe1de": {
         "resource_panel": {
           "match_threshold": 0.82,

--- a/config.sample.json
+++ b/config.sample.json
@@ -42,6 +42,17 @@
     "anchor_right_trim_pct": 0.02,
     "debug_failed_ocr": false
   },
+  "hud_icons": {
+    "required": [
+      "wood_stockpile",
+      "food_stockpile",
+      "gold_stockpile",
+      "stone_stockpile",
+      "population_limit",
+      "idle_villager"
+    ],
+    "optional": []
+  },
   "idle_villager_roi": {
     "top_pct": 0.12,
     "height_pct": 0.20,

--- a/tools/campaign_bot.py
+++ b/tools/campaign_bot.py
@@ -67,7 +67,7 @@ def read_resources_from_hud(required_icons=None):
         resources._ocr_digits_better = original_ocr
 
 
-def gather_hud_stats():
+def gather_hud_stats(force_delay=None, required_icons=None, optional_icons=None):
     """Delegate to :func:`script.resources.gather_hud_stats` using patched helpers."""
     common.HUD_ANCHOR = HUD_ANCHOR
     original_locate = resources.locate_resource_panel
@@ -87,7 +87,11 @@ def gather_hud_stats():
     resources._ocr_digits_better = wrapper
     resources._read_population_from_roi = _read_population_from_roi
     try:
-        return resources.gather_hud_stats()
+        return resources.gather_hud_stats(
+            force_delay=force_delay,
+            required_icons=required_icons,
+            optional_icons=optional_icons,
+        )
     finally:
         resources.locate_resource_panel = original_locate
         screen_utils._grab_frame = original_grab


### PR DESCRIPTION
## Summary
- allow `gather_hud_stats` to read required and optional icons from configuration or parameters
- pass HUD icon preferences from `campaign_bot`
- document configurable HUD icons in config files and README

## Testing
- `pytest tests/test_gather_hud_stats.py -q` *(fails: Xlib.error.DisplayConnectionError: Can't connect to display ":0": [Errno 2] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8e4dd2b083259b48895cd8197337