### PR TITLE
feat(resources): add configurable cache TTL and stale fallback

### DIFF
--- a/config.json
+++ b/config.json
@@ -11,6 +11,8 @@
   "ocr_kernel_size": 3,
   "ocr_psm_list": [6, 7, 8, 10, 13],
   "tesseract_path": "C:\\Program Files\\Tesseract-OCR\\tesseract.exe",
+  "resource_cache_ttl": 1.5,
+  "resource_cache_max_age": null,
   "keys": {
     "idle_vill": ".",
     "build_menu": "b",

--- a/config.sample.json
+++ b/config.sample.json
@@ -11,6 +11,8 @@
   "ocr_kernel_size": 2,
   "ocr_psm_list": [6, 7, 8, 10, 13],
   "tesseract_path": "C:\\Program Files\\Tesseract-OCR\\tesseract.exe",
+  "resource_cache_ttl": 1.5,
+  "resource_cache_max_age": null,
   "keys": {
     "idle_vill": ".",
     "build_menu": "b",

--- a/tests/test_gather_hud_stats.py
+++ b/tests/test_gather_hud_stats.py
@@ -8,6 +8,12 @@ import tools.campaign_bot as cb
 
 
 class TestGatherHudStats(TestCase):
+    def setUp(self):
+        # Clear caches in resources module used by campaign bot
+        cb.resources._LAST_RESOURCE_VALUES.clear()
+        cb.resources._LAST_RESOURCE_TS.clear()
+        cb.resources._RESOURCE_FAILURE_COUNTS.clear()
+
     def test_gather_reads_resources_and_population(self):
         anchor = {"left": 10, "top": 20, "width": 600, "height": 60, "asset": "assets/resources.png"}
         cb.HUD_ANCHOR = anchor.copy()

--- a/tests/test_hud_anchor.py
+++ b/tests/test_hud_anchor.py
@@ -41,6 +41,11 @@ ASSET = "assets/resources.png"
 
 
 class TestHudAnchor(TestCase):
+    def setUp(self):
+        resources._LAST_RESOURCE_VALUES.clear()
+        resources._LAST_RESOURCE_TS.clear()
+        resources._RESOURCE_FAILURE_COUNTS.clear()
+
     def test_wait_hud_sets_asset(self):
         common.HUD_ANCHOR = None
         fake_frame = np.zeros((100, 100, 3), dtype=np.uint8)

--- a/tests/test_idle_villager_ocr.py
+++ b/tests/test_idle_villager_ocr.py
@@ -36,6 +36,11 @@ import script.resources as resources
 
 
 class TestIdleVillagerOCR(TestCase):
+    def setUp(self):
+        resources._LAST_RESOURCE_VALUES.clear()
+        resources._LAST_RESOURCE_TS.clear()
+        resources._RESOURCE_FAILURE_COUNTS.clear()
+
     def test_idle_villager_uses_digit_only_tesseract(self):
         def fake_detect(frame, required_icons):
             return {"idle_villager": (0, 0, 50, 50)}

--- a/tests/test_resource_debug_images.py
+++ b/tests/test_resource_debug_images.py
@@ -37,6 +37,11 @@ import script.resources as resources
 
 
 class TestResourceDebugImages(TestCase):
+    def setUp(self):
+        resources._LAST_RESOURCE_VALUES.clear()
+        resources._LAST_RESOURCE_TS.clear()
+        resources._RESOURCE_FAILURE_COUNTS.clear()
+
     def test_debug_images_written_when_all_none_and_debug_off(self):
         common.CFG["debug"] = False
         common.CFG.get("resource_panel", {})["debug_failed_ocr"] = False
@@ -95,6 +100,7 @@ class TestResourceDebugImages(TestCase):
 
         resources._LAST_RESOURCE_VALUES.clear()
         resources._LAST_RESOURCE_TS.clear()
+        resources._RESOURCE_FAILURE_COUNTS.clear()
         with patch("script.screen_utils._grab_frame", side_effect=fake_grab_frame), \
              patch(
                  "script.resources.locate_resource_panel",

--- a/tests/test_resource_force_delay.py
+++ b/tests/test_resource_force_delay.py
@@ -34,6 +34,11 @@ import script.resources as resources
 
 
 class TestResourceForceDelay(TestCase):
+    def setUp(self):
+        resources._LAST_RESOURCE_VALUES.clear()
+        resources._LAST_RESOURCE_TS.clear()
+        resources._RESOURCE_FAILURE_COUNTS.clear()
+
     def test_force_delay_waits_before_grab(self):
         calls = []
 

--- a/tests/test_resource_ocr_failure.py
+++ b/tests/test_resource_ocr_failure.py
@@ -40,9 +40,13 @@ import script.resources as resources
 class TestResourceOcrFailure(TestCase):
     def setUp(self):
         resources._LAST_RESOURCE_VALUES.clear()
+        resources._LAST_RESOURCE_TS.clear()
+        resources._RESOURCE_FAILURE_COUNTS.clear()
 
     def tearDown(self):
         resources._LAST_RESOURCE_VALUES.clear()
+        resources._LAST_RESOURCE_TS.clear()
+        resources._RESOURCE_FAILURE_COUNTS.clear()
     def test_read_resources_fallback(self):
         def fake_grab_frame(bbox=None):
             if bbox:

--- a/tools/campaign_bot.py
+++ b/tools/campaign_bot.py
@@ -67,7 +67,12 @@ def read_resources_from_hud(required_icons=None):
         resources._ocr_digits_better = original_ocr
 
 
-def gather_hud_stats(force_delay=None, required_icons=None, optional_icons=None):
+def gather_hud_stats(
+    force_delay=None,
+    required_icons=None,
+    optional_icons=None,
+    max_cache_age=None,
+):
     """Delegate to :func:`script.resources.gather_hud_stats` using patched helpers."""
     common.HUD_ANCHOR = HUD_ANCHOR
     original_locate = resources.locate_resource_panel
@@ -91,6 +96,7 @@ def gather_hud_stats(force_delay=None, required_icons=None, optional_icons=None)
             force_delay=force_delay,
             required_icons=required_icons,
             optional_icons=optional_icons,
+            max_cache_age=max_cache_age,
         )
     finally:
         resources.locate_resource_panel = original_locate


### PR DESCRIPTION
## Summary
- make resource cache TTL and max age configurable via config
- fallback to cached resource values after consecutive OCR failures even when expired
- cover expired cache fallback in tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa8fe9f1108325a45c04911c84e00a