### PR TITLE
Respect available space for resource panel ROIs

### DIFF
--- a/script/resources.py
+++ b/script/resources.py
@@ -147,7 +147,7 @@ def locate_resource_panel(frame):
     height = int(height_pct * h)
     regions = {}
     panel_left = x
-    panel_right = x + w - pad_right
+    panel_right = x + w
 
     for idx, name in enumerate(RESOURCE_ICON_ORDER):
         if name not in detected:
@@ -159,7 +159,7 @@ def locate_resource_panel(frame):
             top_i = y + yi
             height_i = hi
         else:
-            left = panel_left + xi + wi + pad_left
+            icon_right = panel_left + xi + wi
             next_name = (
                 RESOURCE_ICON_ORDER[idx + 1]
                 if idx + 1 < len(RESOURCE_ICON_ORDER)
@@ -168,9 +168,16 @@ def locate_resource_panel(frame):
             if name == "population_limit":
                 next_name = "idle_villager"
             if next_name and next_name in detected:
-                right = panel_left + detected[next_name][0] - pad_right
+                next_icon_left = panel_left + detected[next_name][0]
             else:
-                right = panel_right
+                next_icon_left = panel_right
+
+            available_left = icon_right + pad_left
+            available_right = next_icon_left - pad_right
+
+            left = available_left
+            right = available_right
+
             top_i = top
             height_i = height
 
@@ -185,14 +192,12 @@ def locate_resource_panel(frame):
                 continue
             if width < min_width:
                 center = (left + right) // 2
-                left = max(panel_left, center - min_width // 2)
+                left = max(available_left, center - min_width // 2)
                 right = left + min_width
-                if right > panel_right:
-                    right = panel_right
-                    left = right - min_width
-                    if left < panel_left:
-                        left = panel_left
-                width = right - left
+                if right > available_right:
+                    right = available_right
+                    left = max(available_left, right - min_width)
+            width = right - left
 
         logger.debug("ROI for '%s': left=%d width=%d", name, left, width)
         regions[name] = (left, top_i, width, height_i)

--- a/tests/test_resource_rois.py
+++ b/tests/test_resource_rois.py
@@ -146,9 +146,17 @@ class TestResourceROIs(TestCase):
             }):
                 regions = resources.locate_resource_panel(frame)
 
-        for name in icons:
+        icon_width = screen_utils.ICON_TEMPLATES[icons[0]].shape[1]
+        for i, name in enumerate(icons):
             width = regions[name][2]
-            self.assertGreaterEqual(width, min_width, f"{name} width < min_width")
+            icon_left = positions[i]
+            icon_right = icon_left + icon_width
+            if i + 1 < len(icons):
+                next_icon_left = positions[i + 1]
+            else:
+                next_icon_left = panel_box[2]
+            available_width = next_icon_left - pad_right - (icon_right + pad_left)
+            self.assertEqual(width, available_width, f"{name} width mismatch")
 
     def test_rois_respect_min_width_near_panel_edge(self):
         frame = np.zeros((50, 200, 3), dtype=np.uint8)
@@ -187,5 +195,9 @@ class TestResourceROIs(TestCase):
         roi = regions[icons[0]]
         width = roi[2]
         right = roi[0] + roi[2]
-        self.assertGreaterEqual(width, min_width, "width < min_width at panel edge")
+        icon_width = screen_utils.ICON_TEMPLATES[icons[0]].shape[1]
+        icon_left = positions[0]
+        icon_right = icon_left + icon_width
+        available_width = panel_box[2] - pad_right - (icon_right + pad_left)
+        self.assertEqual(width, available_width, "width not limited by panel edge")
         self.assertLessEqual(right, panel_box[0] + panel_box[2] - pad_right, "ROI exceeds panel bounds")


### PR DESCRIPTION
## Summary
- compute icon_right and next_icon_left to derive safe ROI bounds between resource icons
- limit ROI expansion to the available space so icons are never included
- update tests to expect width limited by available space

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa9a7527cc8325b95f5da4ce748fce