### PR TITLE
Ensure resource ROIs meet minimum width

### DIFF
--- a/script/resources.py
+++ b/script/resources.py
@@ -190,31 +190,59 @@ def locate_resource_panel(frame):
                 )
                 continue
 
+            if available_width < min_width:
+                deficit = min_width - available_width
+                # expand evenly to both sides within panel bounds
+                expand_left = min(deficit // 2, available_left - panel_left)
+                expand_right = min(deficit // 2, panel_right - available_right)
+                available_left -= expand_left
+                available_right += expand_right
+                available_width = available_right - available_left
+
+                if available_width < min_width:
+                    remaining = min_width - available_width
+                    extra_left = min(remaining, available_left - panel_left)
+                    available_left -= extra_left
+                    remaining -= extra_left
+                    if remaining > 0:
+                        extra_right = min(remaining, panel_right - available_right)
+                        available_right += extra_right
+                    available_width = available_right - available_left
+
+                if available_width < min_width:
+                    slice_w = w / len(RESOURCE_ICON_ORDER)
+                    center = int(panel_left + (idx + 0.5) * slice_w)
+                    available_left = max(panel_left, center - min_width // 2)
+                    available_right = min(panel_right, available_left + min_width)
+                    available_width = available_right - available_left
+
             width = min(available_width, max_width)
             center = (available_left + available_right) // 2
-            left = max(available_left, center - width // 2)
+            left = max(panel_left, center - width // 2)
             right = left + width
-            if right > available_right:
-                right = available_right
-                left = right - width
+            if right > panel_right:
+                right = panel_right
+                left = max(panel_left, right - width)
             width = right - left
 
             if width < min_width:
                 width = min_width
-                left = max(available_left, center - width // 2)
+                center = (available_left + available_right) // 2
+                left = max(panel_left, center - width // 2)
                 right = left + width
-                if right > available_right:
-                    right = available_right
-                    left = max(available_left, right - width)
+                if right > panel_right:
+                    right = panel_right
+                    left = max(panel_left, right - width)
                 width = right - left
 
             if width > max_width:
                 width = max_width
-                left = max(available_left, center - width // 2)
+                center = (available_left + available_right) // 2
+                left = max(panel_left, center - width // 2)
                 right = left + width
-                if right > available_right:
-                    right = available_right
-                    left = max(available_left, right - width)
+                if right > panel_right:
+                    right = panel_right
+                    left = max(panel_left, right - width)
                 width = right - left
 
         logger.debug("ROI for '%s': left=%d width=%d", name, left, width)


### PR DESCRIPTION
## Summary
- Expand resource value search areas when adjacent icons leave too little space
- Add slice-based fallback so ROIs still meet minimum width
- Update ROI tests to verify minimum widths remain within HUD bounds

## Testing
- `pytest tests/test_resource_rois.py tests/test_resource_debug_images.py tests/test_gather_hud_stats.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aaaafbf81c8325b34c4ce5f2bf2e45