### PR TITLE
Fallback to HUD anchor when narrow resource ROIs detected

### DIFF
--- a/script/resources.py
+++ b/script/resources.py
@@ -321,6 +321,16 @@ def detect_resource_regions(frame, required_icons):
             logger.debug(
                 "Custom ROI aplicada para idle_villager: %s", regions["idle_villager"]
             )
+    res_cfg = CFG.get("resource_panel", {})
+    min_width = res_cfg.get("min_width", 110)
+    narrow = any(
+        name in regions and regions[name][2] < min_width for name in required_icons
+    )
+    if narrow and common.HUD_ANCHOR:
+        logger.warning(
+            "Detected narrow resource region; falling back to HUD_ANCHOR slices"
+        )
+        regions = {}
     missing = [name for name in required_icons if name not in regions]
 
     if missing and common.HUD_ANCHOR:


### PR DESCRIPTION
## Summary
- Recompute resource ROI slices from HUD anchor when detected regions are narrower than the configured minimum
- Skip narrow-region fallback when no HUD anchor exists

## Testing
- `pytest`
- `python campaign_bot.py` (with stubbed screen capture and OCR)

------
https://chatgpt.com/codex/tasks/task_e_68aaacc504d88325a89b772b1092e797