### PR TITLE
Refactor resource panel ROI bounds

### DIFF
--- a/script/resources.py
+++ b/script/resources.py
@@ -156,6 +156,7 @@ def locate_resource_panel(frame):
         if name == "idle_villager":
             left = panel_left + xi
             width = wi
+            right = left + width
             top_i = y + yi
             height_i = hi
         else:
@@ -190,17 +191,16 @@ def locate_resource_panel(frame):
                 continue
 
             width = min(available_width, max_width)
-            center = (available_left + available_right) // 2
-            left = max(available_left, center - width // 2)
+            left = available_left
             right = left + width
             if right > available_right:
+                left = available_right - width
                 right = available_right
-                left = right - width
             left = max(panel_left, left)
             right = min(panel_right, right)
             width = right - left
 
-        logger.debug("ROI for '%s': left=%d width=%d", name, left, width)
+        logger.debug("ROI for '%s': left=%d right=%d width=%d", name, left, right, width)
         regions[name] = (left, top_i, width, height_i)
 
     global _LAST_REGION_BOUNDS, _LAST_RESOURCE_VALUES, _LAST_RESOURCE_TS

--- a/tests/test_resource_rois.py
+++ b/tests/test_resource_rois.py
@@ -218,13 +218,14 @@ class TestResourceROIs(TestCase):
         next_icon_left = positions[1]
         available_left = icon_right + pad_left
         available_right = next_icon_left - pad_right
-        expected_center = (available_left + available_right) // 2
-        expected_left = max(available_left, expected_center - max_width // 2)
-        expected_right = expected_left + max_width
+        available_width = available_right - available_left
+        expected_width = min(available_width, max_width)
+        expected_left = available_left
+        expected_right = expected_left + expected_width
         if expected_right > available_right:
+            expected_left = available_right - expected_width
             expected_right = available_right
-            expected_left = max(available_left, expected_right - max_width)
 
-        self.assertEqual(width, max_width, "width not limited by max_width")
-        self.assertEqual(left, expected_left, "ROI not centered within bounds")
+        self.assertEqual(width, expected_width, "width not limited by max_width")
+        self.assertEqual(left, expected_left, "ROI not anchored within bounds")
         self.assertEqual(right, expected_right, "ROI exceeds available space")


### PR DESCRIPTION
## Summary
- anchor resource value ROIs to the left boundary instead of centering
- ensure ROIs stay within panel and log final left/right/width
- adjust tests for new ROI anchoring logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aab8a63fe88325a4f175f0b2d67bad