### PR TITLE
Add min_width handling and anchor fallback for resource panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ placeholders and should be calibrated for your setup.
 
 The `resource_panel` section includes `max_width`, which caps the width of the region used to read each resource value. When extra space is available between icons, the ROI is centered and limited to this width (default `160`).
 
+`min_width` defines the minimum width for each ROI. If the free space between icons is narrower than this value, the region expands symmetrically to at least `min_width` (default `90`). Set `narrow_mode` to `"anchor"` to skip the expansion and fall back to the `HUD_ANCHOR`-based estimation instead.
+
 ### OCR tuning
 
 Two fields in `config.json` allow adjusting how resource numbers are read:

--- a/config.json
+++ b/config.json
@@ -28,6 +28,8 @@
         "roi_padding_left": 4,
         "roi_padding_right": 2,
         "max_width": 160,
+        "min_width": 90,
+        "narrow_mode": "expand",
         "idle_roi_extra_width": 0,
         "top_pct": 0.08,
         "height_pct": 0.84,

--- a/config.sample.json
+++ b/config.sample.json
@@ -38,6 +38,8 @@
     "icon_trim_pct": [0.18, 0.18, 0.18, 0.18, 0.18, 0.18],
     "right_trim_pct": 0.02,
     "max_width": 160,
+    "min_width": 90,
+    "narrow_mode": "expand",
     "idle_roi_extra_width": 0,
     "anchor_top_pct": 0.15,
     "anchor_height_pct": 0.70,

--- a/tests/test_idle_villager_roi.py
+++ b/tests/test_idle_villager_roi.py
@@ -83,6 +83,7 @@ class TestIdleVillagerROI(TestCase):
                     "scales": [1.0],
                     "match_threshold": 0.5,
                     "max_width": 999,
+                    "min_width": 0,
                 },
             ):
                 regions = resources.locate_resource_panel(frame)

--- a/tests/test_resource_rois.py
+++ b/tests/test_resource_rois.py
@@ -103,6 +103,7 @@ class TestResourceROIs(TestCase):
                 "scales": [1.0],
                 "match_threshold": 0.5,
                 "max_width": 999,
+                "min_width": 0,
                 "top_pct": 0.0,
                 "height_pct": 1.0,
             },
@@ -185,6 +186,7 @@ class TestResourceROIs(TestCase):
                 "scales": [1.0],
                 "match_threshold": 0.5,
                 "max_width": 999,
+                "min_width": 0,
                 "top_pct": 0.0,
                 "height_pct": 1.0,
             }):
@@ -232,6 +234,7 @@ class TestResourceROIs(TestCase):
                 "scales": [1.0],
                 "match_threshold": 0.5,
                 "max_width": max_width,
+                "min_width": 0,
                 "top_pct": 0.0,
                 "height_pct": 1.0,
             }):


### PR DESCRIPTION
## Summary
- ensure resource ROIs meet configurable `min_width`
- allow using HUD_ANCHOR fallback when ROIs are too narrow
- expose `min_width`/`narrow_mode` options in config and docs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad3e3f5b0083258119ad846650e7d8