### PR TITLE
Add per-icon resource ROI padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,16 +59,20 @@ locate each value.
 ### ROI padding and spacing
 
 The region of interest (ROI) used to read each number sits between two icons.
-Two configuration options define the valid horizontal area:
+Three configuration options define the valid horizontal area. Each option
+accepts a list of six values corresponding to the icons in the order
+`wood`, `food`, `gold`, `stone`, `population` and `idle villager`:
 
 * `roi_padding_left` – pixels added to the right edge of the current icon.
 * `roi_padding_right` – pixels subtracted from the left edge of the next icon.
+* `icon_trim_pct` – fraction of the icon slot to skip when estimating ROIs
+  from the HUD anchor.
 
 For a given resource the horizontal bounds are computed as:
 
 ```
-available_left = icon_right + roi_padding_left
-available_right = next_icon_left - roi_padding_right
+available_left = icon_right + roi_padding_left[i]
+available_right = next_icon_left - roi_padding_right[i]
 ```
 
 With icon positions `0, 30, 60, 90, 120, 150`, icon width `5` and paddings
@@ -77,13 +81,27 @@ With icon positions `0, 30, 60, 90, 120, 150`, icon width `5` and paddings
 | Resource       | icon_right | next_icon_left | available_left | available_right |
 |----------------|-----------:|---------------:|---------------:|----------------:|
 | wood           | 5          | 30             | 7              | 28              |
-| food           | 35         | 60             | 37             | 58              |
-| gold           | 65         | 90             | 67             | 88              |
-| stone          | 95         | 120            | 97             | 118             |
+| food           | 35         | 60             | 37              | 58              |
+| gold           | 65         | 90             | 67              | 88              |
+| stone          | 95         | 120            | 97              | 118             |
 | population     | 125        | 150            | 127            | 148             |
 | idle villager* | –          | –              | (ROI equals icon bounds) |            |
 
 `*` Idle villager is the last icon, so its ROI is confined to the icon itself.
+
+#### Calibrating per-icon offsets
+
+| Icon              | `roi_padding_left[i]` measurement                               | `roi_padding_right[i]` measurement                              | `icon_trim_pct[i]` measurement                                                                 |
+|-------------------|----------------------------------------------------------------|-----------------------------------------------------------------|------------------------------------------------------------------------------------------------|
+| wood_stockpile    | pixels from wood icon's right edge to first digit              | pixels from last digit to food icon's left edge                 | width of wood icon and left spacing divided by total slot width                               |
+| food_stockpile    | pixels from food icon's right edge to first digit              | pixels from last digit to gold icon's left edge                 | width of food icon and left spacing divided by slot width                                      |
+| gold_stockpile    | pixels from gold icon's right edge to first digit              | pixels from last digit to stone icon's left edge                | width of gold icon and left spacing divided by slot width                                      |
+| stone_stockpile   | pixels from stone icon's right edge to first digit             | pixels from last digit to population icon's left edge           | width of stone icon and left spacing divided by slot width                                     |
+| population_limit  | pixels from population icon's right edge to first digit        | pixels from last digit to idle villager icon's left edge        | width of population icon and left spacing divided by slot width                               |
+| idle_villager     | not used (ROI equals icon bounds)                              | not used                                                       | width of idle villager icon and left spacing divided by slot width (used only for HUD fallback) |
+
+Use a screenshot editor to count pixels or run `python tools/roi_calibrator.py`
+to compute the `icon_trim_pct` values interactively.
 
 ### Customizing required icons
 

--- a/config.json
+++ b/config.json
@@ -25,8 +25,8 @@
     "resource_panel": {
         "match_threshold": 0.8,
         "scales": [0.9, 0.95, 1.0, 1.05, 1.1],
-        "roi_padding_left": 4,
-        "roi_padding_right": 2,
+        "roi_padding_left": [4, 4, 4, 4, 4, 4],
+        "roi_padding_right": [2, 2, 2, 2, 2, 2],
         "max_width": 160,
         "min_width": 90,
         "narrow_mode": "expand",
@@ -60,6 +60,8 @@
           "match_threshold": 0.82,
           "top_pct": 0.08,
           "height_pct": 0.84,
+          "roi_padding_left": [4, 4, 4, 4, 4, 4],
+          "roi_padding_right": [2, 2, 2, 2, 2, 2],
           "icon_trim_pct": [0.25, 0.20, 0.20, 0.20, 0.20, 0.20],
           "right_trim_pct": 0.02
         }

--- a/config.sample.json
+++ b/config.sample.json
@@ -37,6 +37,8 @@
     "height_pct": 0.84,
     "icon_trim_pct": [0.18, 0.18, 0.18, 0.18, 0.18, 0.18],
     "right_trim_pct": 0.02,
+    "roi_padding_left": [4, 4, 4, 4, 4, 4],
+    "roi_padding_right": [2, 2, 2, 2, 2, 2],
     "max_width": 160,
     "min_width": 90,
     "narrow_mode": "expand",
@@ -71,6 +73,8 @@
           "match_threshold": 0.82,
           "top_pct": 0.08,
           "height_pct": 0.84,
+          "roi_padding_left": [4, 4, 4, 4, 4, 4],
+          "roi_padding_right": [2, 2, 2, 2, 2, 2],
           "icon_trim_pct": [0.18, 0.18, 0.18, 0.18, 0.18, 0.18],
           "right_trim_pct": 0.02
         }

--- a/script/resources.py
+++ b/script/resources.py
@@ -114,6 +114,15 @@ def locate_resource_panel(frame):
     scales = res_cfg.get("scales", CFG.get("scales", [1.0]))
     pad_left = res_cfg.get("roi_padding_left", 2)
     pad_right = res_cfg.get("roi_padding_right", 2)
+    pad_left = pad_left if isinstance(pad_left, (list, tuple)) else [pad_left] * 6
+    pad_right = pad_right if isinstance(pad_right, (list, tuple)) else [pad_right] * 6
+    icon_trims = profile_res.get(
+        "icon_trim_pct",
+        res_cfg.get("icon_trim_pct", [0, 0, 0, 0, 0, 0]),
+    )
+    icon_trims = (
+        icon_trims if isinstance(icon_trims, (list, tuple)) else [icon_trims] * 6
+    )
     max_width = res_cfg.get("max_width", 160)
     min_width = res_cfg.get("min_width", 90)
     narrow_mode = res_cfg.get("narrow_mode", "expand")
@@ -162,8 +171,10 @@ def locate_resource_panel(frame):
             top_i = y + yi
             height_i = hi
         else:
-            # Determine the free space between the current icon and the next one
-            icon_right = panel_left + xi + wi
+            pad_l = pad_left[idx] if idx < len(pad_left) else pad_left[-1]
+            pad_r = pad_right[idx] if idx < len(pad_right) else pad_right[-1]
+            trim = icon_trims[idx] if idx < len(icon_trims) else icon_trims[-1]
+            icon_right = panel_left + xi + wi - int(trim * wi)
             next_name = (
                 RESOURCE_ICON_ORDER[idx + 1]
                 if idx + 1 < len(RESOURCE_ICON_ORDER)
@@ -172,12 +183,18 @@ def locate_resource_panel(frame):
             if name == "population_limit":
                 next_name = "idle_villager"
             if next_name and next_name in detected:
-                next_icon_left = panel_left + detected[next_name][0]
+                nx, ny, nwi, nhi = detected[next_name]
+                trim_next = (
+                    icon_trims[idx + 1]
+                    if idx + 1 < len(icon_trims)
+                    else icon_trims[-1]
+                )
+                next_icon_left = panel_left + nx + int(trim_next * nwi)
             else:
                 next_icon_left = panel_right
 
-            available_left = icon_right + pad_left
-            available_right = next_icon_left - pad_right
+            available_left = icon_right + pad_l
+            available_right = next_icon_left - pad_r
 
             top_i = top
             height_i = height

--- a/tests/test_idle_villager_roi.py
+++ b/tests/test_idle_villager_roi.py
@@ -78,13 +78,17 @@ class TestIdleVillagerROI(TestCase):
             patch.dict(
                 common.CFG["resource_panel"],
                 {
-                    "roi_padding_left": 0,
-                    "roi_padding_right": 0,
+                    "roi_padding_left": [0] * 6,
+                    "roi_padding_right": [0] * 6,
+                    "icon_trim_pct": [0] * 6,
                     "scales": [1.0],
                     "match_threshold": 0.5,
                     "max_width": 999,
                     "min_width": 0,
                 },
+            ), patch.dict(
+                common.CFG["profiles"]["aoe1de"]["resource_panel"],
+                {"icon_trim_pct": [0] * 6},
             ):
                 regions = resources.locate_resource_panel(frame)
 

--- a/tests/test_resource_rois.py
+++ b/tests/test_resource_rois.py
@@ -98,14 +98,20 @@ class TestResourceROIs(TestCase):
         ), patch.dict(
             common.CFG["resource_panel"],
             {
-                "roi_padding_left": self.pad_left,
-                "roi_padding_right": self.pad_right,
+                "roi_padding_left": [self.pad_left] * 6,
+                "roi_padding_right": [self.pad_right] * 6,
+                "icon_trim_pct": [0] * 6,
                 "scales": [1.0],
                 "match_threshold": 0.5,
                 "max_width": 999,
                 "min_width": 0,
                 "top_pct": 0.0,
                 "height_pct": 1.0,
+            },
+        ), patch.dict(
+            common.CFG["profiles"]["aoe1de"]["resource_panel"],
+            {
+                "icon_trim_pct": [0] * 6,
             },
         ):
             regions = resources.locate_resource_panel(self.frame)
@@ -181,15 +187,19 @@ class TestResourceROIs(TestCase):
             patch.object(screen_utils, "HUD_TEMPLATE", np.zeros((1, 1), dtype=np.uint8)), \
             patch.dict(screen_utils.ICON_TEMPLATES, {name: np.zeros((5, 5), dtype=np.uint8) for name in icons}, clear=True), \
             patch.dict(common.CFG["resource_panel"], {
-                "roi_padding_left": pad_left,
-                "roi_padding_right": pad_right,
+                "roi_padding_left": [pad_left] * 6,
+                "roi_padding_right": [pad_right] * 6,
+                "icon_trim_pct": [0] * 6,
                 "scales": [1.0],
                 "match_threshold": 0.5,
                 "max_width": 999,
                 "min_width": 0,
                 "top_pct": 0.0,
                 "height_pct": 1.0,
-            }):
+            }), patch.dict(
+                common.CFG["profiles"]["aoe1de"]["resource_panel"],
+                {"icon_trim_pct": [0] * 6},
+            ):
                 regions = resources.locate_resource_panel(frame)
                 icon_width = screen_utils.ICON_TEMPLATES[icons[0]].shape[1]
 
@@ -229,15 +239,19 @@ class TestResourceROIs(TestCase):
             patch.object(screen_utils, "HUD_TEMPLATE", np.zeros((1, 1), dtype=np.uint8)), \
             patch.dict(screen_utils.ICON_TEMPLATES, {name: np.zeros((5, 5), dtype=np.uint8) for name in icons}, clear=True), \
             patch.dict(common.CFG["resource_panel"], {
-                "roi_padding_left": pad_left,
-                "roi_padding_right": pad_right,
+                "roi_padding_left": [pad_left] * 6,
+                "roi_padding_right": [pad_right] * 6,
+                "icon_trim_pct": [0] * 6,
                 "scales": [1.0],
                 "match_threshold": 0.5,
                 "max_width": max_width,
                 "min_width": 0,
                 "top_pct": 0.0,
                 "height_pct": 1.0,
-            }):
+            }), patch.dict(
+                common.CFG["profiles"]["aoe1de"]["resource_panel"],
+                {"icon_trim_pct": [0] * 6},
+            ):
                 regions = resources.locate_resource_panel(frame)
                 icon_width = screen_utils.ICON_TEMPLATES[icons[0]].shape[1]
 


### PR DESCRIPTION
## Summary
- allow configuring ROI padding and icon trims per resource icon
- handle per-icon offsets when locating the resource panel
- document calibration of padding and trim arrays

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad4031d2a483258fa020d5345f0cd8