### PR TITLE
Ajusta padding esquerdo dos recursos

### DIFF
--- a/config.json
+++ b/config.json
@@ -25,7 +25,7 @@
     "resource_panel": {
         "match_threshold": 0.8,
         "scales": [0.9, 0.95, 1.0, 1.05, 1.1],
-        "roi_padding_left": [4, 4, 4, 4, 4, 4],
+        "roi_padding_left": [6, 6, 6, 6, 6, 6],
         "roi_padding_right": [2, 2, 2, 2, 2, 2],
         "max_width": 160,
         "min_width": 90,
@@ -60,7 +60,7 @@
           "match_threshold": 0.82,
           "top_pct": 0.08,
           "height_pct": 0.84,
-          "roi_padding_left": [4, 4, 4, 4, 4, 4],
+          "roi_padding_left": [6, 6, 6, 6, 6, 6],
           "roi_padding_right": [2, 2, 2, 2, 2, 2],
           "icon_trim_pct": [0.25, 0.20, 0.20, 0.20, 0.20, 0.20],
           "right_trim_pct": 0.02

--- a/config.sample.json
+++ b/config.sample.json
@@ -37,7 +37,7 @@
     "height_pct": 0.84,
     "icon_trim_pct": [0.18, 0.18, 0.18, 0.18, 0.18, 0.18],
     "right_trim_pct": 0.02,
-    "roi_padding_left": [4, 4, 4, 4, 4, 4],
+    "roi_padding_left": [6, 6, 6, 6, 6, 6],
     "roi_padding_right": [2, 2, 2, 2, 2, 2],
     "max_width": 160,
     "min_width": 90,
@@ -73,7 +73,7 @@
           "match_threshold": 0.82,
           "top_pct": 0.08,
           "height_pct": 0.84,
-          "roi_padding_left": [4, 4, 4, 4, 4, 4],
+          "roi_padding_left": [6, 6, 6, 6, 6, 6],
           "roi_padding_right": [2, 2, 2, 2, 2, 2],
           "icon_trim_pct": [0.18, 0.18, 0.18, 0.18, 0.18, 0.18],
           "right_trim_pct": 0.02


### PR DESCRIPTION
## Summary
- aumenta padding esquerdo do painel de recursos para [6,6,6,6,6,6]
- atualiza padding específico do perfil aoe1de

## Testing
- `pytest -q` *(interrompido: KeyboardInterrupt, 3 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad491ef3988325ac9d2ca68ee5a415