### PR TITLE
Adjust OCR kernel and resource panel spacing

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,8 +8,8 @@
   "ocr_debug": true,
   "verbose_logging": false,
   "ocr_conf_threshold": 45,
-  "ocr_kernel_size": 3,
-  "ocr_psm_list": [6, 7, 8, 10, 13],
+  "ocr_kernel_size": 2,
+  "ocr_psm_list": [7, 6, 8, 10, 13],
   "tesseract_path": "C:\\Program Files\\Tesseract-OCR\\tesseract.exe",
   "resource_cache_ttl": 1.5,
   "resource_cache_max_age": null,
@@ -26,14 +26,14 @@
         "match_threshold": 0.8,
         "scales": [0.9, 0.95, 1.0, 1.05, 1.1],
         "roi_padding_left": [6, 6, 6, 6, 6, 6],
-        "roi_padding_right": [2, 2, 2, 2, 2, 2],
+        "roi_padding_right": [1, 1, 1, 1, 1, 1],
         "max_width": 160,
         "min_width": 90,
         "narrow_mode": "expand",
         "idle_roi_extra_width": 0,
         "top_pct": 0.08,
         "height_pct": 0.84,
-        "icon_trim_pct": [0.25, 0.20, 0.20, 0.20, 0.20, 0.20],
+        "icon_trim_pct": [0.30, 0.25, 0.22, 0.22, 0.20, 0.20],
     "right_trim_pct": 0.02,
     "debug_failed_ocr": true
   },
@@ -61,8 +61,8 @@
           "top_pct": 0.08,
           "height_pct": 0.84,
           "roi_padding_left": [6, 6, 6, 6, 6, 6],
-          "roi_padding_right": [2, 2, 2, 2, 2, 2],
-          "icon_trim_pct": [0.25, 0.20, 0.20, 0.20, 0.20, 0.20],
+          "roi_padding_right": [1, 1, 1, 1, 1, 1],
+          "icon_trim_pct": [0.30, 0.25, 0.22, 0.22, 0.20, 0.20],
           "right_trim_pct": 0.02
         }
       }


### PR DESCRIPTION
## Summary
- tune OCR for single-line digits with smaller kernel and new PSM order
- expand resource panel width by trimming icons more and reducing right padding

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68ad4bbdd8dc8325bf4c4295cb121a88