### PR TITLE
Simplify ROI building and remove narrow mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ HUD-related coordinates, such as `areas.pop_box`, use ``[x, y, width, height]``
 fractions of the entire screen. The default values in `config.json` are
 placeholders and should be calibrated for your setup.
 
-The `resource_panel` uses a span-based ROI builder that measures the gap between consecutive icons. `max_width` caps the width of each region when the gap is wide. The default `narrow_mode` of `"fit"` keeps the ROI confined to the available span even if it is narrower than `min_width`. Switch to `"anchor"` to skip spans that fall below `min_width` and rely on `HUD_ANCHOR` estimates, or use `"right"` to align the ROI to the following icon.
+The `resource_panel` uses a span-based ROI builder that measures the gap between consecutive icons. `max_width` caps the width of each region when the gap is wide. If the gap is smaller than `min_width`, the ROI shrinks to fit the available space.
 
 ### OCR tuning
 

--- a/config.json
+++ b/config.json
@@ -29,7 +29,6 @@
         "roi_padding_right": [2, 2, 2, 2, 2, 2],
         "max_width": 160,
         "min_width": 90,
-        "narrow_mode": "fit",
         "idle_roi_extra_width": 0,
         "top_pct": 0.08,
         "height_pct": 0.84,

--- a/config.sample.json
+++ b/config.sample.json
@@ -44,8 +44,6 @@
     "//roi_padding_right": "pixels removed before the next icon; tweak per resource",
     "max_width": 160,
     "min_width": 90,
-    "narrow_mode": "fit",
-    "//narrow_mode": "'fit' uses the gap as-is; 'anchor' skips gaps < min_width; 'right' anchors to next icon",
     "idle_roi_extra_width": 0,
     "anchor_top_pct": 0.15,
     "anchor_height_pct": 0.70,

--- a/tests/test_resource_rois.py
+++ b/tests/test_resource_rois.py
@@ -338,7 +338,6 @@ class TestResourceROIs(TestCase):
             icon_trims=[0] * 6,
             max_width=999,
             min_width=20,
-            narrow_mode="expand",
             detected={
                 "wood_stockpile": (0, 0, 5, 5),
                 "food_stockpile": (15, 0, 5, 5),
@@ -352,33 +351,6 @@ class TestResourceROIs(TestCase):
         self.assertEqual(roi[0], span_left)
         self.assertEqual(roi[0] + roi[2], span_right)
         self.assertEqual(roi[2], span_right - span_left)
-
-    def test_right_anchored_narrow_mode_aligns_to_next_icon(self):
-        """narrow_mode='right' should anchor the ROI to the following icon."""
-
-        ctx = types.SimpleNamespace(
-            panel_left=0,
-            panel_right=200,
-            top=0,
-            height=10,
-            pad_left=[2] * 6,
-            pad_right=[2] * 6,
-            icon_trims=[0] * 6,
-            max_width=10,
-            min_width=0,
-            narrow_mode="right",
-            detected={
-                "wood_stockpile": (0, 0, 5, 5),
-                "food_stockpile": (40, 0, 5, 5),
-            },
-        )
-
-        regions = resources._build_resource_rois_between_icons(ctx)
-        roi = regions["wood_stockpile"]
-        expected_right = 38  # next_icon_left - pad_right
-        expected_left = expected_right - ctx.max_width
-        self.assertEqual(roi[0], expected_left)
-        self.assertEqual(roi[0] + roi[2], expected_right)
 
     def test_cache_cleared_on_region_change(self):
         resources._LAST_ICON_BOUNDS.clear()


### PR DESCRIPTION
## Summary
- Compute ROI bounds solely from available space between icons
- Drop `narrow_mode` and anchor-based sizing from ROI logic and configs
- Refresh documentation and tests to match simplified ROI behaviour

## Testing
- `pytest tests/test_resource_rois.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae3151b2908325bb46e0de53c0f382