### PR TITLE
Calibrate resource panel width lists

### DIFF
--- a/config.json
+++ b/config.json
@@ -28,14 +28,14 @@
         "roi_padding_left": [4, 6, 6, 6, 6, 6],
         "roi_padding_right": [2, 2, 2, 2, 2, 2],
         "max_width": 160,
-        "min_width": 90,
+        "min_width": [54, 51, 50, 51, 50, 40],
         "idle_roi_extra_width": 24,
         "top_pct": 0.08,
         "height_pct": 0.84,
-        "icon_trim_pct": [0.30, 0.25, 0.22, 0.22, 0.20, 0.20],
-    "right_trim_pct": 0.02,
-    "debug_failed_ocr": true
-  },
+        "icon_trim_pct": [0.30, 0.25, 0.24, 0.24, 0.22, 0.20],
+        "right_trim_pct": 0.02,
+        "debug_failed_ocr": true
+      },
   "hud_icons": {
     "required": [
       "wood_stockpile",
@@ -61,7 +61,8 @@
           "height_pct": 0.84,
           "roi_padding_left": [4, 6, 6, 6, 6, 6],
           "roi_padding_right": [2, 2, 2, 2, 2, 2],
-          "icon_trim_pct": [0.30, 0.25, 0.22, 0.22, 0.20, 0.20],
+          "min_width": [54, 51, 50, 51, 50, 40],
+          "icon_trim_pct": [0.30, 0.25, 0.24, 0.24, 0.22, 0.20],
           "right_trim_pct": 0.02
         }
       }


### PR DESCRIPTION
## Summary
- calibrate resource panel with per-icon `min_width` and updated `icon_trim_pct` lists
- mirror list-based values in `aoe1de` profile

## Testing
- `pytest tests/test_load_config_errors.py tests/test_ocr_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae4de73a2083258e1eec075f441447