### PR TITLE
refactor: unify population reading

### DIFF
--- a/script/buldings/town_center.py
+++ b/script/buldings/town_center.py
@@ -26,7 +26,7 @@ def train_villagers(target_pop: int):
                 "Attempt %s to read food from HUD while training villagers", attempt
             )
             try:
-                res_vals = resources.read_resources_from_hud(["food_stockpile"])
+                res_vals, _ = resources.read_resources_from_hud(["food_stockpile"])
             except common.ResourceReadError as exc:
                 logger.error(
                     "Resource read error while training villagers (attempt %s/3): %s",

--- a/script/units/villager.py
+++ b/script/units/villager.py
@@ -20,7 +20,7 @@ def select_idle_villager(delay: float = 0.1) -> bool:
 
     before = None
     try:
-        res_before = resources.read_resources_from_hud(["idle_villager"])
+        res_before, _ = resources.read_resources_from_hud(["idle_villager"])
     except common.ResourceReadError as exc:  # pragma: no cover - falha de OCR
         logger.error("Falha ao ler idle_villager: %s", exc)
     else:
@@ -30,7 +30,7 @@ def select_idle_villager(delay: float = 0.1) -> bool:
 
     after = None
     try:
-        res_after = resources.read_resources_from_hud(
+        res_after, _ = resources.read_resources_from_hud(
             ["idle_villager"], force_delay=delay
         )
     except common.ResourceReadError as exc:  # pragma: no cover - falha de OCR
@@ -74,7 +74,7 @@ def count_idle_villagers_via_hotkey(
     """
 
     try:
-        res = resources.read_resources_from_hud(["idle_villager"])
+        res, _ = resources.read_resources_from_hud(["idle_villager"])
     except common.ResourceReadError as exc:  # pragma: no cover - falha de OCR
         logger.error("Falha ao ler idle_villager: %s", exc)
         initial = 0
@@ -90,7 +90,7 @@ def count_idle_villagers_via_hotkey(
         select_idle_villager()
         selections += 1
         try:
-            res = resources.read_resources_from_hud(
+            res, _ = resources.read_resources_from_hud(
                 ["idle_villager"], force_delay=delay
             )
         except common.ResourceReadError as exc:  # pragma: no cover - falha de OCR
@@ -132,7 +132,7 @@ def build_house():
             "Attempt %s to read wood from HUD while building house", attempt
         )
         try:
-            res_vals = resources.read_resources_from_hud(["wood_stockpile"])
+            res_vals, _ = resources.read_resources_from_hud(["wood_stockpile"])
         except common.ResourceReadError as exc:
             logger.error(
                 "Resource read error while building house (attempt %s/3): %s",
@@ -153,7 +153,7 @@ def build_house():
         logger.debug("Refreshing HUD anchor before final resource read")
         try:
             hud.wait_hud()
-            res_vals = resources.read_resources_from_hud(["wood_stockpile"])
+            res_vals, _ = resources.read_resources_from_hud(["wood_stockpile"])
         except Exception as exc:
             logger.error(
                 "Failed to refresh HUD or read resources while building house: %s",
@@ -207,7 +207,7 @@ def build_house():
 
         logger.warning("Tentativa %s de construir casa falhou.", idx)
         try:
-            res_vals = resources.read_resources_from_hud(["wood_stockpile"])
+            res_vals, _ = resources.read_resources_from_hud(["wood_stockpile"])
         except common.ResourceReadError as exc:
             logger.error(
                 "Resource read error while retrying house construction: %s", exc

--- a/tests/test_build_house.py
+++ b/tests/test_build_house.py
@@ -48,7 +48,7 @@ class TestClickAndBuildHouse(TestCase):
         expected_coords = tuple(common.CFG["areas"]["house_spot"])
         with patch(
             "script.resources.read_resources_from_hud",
-            return_value={"wood_stockpile": 100},
+            return_value=({"wood_stockpile": 100}, (None, None)),
         ), \
             patch("script.input_utils._press_key_safe"), \
             patch("script.input_utils._click_norm") as click_mock, \
@@ -87,7 +87,7 @@ class TestBuildHouseResourceRetry(TestCase):
         common.POP_CAP = 4
         side_effect = [
             common.ResourceReadError("fail1"),
-            {"wood_stockpile": 100},
+            ({"wood_stockpile": 100}, (None, None)),
         ]
         with patch(
             "script.resources.read_resources_from_hud",

--- a/tests/test_hud_anchor.py
+++ b/tests/test_hud_anchor.py
@@ -76,8 +76,9 @@ class TestHudAnchor(TestCase):
         with patch("script.resources.locate_resource_panel", return_value={}), \
              patch("script.screen_utils._grab_frame", side_effect=fake_grab_frame), \
              patch("script.resources._ocr_digits_better", side_effect=fake_ocr), \
-             patch("script.resources.pytesseract.image_to_string", return_value="600"):
-            result = resources.read_resources_from_hud()
+             patch("script.resources.pytesseract.image_to_string", return_value="600"), \
+             patch("script.resources._read_population_from_roi", return_value=(500, 500)):
+            result, _ = resources.read_resources_from_hud()
 
         expected = {
             "wood_stockpile": 100,
@@ -98,7 +99,6 @@ class TestHudAnchor(TestCase):
             {"left": 530, "top": 24, "width": 78, "height": 50},
         ]
         expected_shapes = [
-            (50, 90),
             (50, 90),
             (50, 90),
             (50, 90),
@@ -140,8 +140,9 @@ class TestHudAnchorTools(TestCase):
              patch("tools.campaign_bot._grab_frame", side_effect=fake_grab_frame), \
              patch("tools.campaign_bot._ocr_digits_better", side_effect=fake_ocr), \
              patch("script.resources._ocr_digits_better", side_effect=fake_ocr), \
-             patch("script.resources.pytesseract.image_to_string", return_value="600"):
-            result = cb.read_resources_from_hud([
+             patch("script.resources.pytesseract.image_to_string", return_value="600"), \
+             patch("script.resources._read_population_from_roi", return_value=(500, 500)):
+            result, _ = cb.read_resources_from_hud([
                 "wood_stockpile",
                 "food_stockpile",
                 "gold_stockpile",
@@ -169,7 +170,6 @@ class TestHudAnchorTools(TestCase):
             {"left": 530, "top": 24, "width": 78, "height": 50},
         ]
         expected_shapes = [
-            (50, 90),
             (50, 90),
             (50, 90),
             (50, 90),

--- a/tests/test_idle_villager_ocr.py
+++ b/tests/test_idle_villager_ocr.py
@@ -50,7 +50,7 @@ class TestIdleVillagerOCR(TestCase):
              patch("script.screen_utils._grab_frame", return_value=frame), \
              patch("script.resources.pytesseract.image_to_string", return_value="12") as img2str, \
              patch("script.resources._ocr_digits_better") as ocr_mock:
-            result = resources.read_resources_from_hud(["idle_villager"])
+            result, _ = resources.read_resources_from_hud(["idle_villager"])
 
         self.assertEqual(result["idle_villager"], 12)
         img2str.assert_called_once_with(ANY, config="--psm 7 -c tessedit_char_whitelist=0123456789")

--- a/tests/test_idle_villager_roi.py
+++ b/tests/test_idle_villager_roi.py
@@ -135,10 +135,10 @@ class TestIdleVillagerROI(TestCase):
 
     def test_count_idle_villagers_via_hotkey_stops_on_no_decrease(self):
         counts = iter([
-            {"idle_villager": 3},
-            {"idle_villager": 2},
-            {"idle_villager": 1},
-            {"idle_villager": 1},
+            ({"idle_villager": 3}, (None, None)),
+            ({"idle_villager": 2}, (None, None)),
+            ({"idle_villager": 1}, (None, None)),
+            ({"idle_villager": 1}, (None, None)),
         ])
 
         def fake_read(keys, force_delay=None):
@@ -156,9 +156,9 @@ class TestIdleVillagerROI(TestCase):
 
     def test_count_idle_villagers_via_hotkey_uses_force_delay(self):
         counts = iter([
-            {"idle_villager": 2},
-            {"idle_villager": 1},
-            {"idle_villager": 0},
+            ({"idle_villager": 2}, (None, None)),
+            ({"idle_villager": 1}, (None, None)),
+            ({"idle_villager": 0}, (None, None)),
         ])
 
         delays = []
@@ -181,10 +181,10 @@ class TestIdleVillagerROI(TestCase):
 
     def test_count_idle_villagers_via_hotkey_stops_on_threshold(self):
         counts = iter([
-            {"idle_villager": 4},
-            {"idle_villager": 3},
-            {"idle_villager": 2},
-            {"idle_villager": 1},
+            ({"idle_villager": 4}, (None, None)),
+            ({"idle_villager": 3}, (None, None)),
+            ({"idle_villager": 2}, (None, None)),
+            ({"idle_villager": 1}, (None, None)),
         ])
 
         def fake_read(keys, force_delay=None):

--- a/tests/test_internal_population.py
+++ b/tests/test_internal_population.py
@@ -52,7 +52,7 @@ class TestInternalPopulation(TestCase):
 
         with patch(
             "script.resources.read_resources_from_hud",
-            return_value={"food_stockpile": 500},
+            return_value=({"food_stockpile": 500}, (None, None)),
         ), \
              patch("script.buldings.town_center.build_house", side_effect=fake_build_house) as build_house_mock, \
              patch("script.buldings.town_center.select_idle_villager", return_value=True), \

--- a/tests/test_resource_debug_images.py
+++ b/tests/test_resource_debug_images.py
@@ -66,9 +66,10 @@ class TestResourceDebugImages(TestCase):
                      "idle_villager": (250, 0, 50, 50),
                  },
              ), \
-             patch("script.resources._ocr_digits_better", side_effect=fake_ocr), \
-             patch("script.resources.pytesseract.image_to_string", return_value=""), \
-             patch("script.resources.cv2.imwrite") as imwrite_mock:
+            patch("script.resources._ocr_digits_better", side_effect=fake_ocr), \
+            patch("script.resources.pytesseract.image_to_string", return_value=""), \
+            patch("script.resources._read_population_from_roi", return_value=(0, 0)), \
+            patch("script.resources.cv2.imwrite") as imwrite_mock:
             with self.assertRaises(common.ResourceReadError):
                 resources.read_resources_from_hud()
         paths = [call.args[0] for call in imwrite_mock.call_args_list]
@@ -114,11 +115,12 @@ class TestResourceDebugImages(TestCase):
                  },
              ), \
              patch("script.resources._ocr_digits_better", side_effect=fake_ocr), \
-             patch(
-                 "script.resources.pytesseract.image_to_string",
-                 side_effect=["", "", "0"],
-             ), \
-             patch("script.resources.cv2.imwrite") as imwrite_mock:
+            patch(
+                "script.resources.pytesseract.image_to_string",
+                side_effect=["", "", "0"],
+            ), \
+            patch("script.resources._read_population_from_roi", return_value=(0, 0)), \
+            patch("script.resources.cv2.imwrite") as imwrite_mock:
             with self.assertRaises(common.ResourceReadError) as ctx:
                 resources.read_resources_from_hud()
 

--- a/tests/test_resource_ocr_failure.py
+++ b/tests/test_resource_ocr_failure.py
@@ -69,8 +69,9 @@ class TestResourceOcrFailure(TestCase):
                  },
              ), \
              patch("script.resources._ocr_digits_better", side_effect=fake_ocr), \
-             patch("script.resources.pytesseract.image_to_string", return_value="123"):
-            result = resources.read_resources_from_hud()
+             patch("script.resources.pytesseract.image_to_string", return_value="123"), \
+             patch("script.resources._read_population_from_roi", return_value=(0, 0)):
+            result, _ = resources.read_resources_from_hud()
             self.assertEqual(result["wood_stockpile"], 123)
 
     def test_optional_icon_failure_does_not_raise(self):
@@ -98,7 +99,7 @@ class TestResourceOcrFailure(TestCase):
              patch("script.resources._ocr_digits_better", side_effect=fake_ocr), \
              patch("script.resources.pytesseract.image_to_string", return_value=""), \
              patch("script.resources.cv2.imwrite"):
-            result = resources.read_resources_from_hud(["wood_stockpile"])
+            result, _ = resources.read_resources_from_hud(["wood_stockpile"])
         self.assertEqual(result.get("wood_stockpile"), 123)
         self.assertIsNone(result.get("food_stockpile"))
 
@@ -148,8 +149,8 @@ class TestResourceOcrFailure(TestCase):
              patch("script.resources._ocr_digits_better", side_effect=fake_ocr), \
              patch("script.resources.pytesseract.image_to_string", return_value=""), \
              patch("script.resources.cv2.imwrite"):
-            first = resources.read_resources_from_hud(["wood_stockpile"])
-            second = resources.read_resources_from_hud(["wood_stockpile"])
+            first, _ = resources.read_resources_from_hud(["wood_stockpile"])
+            second, _ = resources.read_resources_from_hud(["wood_stockpile"])
 
         self.assertNotIn("food_stockpile", first)
         self.assertNotIn("food_stockpile", second)

--- a/tests/test_resource_read_retry.py
+++ b/tests/test_resource_read_retry.py
@@ -68,8 +68,8 @@ class TestResourceReadRetry(TestCase):
              patch("script.resources._ocr_digits_better", side_effect=fake_ocr), \
              patch("script.resources.pytesseract.image_to_string", return_value=""), \
              patch("script.resources.cv2.imwrite"):
-            first = resources.read_resources_from_hud(["wood_stockpile"])
-            second = resources.read_resources_from_hud(["wood_stockpile"])
+            first, _ = resources.read_resources_from_hud(["wood_stockpile"])
+            second, _ = resources.read_resources_from_hud(["wood_stockpile"])
 
         self.assertEqual(first["wood_stockpile"], 123)
         self.assertEqual(second["wood_stockpile"], 123)
@@ -94,7 +94,7 @@ class TestResourceReadRetry(TestCase):
              patch("script.resources._ocr_digits_better", side_effect=fake_ocr) as ocr_mock, \
              patch("script.resources.pytesseract.image_to_string", return_value=""), \
              patch("script.resources.cv2.imwrite"):
-            result = resources.read_resources_from_hud(["wood_stockpile"])
+            result, _ = resources.read_resources_from_hud(["wood_stockpile"])
 
         self.assertEqual(result["wood_stockpile"], 456)
         self.assertEqual(ocr_mock.call_count, 2)
@@ -120,7 +120,7 @@ class TestResourceReadRetry(TestCase):
              patch("script.resources.cv2.imwrite"):
             with self.assertRaises(common.ResourceReadError):
                 resources.read_resources_from_hud(["wood_stockpile"])
-            result = resources.read_resources_from_hud(["wood_stockpile"])
+            result, _ = resources.read_resources_from_hud(["wood_stockpile"])
 
         self.assertEqual(result["wood_stockpile"], 999)
         self.assertIn("wood_stockpile", resources._LAST_READ_FROM_CACHE)

--- a/tests/test_select_idle_villager.py
+++ b/tests/test_select_idle_villager.py
@@ -38,8 +38,8 @@ import script.units.villager as villager
 class TestSelectIdleVillager(TestCase):
     def test_returns_true_when_count_decreases(self):
         reads = iter([
-            {"idle_villager": 2},
-            {"idle_villager": 1},
+            ({"idle_villager": 2}, (None, None)),
+            ({"idle_villager": 1}, (None, None)),
         ])
 
         with patch("script.input_utils._press_key_safe"), \
@@ -48,8 +48,8 @@ class TestSelectIdleVillager(TestCase):
 
     def test_returns_false_when_no_idle_villagers(self):
         reads = iter([
-            {"idle_villager": 0},
-            {"idle_villager": 0},
+            ({"idle_villager": 0}, (None, None)),
+            ({"idle_villager": 0}, (None, None)),
         ])
 
         with patch("script.input_utils._press_key_safe"), \


### PR DESCRIPTION
## Summary
- infer population limit ROI using idle villager icon
- share population reading logic across HUD readers
- update consumers and tests for new population API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae53e132708325976f1f755e3bcc93