### PR TITLE
Expand resource panel margins for OCR

### DIFF
--- a/config.json
+++ b/config.json
@@ -30,9 +30,9 @@
         "max_width": 160,
         "min_width": [54, 51, 50, 51, 50, 40],
         "idle_roi_extra_width": 24,
-        "top_pct": 0.08,
-        "height_pct": 0.84,
-        "icon_trim_pct": [0.30, 0.25, 0.24, 0.24, 0.22, 0.20],
+        "top_pct": 0.06,
+        "height_pct": 0.88,
+        "icon_trim_pct": [0.30, 0.25, 0.24, 0.24, 0.20, 0.00],
         "right_trim_pct": 0.02,
         "debug_failed_ocr": true
       },
@@ -57,12 +57,12 @@
       "aoe1de": {
         "resource_panel": {
           "match_threshold": 0.82,
-          "top_pct": 0.08,
-          "height_pct": 0.84,
+          "top_pct": 0.06,
+          "height_pct": 0.88,
           "roi_padding_left": [4, 6, 6, 6, 6, 6],
           "roi_padding_right": [2, 2, 2, 2, 2, 2],
           "min_width": [54, 51, 50, 51, 50, 40],
-          "icon_trim_pct": [0.30, 0.25, 0.24, 0.24, 0.22, 0.20],
+          "icon_trim_pct": [0.30, 0.25, 0.24, 0.24, 0.20, 0.00],
           "right_trim_pct": 0.02
         }
       }

--- a/config.sample.json
+++ b/config.sample.json
@@ -34,9 +34,9 @@
   "//resource_panel": "ROIs built from spans between icons via compute_resource_rois",
   "resource_panel": {
     "match_threshold": 0.8,
-    "top_pct": 0.08,
-    "height_pct": 0.84,
-    "icon_trim_pct": [0.18, 0.18, 0.18, 0.18, 0.18, 0.18],
+    "top_pct": 0.06,
+    "height_pct": 0.88,
+    "icon_trim_pct": [0.30, 0.25, 0.24, 0.24, 0.20, 0.00],
     "right_trim_pct": 0.02,
     "roi_padding_left": [4, 6, 6, 6, 6, 6],
     "//roi_padding_left": "pixels added after each icon; tweak per resource",
@@ -74,11 +74,11 @@
       "aoe1de": {
         "resource_panel": {
           "match_threshold": 0.82,
-          "top_pct": 0.08,
-          "height_pct": 0.84,
+          "top_pct": 0.06,
+          "height_pct": 0.88,
           "roi_padding_left": [4, 6, 6, 6, 6, 6],
           "roi_padding_right": [2, 2, 2, 2, 2, 2],
-          "icon_trim_pct": [0.18, 0.18, 0.18, 0.18, 0.18, 0.18],
+          "icon_trim_pct": [0.30, 0.25, 0.24, 0.24, 0.20, 0.00],
           "right_trim_pct": 0.02
         }
       }

--- a/tests/test_gather_hud_stats.py
+++ b/tests/test_gather_hud_stats.py
@@ -52,7 +52,7 @@ class TestGatherHudStats(TestCase):
         }
         self.assertEqual(res, expected_res)
         self.assertEqual(pop, (123, 200))
-        expected_shapes = [(50, 90)] * 5
+        expected_shapes = [(52, 90), (52, 90), (52, 90), (52, 90), (52, 98)]
         self.assertEqual(roi_shapes, expected_shapes)
-        self.assertEqual(pop_shapes, [(50, 90)])
+        self.assertEqual(pop_shapes, [(52, 90)])
         self.assertEqual(grab_calls, [None])

--- a/tests/test_hud_anchor.py
+++ b/tests/test_hud_anchor.py
@@ -99,10 +99,10 @@ class TestHudAnchor(TestCase):
             {"left": 530, "top": 24, "width": 78, "height": 50},
         ]
         expected_shapes = [
-            (50, 90),
-            (50, 90),
-            (50, 90),
-            (50, 90),
+            (52, 90),
+            (52, 90),
+            (52, 90),
+            (52, 90),
         ]
         self.assertEqual(roi_shapes, expected_shapes)
         self.assertEqual(grab_calls, [None])
@@ -170,10 +170,10 @@ class TestHudAnchorTools(TestCase):
             {"left": 530, "top": 24, "width": 78, "height": 50},
         ]
         expected_shapes = [
-            (50, 90),
-            (50, 90),
-            (50, 90),
-            (50, 90),
+            (52, 90),
+            (52, 90),
+            (52, 90),
+            (52, 90),
         ]
         self.assertEqual(roi_shapes, expected_shapes)
         self.assertEqual(grab_calls, [None])


### PR DESCRIPTION
## Summary
- widen resource panel detection window and refine icon trims
- align profile-specific resource panel defaults with new margins
- update HUD tests to expect larger resource ROI slices

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae60a6fedc832591419ee6098fb587