### PR TITLE
Improve HUD template failure diagnostics

### DIFF
--- a/script/hud.py
+++ b/script/hud.py
@@ -52,15 +52,22 @@ def wait_hud(timeout=60):
             return common.HUD_ANCHOR, asset
         if score > last_score:
             last_score = score
+            logger.debug("HUD template '%s' score improved to %.3f", asset, score)
         time.sleep(0.25)
+    logger.debug(
+        "HUD search ended. Highest score=%.3f using template '%s'",
+        last_score,
+        asset,
+    )
     logger.error(
-        "HUD não encontrada. Melhor score=%.3f no template '%s'. Re-capture o asset e verifique ESCALA 100%%.",
+        "HUD não encontrada. Melhor score=%.3f no template '%s'. "
+        "Considere recapturar templates de ícones ou verificar a resolução/ESCALA 100%%.",
         last_score,
         asset,
     )
     raise RuntimeError(
         f"HUD não encontrada. Melhor score={last_score:.3f} no template '{asset}'. "
-        "Re-capture o asset (recorte mais justo) e verifique ESCALA 100%.",
+        "Considere recapturar os templates de ícones ou verificar a resolução/ESCALA 100%.",
     )
 
 


### PR DESCRIPTION
## Summary
- Enhance `wait_hud` error handling to mention recapturing templates or verifying resolution
- Log highest template score and asset path for HUD search debugging

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae6ca76c8883259ce10962102e8f9f