### PR TITLE
Simplify resource panel configuration and merge profile defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ HUD-related coordinates, such as `areas.pop_box`, use ``[x, y, width, height]``
 fractions of the entire screen. The default values in `config.json` are
 placeholders and should be calibrated for your setup.
 
+Configuration sections like `resource_panel` provide shared defaults at the
+root level. Each entry under `profiles` only needs to include values that
+differ from these defaults; missing keys automatically fall back to the root
+settings when the configuration is loaded.
+
 The `resource_panel` uses a span-based ROI builder that measures the gap between consecutive icons. `max_width` caps the width of each region when the gap is wide. If the gap is smaller than `min_width`, the ROI shrinks to fit the available space. The `min_width` option accepts either a single value applied to all icons or a list of six per-icon values.
 
 ### OCR tuning

--- a/config.json
+++ b/config.json
@@ -57,14 +57,7 @@
   "profiles": {
       "aoe1de": {
         "resource_panel": {
-          "match_threshold": 0.82,
-          "top_pct": 0.06,
-          "height_pct": 0.88,
-          "roi_padding_left": [4, 6, 6, 6, 6, 6],
-          "roi_padding_right": [2, 2, 2, 2, 2, 2],
-          "min_width": [54, 51, 50, 51, 50, 40],
-          "icon_trim_pct": [0.30, 0.25, 0.24, 0.24, 0.20, 0.00],
-          "right_trim_pct": 0.02
+          "match_threshold": 0.82
         }
       }
     },


### PR DESCRIPTION
## Summary
- centralize resource_panel defaults at root and trim profile override to just the match_threshold
- deep-merge profile settings with base config so missing keys fall back to defaults
- document that profiles inherit root-level configuration values

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae82f65dd48325b11eed1421cd7308