### PR TITLE
Limit Town Center food stockpile read to one attempt

### DIFF
--- a/script/buldings/town_center.py
+++ b/script/buldings/town_center.py
@@ -21,7 +21,7 @@ def train_villagers(target_pop: int):
 
         res_vals = None
         food = None
-        for attempt in range(1, 4):
+        for attempt in range(1, 2):
             logger.debug(
                 "Attempt %s to read food from HUD while training villagers", attempt
             )
@@ -29,7 +29,7 @@ def train_villagers(target_pop: int):
                 res_vals, _ = resources.read_resources_from_hud(["food_stockpile"])
             except common.ResourceReadError as exc:
                 logger.error(
-                    "Resource read error while training villagers (attempt %s/3): %s",
+                    "Resource read error while training villagers (attempt %s): %s",
                     attempt,
                     exc,
                 )
@@ -38,14 +38,13 @@ def train_villagers(target_pop: int):
                 if isinstance(food, int):
                     break
                 logger.warning(
-                    "food_stockpile not detected (attempt %s/3); HUD may not be updated",
+                    "food_stockpile not detected (attempt %s); HUD may not be updated",
                     attempt,
                 )
-            if attempt < 3:
-                time.sleep(0.2)
+            time.sleep(0.2)
         if not isinstance(food, int):
             logger.error(
-                "Failed to obtain food stockpile after 3 attempts; stopping villager training"
+                "Failed to obtain food stockpile after 1 attempt; stopping villager training"
             )
             break
         if food < 50:


### PR DESCRIPTION
## Summary
- try reading Town Center food stockpile only once
- update error and warning messages for single attempt
- drop retry sleep guard

## Testing
- `pytest` *(fails: 1 failed, 23 passed, test_gather_reads_resources_and_population assertion error)*

------
https://chatgpt.com/codex/tasks/task_e_68af639fba78832586af0fdf47f6a256