### PR TITLE
Add configurable resource ROI overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,25 @@ cannot be detected or read. Icons listed under `optional` are attempted but do
 not stop execution if they are missing. Adjust these lists to match the
 resources shown in your game profile.
 
+### Manual ROI overrides
+
+Automatic ROI detection may fail on unusual HUD layouts. Optional sections in
+`config.json` let you override the detected rectangles with percentages of the
+screen size. Each entry supplies at least `left_pct` and `width_pct` and may
+also include `top_pct` and `height_pct`:
+
+```json
+"wood_stockpile_roi": {"left_pct": 0.05, "width_pct": 0.05},
+"food_stockpile_roi": {"left_pct": 0.15, "width_pct": 0.05},
+"gold_stockpile_roi": {"left_pct": 0.25, "width_pct": 0.05},
+"stone_stockpile_roi": {"left_pct": 0.35, "width_pct": 0.05},
+"population_limit_roi": {"left_pct": 0.45, "width_pct": 0.05},
+"idle_villager_roi": {"left_pct": 0.84, "width_pct": 0.05}
+```
+
+When present, these overrides take precedence and allow OCR to proceed even
+when the resource bar cannot be located automatically.
+
 ## Calibration helper
 
 To calibrate the `areas.pop_box` fractions interactively, run:

--- a/config.json
+++ b/config.json
@@ -54,6 +54,36 @@
     "left_pct": 0.84,
     "width_pct": 0.05
   },
+  "wood_stockpile_roi": {
+    "top_pct": 0.10,
+    "height_pct": 0.06,
+    "left_pct": 0.05,
+    "width_pct": 0.05
+  },
+  "food_stockpile_roi": {
+    "top_pct": 0.10,
+    "height_pct": 0.06,
+    "left_pct": 0.15,
+    "width_pct": 0.05
+  },
+  "gold_stockpile_roi": {
+    "top_pct": 0.10,
+    "height_pct": 0.06,
+    "left_pct": 0.25,
+    "width_pct": 0.05
+  },
+  "stone_stockpile_roi": {
+    "top_pct": 0.10,
+    "height_pct": 0.06,
+    "left_pct": 0.35,
+    "width_pct": 0.05
+  },
+  "population_limit_roi": {
+    "top_pct": 0.10,
+    "height_pct": 0.06,
+    "left_pct": 0.45,
+    "width_pct": 0.05
+  },
   "profiles": {
       "aoe1de": {
         "resource_panel": {

--- a/config.sample.json
+++ b/config.sample.json
@@ -54,6 +54,36 @@
     "left_pct": 0.84,
     "width_pct": 0.05
   },
+  "wood_stockpile_roi": {
+    "top_pct": 0.06,
+    "height_pct": 0.88,
+    "left_pct": 0.05,
+    "width_pct": 0.05
+  },
+  "food_stockpile_roi": {
+    "top_pct": 0.06,
+    "height_pct": 0.88,
+    "left_pct": 0.15,
+    "width_pct": 0.05
+  },
+  "gold_stockpile_roi": {
+    "top_pct": 0.06,
+    "height_pct": 0.88,
+    "left_pct": 0.25,
+    "width_pct": 0.05
+  },
+  "stone_stockpile_roi": {
+    "top_pct": 0.06,
+    "height_pct": 0.88,
+    "left_pct": 0.35,
+    "width_pct": 0.05
+  },
+  "population_limit_roi": {
+    "top_pct": 0.06,
+    "height_pct": 0.88,
+    "left_pct": 0.45,
+    "width_pct": 0.05
+  },
   "profiles": {
       "aoe1de": {
         "resource_panel": {

--- a/script/hud.py
+++ b/script/hud.py
@@ -77,6 +77,14 @@ def read_population_from_hud(retries=1, conf_threshold=None, save_failed_roi=Fal
 
     frame_full = screen_utils._grab_frame()
     regions = resources.locate_resource_panel(frame_full)
+    pop_cfg = CFG.get("population_limit_roi")
+    if pop_cfg:
+        W, H = input_utils._screen_size()
+        left = int(pop_cfg.get("left_pct", 0) * W)
+        top = int(pop_cfg.get("top_pct", 0) * H)
+        width = int(pop_cfg.get("width_pct", 0) * W)
+        height = int(pop_cfg.get("height_pct", 0) * H)
+        regions["population_limit"] = (left, top, width, height)
     roi_bbox = None
     if "population_limit" in regions:
         x, y, w, h = regions["population_limit"]

--- a/script/resources.py
+++ b/script/resources.py
@@ -395,6 +395,24 @@ def detect_resource_regions(frame, required_icons):
             logger.debug(
                 "Custom ROI aplicada para idle_villager: %s", regions["idle_villager"]
             )
+    custom_names = [
+        "wood_stockpile",
+        "food_stockpile",
+        "gold_stockpile",
+        "stone_stockpile",
+        "population_limit",
+    ]
+    W, H = input_utils._screen_size()
+    for name in custom_names:
+        cfg = CFG.get(f"{name}_roi")
+        if not cfg:
+            continue
+        left = int(cfg.get("left_pct", 0) * W)
+        top = int(cfg.get("top_pct", 0) * H)
+        width = int(cfg.get("width_pct", 0) * W)
+        height = int(cfg.get("height_pct", 0) * H)
+        regions[name] = (left, top, width, height)
+        logger.debug("Custom ROI aplicada para %s: %s", name, regions[name])
     missing = [name for name in required_icons if name not in regions]
 
     if missing and common.HUD_ANCHOR:

--- a/tests/test_resource_custom_rois.py
+++ b/tests/test_resource_custom_rois.py
@@ -1,0 +1,65 @@
+import os
+import sys
+import types
+from unittest import TestCase
+from unittest.mock import patch
+
+import numpy as np
+
+# Stub modules requiring a GUI/display
+
+dummy_pg = types.SimpleNamespace(
+    PAUSE=0,
+    FAILSAFE=False,
+    size=lambda: (200, 200),
+    click=lambda *a, **k: None,
+    moveTo=lambda *a, **k: None,
+    press=lambda *a, **k: None,
+)
+
+
+class DummyMSS:
+    monitors = [{}, {"left": 0, "top": 0, "width": 200, "height": 200}]
+
+    def grab(self, region):
+        h, w = region["height"], region["width"]
+        return np.zeros((h, w, 4), dtype=np.uint8)
+
+
+sys.modules.setdefault("pyautogui", dummy_pg)
+sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
+
+os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import script.common as common
+import script.resources as resources
+
+
+class TestResourceCustomROIs(TestCase):
+    def test_roi_matches_configured_percentages_when_missing(self):
+        frame = np.zeros((100, 200, 3), dtype=np.uint8)
+        cfg = {
+            "left_pct": 0.2,
+            "top_pct": 0.3,
+            "width_pct": 0.25,
+            "height_pct": 0.25,
+        }
+        expected = (40, 60, 50, 50)
+        names = [
+            "wood_stockpile",
+            "food_stockpile",
+            "gold_stockpile",
+            "stone_stockpile",
+            "population_limit",
+        ]
+        with patch("script.resources.locate_resource_panel", return_value={}), \
+            patch("script.resources.input_utils._screen_size", return_value=(200, 200)), \
+            patch.object(common, "HUD_ANCHOR", None):
+            for name in names:
+                with self.subTest(name=name):
+                    key = f"{name}_roi"
+                    with patch.dict(resources.CFG, {key: cfg}, clear=False):
+                        regions = resources.detect_resource_regions(frame, [name])
+                    self.assertEqual(regions[name], expected)
+


### PR DESCRIPTION
## Summary
- allow manual ROI overrides for wood, food, gold, stone and population via config
- fallback to these ROIs when automatic detection fails
- document new configuration options and add regression tests

## Testing
- `pytest tests/test_idle_villager_custom_roi.py tests/test_resource_custom_rois.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af6fd9dad8832589b132ff81b26bae