### PR TITLE
Add configurable minimum ROI width for resource values

### DIFF
--- a/config.json
+++ b/config.json
@@ -30,6 +30,7 @@
         "roi_padding_right": [0,0,0,0,0,0],
         "max_width": 999,
         "min_width": [1, 1, 1, 1, 1, 1],
+        "min_required_width": 0,
         "idle_roi_extra_width": 24,
         "top_pct": 0.20,
         "height_pct": 0.60,

--- a/config.sample.json
+++ b/config.sample.json
@@ -30,6 +30,7 @@
         "roi_padding_right": [0, 0, 0, 0, 0, 0],
         "max_width": 160,
         "min_width": [5, 5, 5, 5, 5, 4],
+        "min_required_width": 0,
         "idle_roi_extra_width": 24,
         "top_pct": 0.06,
         "height_pct": 0.88,

--- a/tests/test_resource_min_required_width.py
+++ b/tests/test_resource_min_required_width.py
@@ -1,0 +1,67 @@
+from unittest import TestCase
+import sys
+import types
+import numpy as np
+import os
+
+cv2_stub = types.SimpleNamespace(
+    cvtColor=lambda src, code: src,
+    resize=lambda img, *a, **k: img,
+    matchTemplate=lambda *a, **k: np.zeros((1, 1), dtype=np.float32),
+    minMaxLoc=lambda *a, **k: (0, 0, (0, 0), (0, 0)),
+    imread=lambda *a, **k: np.zeros((1, 1), dtype=np.uint8),
+    imwrite=lambda *a, **k: True,
+    medianBlur=lambda src, k: src,
+    bitwise_not=lambda src: src,
+    rectangle=lambda img, pt1, pt2, color, thickness: img,
+    threshold=lambda src, *a, **k: (None, src),
+    IMREAD_GRAYSCALE=0,
+    COLOR_BGR2GRAY=0,
+    INTER_LINEAR=0,
+    THRESH_BINARY=0,
+    THRESH_OTSU=0,
+    TM_CCOEFF_NORMED=0,
+)
+sys.modules.setdefault("cv2", cv2_stub)
+sys.modules.setdefault("pytesseract", types.SimpleNamespace())
+sys.modules.setdefault("pyautogui", types.SimpleNamespace())
+sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: None))
+sys.modules.setdefault(
+    "script.screen_utils",
+    types.SimpleNamespace(ICON_TEMPLATES={}, HUD_TEMPLATE=None, _load_icon_templates=lambda: None),
+)
+sys.modules.setdefault(
+    "script.common",
+    types.SimpleNamespace(CFG={"resource_panel": {}}, HUD_ANCHOR={"left": 0, "width": 0}),
+)
+sys.modules.setdefault(
+    "script.input_utils",
+    types.SimpleNamespace(_screen_size=lambda: (0, 0)),
+)
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import script.resources as resources
+
+
+class TestResourceMinRequiredWidth(TestCase):
+    def test_forces_min_width_for_wide_values(self):
+        """ROIs should expand to fit values with 3-4 digits."""
+        detected = {
+            "wood_stockpile": (0, 0, 5, 5),
+            "food_stockpile": (100, 0, 5, 5),
+        }
+        regions, _spans, _narrow = resources.compute_resource_rois(
+            0,
+            200,
+            0,
+            10,
+            [0] * 6,
+            [0] * 6,
+            [0] * 6,
+            20,
+            [0] * 6,
+            [50] * 6,
+            detected,
+        )
+        self.assertEqual(regions["wood_stockpile"][2], 50)

--- a/tests/test_resource_ocr_failure.py
+++ b/tests/test_resource_ocr_failure.py
@@ -277,7 +277,7 @@ class TestResourceOcrRois(TestCase):
             [0] * 6,
             999,
             [0] * 6,
-            detected,
+            detected=detected,
         )
         return frame, regions, values, cap, icon_color
 

--- a/tests/test_resource_rois.py
+++ b/tests/test_resource_rois.py
@@ -416,7 +416,7 @@ class TestResourceROIs(TestCase):
             [0] * 6,
             999,
             [20] * 6,
-            detected,
+            detected=detected,
         )
         roi = regions["wood_stockpile"]
         span_left = 7  # icon_right + pad_left


### PR DESCRIPTION
## Summary
- add `min_required_width` option to enforce minimal ROI width when reading resources
- document new setting in config files
- cover wide resource values with dedicated test

## Testing
- `pytest tests/test_resource_min_required_width.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68af8c0dd2a083259e9092447f30c8db