### PR TITLE
Retain single-digit OCR values with low confidence

### DIFF
--- a/script/resources.py
+++ b/script/resources.py
@@ -639,14 +639,22 @@ def execute_ocr(gray, conf_threshold=None, allow_fallback=True):
         mean_conf = sum(confidences) / len(confidences)
         max_conf = max(confidences)
         if mean_conf < conf_threshold or max_conf < conf_threshold:
-            logger.debug(
-                "Clearing low-confidence OCR result: mean=%.1f max=%.1f digits=%s",
-                mean_conf,
-                max_conf,
-                digits,
-            )
-            digits = ""
-            low_conf = True
+            if len(digits) == 1:
+                logger.warning(
+                    "Accepting low-confidence OCR result: mean=%.1f max=%.1f digits=%s",
+                    mean_conf,
+                    max_conf,
+                    digits,
+                )
+            else:
+                logger.debug(
+                    "Clearing low-confidence OCR result: mean=%.1f max=%.1f digits=%s",
+                    mean_conf,
+                    max_conf,
+                    digits,
+                )
+                digits = ""
+                low_conf = True
     if low_conf:
         alt_gray = cv2.bitwise_not(gray)
         digits2, data2, mask2 = _ocr_digits_better(alt_gray)

--- a/tests/test_resource_helpers.py
+++ b/tests/test_resource_helpers.py
@@ -82,6 +82,17 @@ class TestExecuteOcr(TestCase):
         self.assertEqual(digits, "")
         img2str_mock.assert_called_once()
 
+    def test_execute_ocr_accepts_low_conf_single_digit(self):
+        gray = np.zeros((5, 5), dtype=np.uint8)
+        data = {"text": ["0"], "conf": ["10"]}
+        with patch("script.resources._ocr_digits_better", return_value=("0", data, None)), \
+             patch("script.resources.pytesseract.image_to_string", return_value="") as img2str_mock, \
+             patch("script.resources.logger.warning") as warn_mock:
+            digits, _, _ = resources.execute_ocr(gray, conf_threshold=60)
+        self.assertEqual(digits, "0")
+        img2str_mock.assert_not_called()
+        warn_mock.assert_called_once()
+
     def test_execute_ocr_second_attempt_success(self):
         gray = np.zeros((5, 5), dtype=np.uint8)
         data1 = {"text": ["123"], "conf": ["10", "20", "30"]}


### PR DESCRIPTION
## Summary
- Preserve single-digit OCR results even when confidence is below threshold
- Log a warning instead of clearing the digit when confidence is low
- Add unit test for accepting single low-confidence digit

## Testing
- `pytest tests/test_resource_helpers.py::TestExecuteOcr::test_execute_ocr_accepts_low_conf_single_digit -q`
- `pytest -q` *(fails: Lists differ in TestGatherHudStats, TestHudAnchor, TestHudAnchorTools, TestPopulationROI, TestDetectResourceRegions)*

------
https://chatgpt.com/codex/tasks/task_e_68af8ea8842c8325bc63348f19f96cc2