### PR TITLE
Translate Portuguese log messages to English

### DIFF
--- a/campaign_bot.py
+++ b/campaign_bot.py
@@ -30,25 +30,25 @@ def main():
     screen_utils.init_sct()
     try:
         logger.info(
-            "Entre na missão da campanha (Hunting). O script inicia quando detectar a HUD…",
+            "Enter the campaign mission (Hunting). The script starts when the HUD is detected…",
         )
         try:
             anchor, asset = hud.wait_hud(timeout=90)
-            logger.info("HUD detectada em %s usando '%s'.", anchor, asset)
+            logger.info("HUD detected at %s using '%s'.", anchor, asset)
         except RuntimeError as e:
             logger.error(str(e))
-            logger.info("Dando mais 25s para você ajustar a câmera/HUD (fallback)…")
+            logger.info("Giving another 25s for you to adjust the camera/HUD (fallback)…")
             time.sleep(25)
             try:
                 anchor, asset = hud.wait_hud(timeout=90)
-                logger.info("HUD detectada em %s usando '%s'.", anchor, asset)
+                logger.info("HUD detected at %s using '%s'.", anchor, asset)
             except RuntimeError as e2:
                 logger.error(str(e2))
                 logger.warning(
-                    "HUD não detectada após tentativa extra; rotina continuará sem HUD ancorada."
+                    "HUD not detected after extra attempt; routine will continue without anchored HUD."
                 )
                 raise SystemExit(
-                    "HUD não detectada após duas tentativas; encerrando script."
+                    "HUD not detected after two attempts; exiting script."
                 )
 
         info = parse_scenario_info(args.scenario)
@@ -63,21 +63,21 @@ def main():
                 optional_icons=icon_cfg.get("optional"),
             )
             logger.info(
-                "Recursos detectados: madeira=%s, comida=%s, ouro=%s, pedra=%s",
+                "Detected resources: wood=%s, food=%s, gold=%s, stone=%s",
                 res.get("wood_stockpile"),
                 res.get("food_stockpile"),
                 res.get("gold_stockpile"),
                 res.get("stone_stockpile"),
             )
-            logger.info("População detectada: %s/%s", cur_pop, pop_cap)
+            logger.info("Detected population: %s/%s", cur_pop, pop_cap)
             logger.info(
-                "Aldeões ociosos detectados: %s", res.get("idle_villager")
+                "Detected idle villagers: %s", res.get("idle_villager")
             )
         except Exception as e:
-            logger.error("Falha ao detectar recursos ou população: %s", e)
-            raise SystemExit("Falha ao detectar recursos ou população")
+            logger.error("Failed to detect resources or population: %s", e)
+            raise SystemExit("Failed to detect resources or population")
 
-        logger.info("Setup concluído.")
+        logger.info("Setup complete.")
     finally:
         screen_utils.teardown_sct()
 

--- a/campaigns/Ascent_of_Egypt/1.Hunting.py
+++ b/campaigns/Ascent_of_Egypt/1.Hunting.py
@@ -34,17 +34,17 @@ def main() -> None:
         the target population is.
     """
 
-    logger.info("Entre na missão da campanha (Hunting). O script inicia quando detectar a HUD…")
+    logger.info("Enter the campaign mission (Hunting). The script starts when the HUD is detected…")
 
     try:
         anchor, asset = hud.wait_hud(timeout=90)
-        logger.info("HUD detectada em %s usando '%s'.", anchor, asset)
+        logger.info("HUD detected at %s using '%s'.", anchor, asset)
     except RuntimeError as exc:  # pragma: no cover - retry branch is defensive
         logger.error(str(exc))
-        logger.info("Dando mais 25s para você ajustar a câmera/HUD (fallback)…")
+        logger.info("Giving another 25s for you to adjust the camera/HUD (fallback)…")
         time.sleep(25)
         anchor, asset = hud.wait_hud(timeout=90)
-        logger.info("HUD detectada em %s usando '%s'.", anchor, asset)
+        logger.info("HUD detected at %s using '%s'.", anchor, asset)
 
     scenario_txt = Path(__file__).with_suffix(".txt")
     info = parse_scenario_info(scenario_txt)
@@ -54,7 +54,7 @@ def main() -> None:
     common.POP_CAP = 4  # População suportada pelo Town Center inicial
     common.TARGET_POP = info.objective_villagers
 
-    logger.info("Setup concluído.")
+    logger.info("Setup complete.")
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution entry point

--- a/script/buldings/town_center.py
+++ b/script/buldings/town_center.py
@@ -49,7 +49,7 @@ def train_villagers(target_pop: int):
             break
         if food < 50:
             logger.info(
-                "Comida insuficiente (%s) para treinar aldeões.",
+                "Insufficient food (%s) to train villagers.",
                 food,
             )
             break
@@ -58,11 +58,11 @@ def train_villagers(target_pop: int):
         if common.CURRENT_POP == common.POP_CAP:
             if select_idle_villager():
                 if build_house():
-                    logger.info("Casa construída para expandir população")
+                    logger.info("House built to increase population")
                 else:
-                    logger.warning("Falha ao construir casa para expandir população")
+                    logger.warning("Failed to build house to increase population")
             else:
-                logger.warning("Nenhum aldeão ocioso para construir casa")
+                logger.warning("No idle villager to build house")
             # Reselect the Town Center after attempting to build a house so
             # that further villager training continues from the correct
             # building.

--- a/script/hud.py
+++ b/script/hud.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 def wait_hud(timeout=60):
-    logger.info("Aguardando HUD por até %ss...", timeout)
+    logger.info("Waiting for HUD for up to %ss...", timeout)
     t0 = time.time()
     tmpl = screen_utils.HUD_TEMPLATE
     asset = "assets/resources.png"
@@ -41,7 +41,7 @@ def wait_hud(timeout=60):
             if CFG["debug"]:
                 cv2.imwrite(f"debug_hud_{asset}.png", frame)
             x, y, w, h = box
-            logger.info("HUD detectada com template '%s'", asset)
+            logger.info("HUD detected with template '%s'", asset)
             common.HUD_ANCHOR = {
                 "left": x,
                 "top": y,
@@ -60,14 +60,14 @@ def wait_hud(timeout=60):
         asset,
     )
     logger.error(
-        "HUD não encontrada. Melhor score=%.3f no template '%s'. "
-        "Considere recapturar templates de ícones ou verificar a resolução/ESCALA 100%%.",
+        "HUD not found. Best score=%.3f on template '%s'. "
+        "Consider recapturing icon templates or checking resolution/SCALING 100%%.",
         last_score,
         asset,
     )
     raise RuntimeError(
-        f"HUD não encontrada. Melhor score={last_score:.3f} no template '{asset}'. "
-        "Considere recapturar os templates de ícones ou verificar a resolução/ESCALA 100%.",
+        f"HUD not found. Best score={last_score:.3f} on template '{asset}'. "
+        "Consider recapturing icon templates or checking resolution/SCALING 100%.",
     )
 
 
@@ -113,7 +113,7 @@ def read_population_from_hud(retries=1, conf_threshold=None, save_failed_roi=Fal
                 "Population ROI out of screen bounds: "
                 f"left={abs_left}, top={abs_top}, width={pw}, height={ph}, "
                 f"screen={screen_width}x{screen_height}. "
-                "Recalibrate areas.pop_box em config.json ou use a âncora por template."
+                "Recalibrate areas.pop_box in config.json or use template anchoring."
             )
         roi_bbox = {"left": abs_left, "top": abs_top, "width": pw, "height": ph}
 
@@ -155,7 +155,7 @@ def read_population_from_hud(retries=1, conf_threshold=None, save_failed_roi=Fal
         time.sleep(0.1)
 
     logger.warning(
-        "Falha ao ler população da HUD após %s tentativas; último texto='%s', conf=%s",
+        "Failed to read population from HUD after %s attempts; last text='%s', conf=%s",
         retries,
         last_text,
         last_confidences,
@@ -165,23 +165,23 @@ def read_population_from_hud(retries=1, conf_threshold=None, save_failed_roi=Fal
         cv2.imwrite(str(ROOT / f"debug_pop_roi_{ts}.png"), last_roi)
         cv2.imwrite(str(ROOT / f"debug_pop_thresh_{ts}.png"), last_thresh)
         logger.info(
-            "ROI salva; texto extraído: '%s'; conf=%s",
+            "ROI saved; extracted text: '%s'; conf=%s",
             last_text,
             last_confidences,
         )
     logger.info(
-        "Acionando fallback para leitura de população via resources.read_resources_from_hud"
+        "Triggering fallback to read population via resources.read_resources_from_hud"
     )
     try:
         _, (cur, limit) = resources.read_resources_from_hud(
             ["population_limit"], force_delay=0.1, conf_threshold=conf_threshold
         )
         if cur is not None and limit is not None:
-            logger.info("Fallback de população bem-sucedido: %s/%s", cur, limit)
+            logger.info("Population fallback succeeded: %s/%s", cur, limit)
             return cur, limit
     except Exception as exc:  # pragma: no cover - log but ignore any failure
-        logger.debug("Fallback falhou: %s", exc)
+        logger.debug("Fallback failed: %s", exc)
 
     raise common.PopulationReadError(
-        f"Falha ao ler população da HUD após {retries} tentativas. Texto='{last_text}', confs={last_confidences}"
+        f"Failed to read population from HUD after {retries} attempts. Text='{last_text}', confs={last_confidences}"
     )

--- a/script/resources.py
+++ b/script/resources.py
@@ -207,7 +207,7 @@ def compute_resource_rois(
             width = available_width
             narrow[current] = True
             logger.warning(
-                "ROI estreita para '%s': disp=%d min=%d",
+                "Narrow ROI for '%s': available=%d min=%d",
                 current,
                 available_width,
                 min_w,
@@ -626,7 +626,7 @@ def detect_resource_regions(frame, required_icons):
                 max(20, height),
             )
             logger.debug(
-                "Custom ROI aplicada para idle_villager: %s", regions["idle_villager"]
+                "Custom ROI applied for idle_villager: %s", regions["idle_villager"]
             )
     custom_names = [
         "wood_stockpile",
@@ -645,7 +645,7 @@ def detect_resource_regions(frame, required_icons):
         width = int(cfg.get("width_pct", 0) * W)
         height = int(cfg.get("height_pct", 0) * H)
         regions[name] = (left, top, width, height)
-        logger.debug("Custom ROI aplicada para %s: %s", name, regions[name])
+        logger.debug("Custom ROI applied for %s: %s", name, regions[name])
     missing = [name for name in required_icons if name not in regions]
 
     if missing:
@@ -1207,7 +1207,7 @@ def _read_population_from_roi(roi, conf_threshold=None):
     cv2.imwrite(str(debug_dir / f"population_roi_{ts}.png"), roi)
     cv2.imwrite(str(debug_dir / f"population_thresh_{ts}.png"), thresh)
     raise common.PopulationReadError(
-        f"Falha ao ler população da HUD: texto='{text}', confs={confidences}"
+        f"Failed to read population from HUD: text='{text}', confs={confidences}"
     )
 
 

--- a/script/screen_utils.py
+++ b/script/screen_utils.py
@@ -69,7 +69,7 @@ def _grab_frame(bbox=None):
 def _load_gray(path):
     im = cv2.imread(str(path), cv2.IMREAD_GRAYSCALE)
     if im is None:
-        logger.warning("Asset não encontrado: %s", path)
+        logger.warning("Asset not found: %s", path)
         return None
     return im
 

--- a/script/units/villager.py
+++ b/script/units/villager.py
@@ -22,7 +22,7 @@ def select_idle_villager(delay: float = 0.1) -> bool:
     try:
         res_before, _ = resources.read_resources_from_hud(["idle_villager"])
     except common.ResourceReadError as exc:  # pragma: no cover - falha de OCR
-        logger.error("Falha ao ler idle_villager: %s", exc)
+        logger.error("Failed to read idle_villager: %s", exc)
     else:
         before = res_before.get("idle_villager")
 
@@ -34,7 +34,7 @@ def select_idle_villager(delay: float = 0.1) -> bool:
             ["idle_villager"], force_delay=delay
         )
     except common.ResourceReadError as exc:  # pragma: no cover - falha de OCR
-        logger.error("Falha ao ler idle_villager: %s", exc)
+        logger.error("Failed to read idle_villager: %s", exc)
     else:
         after = res_after.get("idle_villager")
 
@@ -76,7 +76,7 @@ def count_idle_villagers_via_hotkey(
     try:
         res, _ = resources.read_resources_from_hud(["idle_villager"])
     except common.ResourceReadError as exc:  # pragma: no cover - falha de OCR
-        logger.error("Falha ao ler idle_villager: %s", exc)
+        logger.error("Failed to read idle_villager: %s", exc)
         initial = 0
     else:
         initial = res.get("idle_villager")
@@ -94,7 +94,7 @@ def count_idle_villagers_via_hotkey(
                 ["idle_villager"], force_delay=delay
             )
         except common.ResourceReadError as exc:  # pragma: no cover - falha de OCR
-            logger.error("Falha ao ler idle_villager: %s", exc)
+            logger.error("Failed to read idle_villager: %s", exc)
             break
         new_val = res.get("idle_villager")
         if (
@@ -167,14 +167,14 @@ def build_house():
             return False
     if wood < wood_needed:
         logger.warning(
-            "Madeira insuficiente (%s) para construir casa.",
+            "Insufficient wood (%s) to build house.",
             wood,
         )
         return False
 
     house_key = common.CFG["keys"].get("house")
     if not house_key:
-        logger.warning("Tecla de construção de casa não configurada.")
+        logger.warning("House build key not configured.")
         return False
 
     areas = common.CFG.get("areas", {})
@@ -197,14 +197,14 @@ def build_house():
         try:
             cur, limit = hud.read_population_from_hud()
         except Exception as exc:  # pragma: no cover - falha de OCR
-            logger.warning("Falha ao ler população: %s", exc)
+            logger.warning("Failed to read population: %s", exc)
             limit = common.POP_CAP
 
         if limit > common.POP_CAP:
             common.POP_CAP = limit
             return True
 
-        logger.warning("Tentativa %s de construir casa falhou.", idx)
+        logger.warning("Attempt %s to build house failed.", idx)
         try:
             res_vals, _ = resources.read_resources_from_hud(["wood_stockpile"])
         except common.ResourceReadError as exc:
@@ -218,7 +218,7 @@ def build_house():
             return False
         if wood < wood_needed:
             logger.warning(
-                "Madeira insuficiente após tentativa (%s).", wood
+                "Insufficient wood after attempt (%s).", wood
             )
             break
 
@@ -230,7 +230,7 @@ def build_granary():
     input_utils._press_key_safe(common.CFG["keys"]["build_menu"], 0.05)
     g_key = common.CFG["keys"].get("granary")
     if not g_key:
-        logger.warning("Tecla de construção de Granary não configurada.")
+        logger.warning("Granary build key not configured.")
         return False
     areas = common.CFG.get("areas", {})
     spot = areas.get("granary_spot")
@@ -248,7 +248,7 @@ def build_storage_pit():
     input_utils._press_key_safe(common.CFG["keys"]["build_menu"], 0.05)
     s_key = common.CFG["keys"].get("storage_pit")
     if not s_key:
-        logger.warning("Tecla de construção de Storage Pit não configurada.")
+        logger.warning("Storage Pit build key not configured.")
         return False
     areas = common.CFG.get("areas", {})
     spot = areas.get("storage_spot")


### PR DESCRIPTION
## Summary
- Translate resource logging to report "Narrow ROI" and other messages in English
- Replace Portuguese HUD and campaign log strings with English equivalents
- Update villager and building logs for wood and population handling

## Testing
- `pytest` *(fails: ResourceReadError not raised and other assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68afad296014832593eb96d943033ede