### PR TITLE
Refactor resource caching into centralized class

### DIFF
--- a/tests/test_gather_hud_stats.py
+++ b/tests/test_gather_hud_stats.py
@@ -10,9 +10,9 @@ import tools.campaign_bot as cb
 class TestGatherHudStats(TestCase):
     def setUp(self):
         # Clear caches in resources module used by campaign bot
-        cb.resources._LAST_RESOURCE_VALUES.clear()
-        cb.resources._LAST_RESOURCE_TS.clear()
-        cb.resources._RESOURCE_FAILURE_COUNTS.clear()
+        cb.resources.RESOURCE_CACHE.last_resource_values.clear()
+        cb.resources.RESOURCE_CACHE.last_resource_ts.clear()
+        cb.resources.RESOURCE_CACHE.resource_failure_counts.clear()
 
     def test_gather_reads_resources_and_population(self):
         anchor = {"left": 10, "top": 20, "width": 600, "height": 60, "asset": "assets/resources.png"}

--- a/tests/test_hud_anchor.py
+++ b/tests/test_hud_anchor.py
@@ -42,9 +42,9 @@ ASSET = "assets/resources.png"
 
 class TestHudAnchor(TestCase):
     def setUp(self):
-        resources._LAST_RESOURCE_VALUES.clear()
-        resources._LAST_RESOURCE_TS.clear()
-        resources._RESOURCE_FAILURE_COUNTS.clear()
+        resources.RESOURCE_CACHE.last_resource_values.clear()
+        resources.RESOURCE_CACHE.last_resource_ts.clear()
+        resources.RESOURCE_CACHE.resource_failure_counts.clear()
 
     def test_wait_hud_sets_asset(self):
         common.HUD_ANCHOR = None

--- a/tests/test_idle_villager_ocr.py
+++ b/tests/test_idle_villager_ocr.py
@@ -37,12 +37,12 @@ import script.resources as resources
 
 class TestIdleVillagerOCR(TestCase):
     def setUp(self):
-        resources._LAST_RESOURCE_VALUES.clear()
-        resources._LAST_RESOURCE_TS.clear()
-        resources._RESOURCE_FAILURE_COUNTS.clear()
+        resources.RESOURCE_CACHE.last_resource_values.clear()
+        resources.RESOURCE_CACHE.last_resource_ts.clear()
+        resources.RESOURCE_CACHE.resource_failure_counts.clear()
 
     def test_idle_villager_uses_digit_only_tesseract(self):
-        def fake_detect(frame, required_icons):
+        def fake_detect(frame, required_icons, cache=None):
             return {"idle_villager": (0, 0, 50, 50)}
 
         frame = np.zeros((100, 100, 3), dtype=np.uint8)

--- a/tests/test_resource_debug_images.py
+++ b/tests/test_resource_debug_images.py
@@ -38,9 +38,9 @@ import script.resources as resources
 
 class TestResourceDebugImages(TestCase):
     def setUp(self):
-        resources._LAST_RESOURCE_VALUES.clear()
-        resources._LAST_RESOURCE_TS.clear()
-        resources._RESOURCE_FAILURE_COUNTS.clear()
+        resources.RESOURCE_CACHE.last_resource_values.clear()
+        resources.RESOURCE_CACHE.last_resource_ts.clear()
+        resources.RESOURCE_CACHE.resource_failure_counts.clear()
 
     def test_debug_images_written_when_all_none_and_debug_off(self):
         common.CFG["debug"] = False
@@ -102,9 +102,9 @@ class TestResourceDebugImages(TestCase):
                 np.zeros((1, 1), dtype=np.uint8),
             )
 
-        resources._LAST_RESOURCE_VALUES.clear()
-        resources._LAST_RESOURCE_TS.clear()
-        resources._RESOURCE_FAILURE_COUNTS.clear()
+        resources.RESOURCE_CACHE.last_resource_values.clear()
+        resources.RESOURCE_CACHE.last_resource_ts.clear()
+        resources.RESOURCE_CACHE.resource_failure_counts.clear()
         with patch("script.screen_utils._grab_frame", side_effect=fake_grab_frame), \
              patch(
                  "script.resources.locate_resource_panel",

--- a/tests/test_resource_force_delay.py
+++ b/tests/test_resource_force_delay.py
@@ -35,9 +35,9 @@ import script.resources as resources
 
 class TestResourceForceDelay(TestCase):
     def setUp(self):
-        resources._LAST_RESOURCE_VALUES.clear()
-        resources._LAST_RESOURCE_TS.clear()
-        resources._RESOURCE_FAILURE_COUNTS.clear()
+        resources.RESOURCE_CACHE.last_resource_values.clear()
+        resources.RESOURCE_CACHE.last_resource_ts.clear()
+        resources.RESOURCE_CACHE.resource_failure_counts.clear()
 
     def test_force_delay_waits_before_grab(self):
         calls = []

--- a/tests/test_resource_ocr_failure.py
+++ b/tests/test_resource_ocr_failure.py
@@ -65,15 +65,15 @@ import script.resources as resources
 
 class TestResourceOcrFailure(TestCase):
     def setUp(self):
-        resources._LAST_RESOURCE_VALUES.clear()
-        resources._LAST_RESOURCE_TS.clear()
-        resources._RESOURCE_FAILURE_COUNTS.clear()
+        resources.RESOURCE_CACHE.last_resource_values.clear()
+        resources.RESOURCE_CACHE.last_resource_ts.clear()
+        resources.RESOURCE_CACHE.resource_failure_counts.clear()
         resources._LAST_REGION_SPANS.clear()
 
     def tearDown(self):
-        resources._LAST_RESOURCE_VALUES.clear()
-        resources._LAST_RESOURCE_TS.clear()
-        resources._RESOURCE_FAILURE_COUNTS.clear()
+        resources.RESOURCE_CACHE.last_resource_values.clear()
+        resources.RESOURCE_CACHE.last_resource_ts.clear()
+        resources.RESOURCE_CACHE.resource_failure_counts.clear()
         resources._LAST_REGION_SPANS.clear()
     def test_read_resources_fallback(self):
         def fake_ocr(gray):
@@ -106,7 +106,7 @@ class TestResourceOcrFailure(TestCase):
                 return np.zeros((bbox["height"], bbox["width"], 3), dtype=np.uint8)
             return np.zeros((600, 600, 3), dtype=np.uint8)
 
-        def fake_detect(frame, required_icons):
+        def fake_detect(frame, required_icons, cache=None):
             return {
                 "wood_stockpile": (0, 0, 50, 50),
                 "food_stockpile": (50, 0, 50, 50),
@@ -135,7 +135,7 @@ class TestResourceOcrFailure(TestCase):
                 return np.zeros((bbox["height"], bbox["width"], 3), dtype=np.uint8)
             return np.zeros((600, 600, 3), dtype=np.uint8)
 
-        def fake_detect(frame, required_icons):
+        def fake_detect(frame, required_icons, cache=None):
             return {"wood_stockpile": (0, 0, 50, 50)}
 
         def fake_ocr(gray):
@@ -157,7 +157,7 @@ class TestResourceOcrFailure(TestCase):
                 return np.zeros((bbox["height"], bbox["width"], 3), dtype=np.uint8)
             return np.zeros((600, 600, 3), dtype=np.uint8)
 
-        def fake_detect(frame, required_icons):
+        def fake_detect(frame, required_icons, cache=None):
             return {"wood_stockpile": (0, 0, 50, 50)}
 
         def fake_ocr(gray):
@@ -174,7 +174,7 @@ class TestResourceOcrFailure(TestCase):
         self.assertGreaterEqual(img2str_mock.call_count, 1)
 
     def test_cached_value_used_for_optional_failure(self):
-        def fake_detect(frame, required_icons):
+        def fake_detect(frame, required_icons, cache=None):
             return {
                 "wood_stockpile": (0, 0, 50, 50),
                 "food_stockpile": (50, 0, 50, 50),
@@ -216,22 +216,22 @@ class TestResourceOcrFailure(TestCase):
 
 class TestGatherHudStatsSliding(TestCase):
     def setUp(self):
-        resources._LAST_RESOURCE_VALUES.clear()
-        resources._LAST_RESOURCE_TS.clear()
-        resources._RESOURCE_FAILURE_COUNTS.clear()
+        resources.RESOURCE_CACHE.last_resource_values.clear()
+        resources.RESOURCE_CACHE.last_resource_ts.clear()
+        resources.RESOURCE_CACHE.resource_failure_counts.clear()
         resources._LAST_REGION_SPANS.clear()
 
     def tearDown(self):
-        resources._LAST_RESOURCE_VALUES.clear()
-        resources._LAST_RESOURCE_TS.clear()
-        resources._RESOURCE_FAILURE_COUNTS.clear()
+        resources.RESOURCE_CACHE.last_resource_values.clear()
+        resources.RESOURCE_CACHE.last_resource_ts.clear()
+        resources.RESOURCE_CACHE.resource_failure_counts.clear()
         resources._LAST_REGION_SPANS.clear()
 
     def test_gather_hud_stats_succeeds_after_sliding(self):
         frame = np.tile(np.arange(120, dtype=np.uint8), (20, 1))
         frame = np.stack([frame] * 3, axis=-1)
 
-        def fake_detect(frame_in, required_icons):
+        def fake_detect(frame_in, required_icons, cache=None):
             return {"wood_stockpile": (10, 0, 50, 20)}
 
         calls = []
@@ -272,14 +272,14 @@ class TestGatherHudStatsSliding(TestCase):
 
 class TestResourceOcrRois(TestCase):
     def setUp(self):
-        resources._LAST_RESOURCE_VALUES.clear()
-        resources._LAST_RESOURCE_TS.clear()
-        resources._RESOURCE_FAILURE_COUNTS.clear()
+        resources.RESOURCE_CACHE.last_resource_values.clear()
+        resources.RESOURCE_CACHE.last_resource_ts.clear()
+        resources.RESOURCE_CACHE.resource_failure_counts.clear()
 
     def tearDown(self):
-        resources._LAST_RESOURCE_VALUES.clear()
-        resources._LAST_RESOURCE_TS.clear()
-        resources._RESOURCE_FAILURE_COUNTS.clear()
+        resources.RESOURCE_CACHE.last_resource_values.clear()
+        resources.RESOURCE_CACHE.last_resource_ts.clear()
+        resources.RESOURCE_CACHE.resource_failure_counts.clear()
 
     def _build_frame(self):
         icons = [
@@ -337,7 +337,7 @@ class TestResourceOcrRois(TestCase):
             "population_limit",
         ]
 
-        def fake_detect(frame_in, required_icons):
+        def fake_detect(frame_in, required_icons, cache=None):
             return regions
 
         def fake_preprocess(roi):

--- a/tests/test_resource_read_retry.py
+++ b/tests/test_resource_read_retry.py
@@ -58,21 +58,21 @@ import script.resources as resources
 
 class TestResourceReadRetry(TestCase):
     def setUp(self):
-        resources._LAST_RESOURCE_VALUES.clear()
-        resources._LAST_RESOURCE_TS.clear()
+        resources.RESOURCE_CACHE.last_resource_values.clear()
+        resources.RESOURCE_CACHE.last_resource_ts.clear()
         resources._LAST_READ_FROM_CACHE.clear()
-        resources._RESOURCE_FAILURE_COUNTS.clear()
+        resources.RESOURCE_CACHE.resource_failure_counts.clear()
         resources._LAST_REGION_SPANS.clear()
 
     def tearDown(self):
-        resources._LAST_RESOURCE_VALUES.clear()
-        resources._LAST_RESOURCE_TS.clear()
+        resources.RESOURCE_CACHE.last_resource_values.clear()
+        resources.RESOURCE_CACHE.last_resource_ts.clear()
         resources._LAST_READ_FROM_CACHE.clear()
-        resources._RESOURCE_FAILURE_COUNTS.clear()
+        resources.RESOURCE_CACHE.resource_failure_counts.clear()
         resources._LAST_REGION_SPANS.clear()
 
     def test_required_icon_fallback(self):
-        def fake_detect(frame, required_icons):
+        def fake_detect(frame, required_icons, cache=None):
             return {"wood_stockpile": (0, 0, 50, 50)}
 
         ocr_seq = [
@@ -104,7 +104,7 @@ class TestResourceReadRetry(TestCase):
         self.assertIn("wood_stockpile", resources._LAST_READ_FROM_CACHE)
 
     def test_retry_succeeds_after_expansion(self):
-        def fake_detect(frame, required_icons):
+        def fake_detect(frame, required_icons, cache=None):
             return {"wood_stockpile": (0, 0, 50, 50)}
 
         ocr_seq = [
@@ -128,7 +128,7 @@ class TestResourceReadRetry(TestCase):
         self.assertEqual(ocr_mock.call_count, 2)
 
     def test_sliding_window_succeeds_when_anchor_right(self):
-        def fake_detect(frame, required_icons):
+        def fake_detect(frame, required_icons, cache=None):
             return {"wood_stockpile": (10, 0, 50, 20)}
 
         frame = np.tile(np.arange(120, dtype=np.uint8), (20, 1))
@@ -159,7 +159,7 @@ class TestResourceReadRetry(TestCase):
         self.assertEqual([a for _, _, a in calls], [True, False, False, False])
 
     def test_expired_cache_used_after_consecutive_failures(self):
-        def fake_detect(frame, required_icons):
+        def fake_detect(frame, required_icons, cache=None):
             return {"wood_stockpile": (0, 0, 50, 50)}
 
         def fake_ocr(gray):
@@ -167,8 +167,8 @@ class TestResourceReadRetry(TestCase):
 
         frame = np.zeros((600, 600, 3), dtype=np.uint8)
 
-        resources._LAST_RESOURCE_VALUES["wood_stockpile"] = 999
-        resources._LAST_RESOURCE_TS["wood_stockpile"] = (
+        resources.RESOURCE_CACHE.last_resource_values["wood_stockpile"] = 999
+        resources.RESOURCE_CACHE.last_resource_ts["wood_stockpile"] = (
             time.time() - (resources._RESOURCE_CACHE_TTL + 10)
         )
 

--- a/tests/test_resource_rois.py
+++ b/tests/test_resource_rois.py
@@ -494,24 +494,24 @@ class TestResourceROIs(TestCase):
         self.assertEqual(result, {"wood_stockpile"})
 
     def test_cache_cleared_on_region_change(self):
-        resources._LAST_ICON_BOUNDS.clear()
+        resources.RESOURCE_CACHE.last_icon_bounds.clear()
         resources._LAST_REGION_BOUNDS = None
-        resources._LAST_RESOURCE_VALUES.clear()
-        resources._LAST_RESOURCE_TS.clear()
+        resources.RESOURCE_CACHE.last_resource_values.clear()
+        resources.RESOURCE_CACHE.last_resource_ts.clear()
 
         self.positions = [0, 30, 60, 90, 120, 150]
         self._locate_regions()
 
-        resources._LAST_RESOURCE_VALUES["wood_stockpile"] = 111
-        resources._LAST_RESOURCE_TS["wood_stockpile"] = 1.0
-        self.assertTrue(resources._LAST_RESOURCE_VALUES)
-        self.assertTrue(resources._LAST_RESOURCE_TS)
+        resources.RESOURCE_CACHE.last_resource_values["wood_stockpile"] = 111
+        resources.RESOURCE_CACHE.last_resource_ts["wood_stockpile"] = 1.0
+        self.assertTrue(resources.RESOURCE_CACHE.last_resource_values)
+        self.assertTrue(resources.RESOURCE_CACHE.last_resource_ts)
 
         self.positions = [5, 35, 65, 95, 125, 155]
         self._locate_regions()
 
-        self.assertEqual(resources._LAST_RESOURCE_VALUES, {})
-        self.assertEqual(resources._LAST_RESOURCE_TS, {})
+        self.assertEqual(resources.RESOURCE_CACHE.last_resource_values, {})
+        self.assertEqual(resources.RESOURCE_CACHE.last_resource_ts, {})
 
     def test_detect_regions_scales_with_resolution(self):
         """Auto-calibrated ROIs should scale with the screen resolution."""


### PR DESCRIPTION
## Summary
- Introduce `ResourceCache` dataclass for icon bounds, resource values, timestamps, and failure counts
- Update resource reading functions to use a cache instance
- Adjust tests to clear and use the shared cache

## Testing
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tess_9wfjv0km.txt')*


------
https://chatgpt.com/codex/tasks/task_e_68afafbcf794832588c5f1b4ca45a30e