### PR TITLE
Support optional HUD icons per scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,31 @@ cannot be detected or read. Icons listed under `optional` are attempted but do
 not stop execution if they are missing. Adjust these lists to match the
 resources shown in your game profile.
 
+Campaign missions can override these lists either under `profiles` in
+`config.json` or directly when invoking `gather_hud_stats` from a scenario:
+
+```json
+"profiles": {
+  "tutorial": {
+    "hud_icons": {
+      "required": ["wood_stockpile", "food_stockpile"],
+      "optional": ["idle_villager"]
+    }
+  }
+}
+```
+
+```python
+# inside a scenario module
+res, pop = cb.gather_hud_stats(
+    required_icons=["wood_stockpile", "food_stockpile"],
+    optional_icons=["idle_villager"],
+)
+```
+
+When neither list is supplied, `gather_hud_stats` detects which icons are
+present and automatically treats missing ones as optional.
+
 ### Manual ROI overrides
 
 Automatic ROI detection may fail on unusual HUD layouts. Optional sections in

--- a/script/resources.py
+++ b/script/resources.py
@@ -1240,6 +1240,7 @@ def gather_hud_stats(
     frame = screen_utils._grab_frame()
 
     icon_cfg = CFG.get("hud_icons", {})
+    provided_lists = not (required_icons is None and optional_icons is None)
     if required_icons is None:
         required_icons = icon_cfg.get(
             "required",
@@ -1258,6 +1259,11 @@ def gather_hud_stats(
     required_icons = list(required_icons)
     optional_icons = list(optional_icons)
     all_icons = list(dict.fromkeys(required_icons + optional_icons))
+
+    if not provided_lists:
+        regions = detect_resource_regions(frame, all_icons, cache)
+        required_icons = [n for n in required_icons if n in regions]
+        all_icons = list(regions.keys())
 
     return _read_resources(
         frame,

--- a/tests/test_gather_hud_stats.py
+++ b/tests/test_gather_hud_stats.py
@@ -3,6 +3,47 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import numpy as np
+import os
+import sys
+
+dummy_pg = types.SimpleNamespace(
+    PAUSE=0,
+    FAILSAFE=False,
+    size=lambda: (200, 200),
+    click=lambda *a, **k: None,
+    moveTo=lambda *a, **k: None,
+    press=lambda *a, **k: None,
+)
+
+
+class DummyMSS:
+    monitors = [{}, {"left": 0, "top": 0, "width": 200, "height": 200}]
+
+    def grab(self, region):
+        h, w = region["height"], region["width"]
+        return np.zeros((h, w, 4), dtype=np.uint8)
+
+
+sys.modules.setdefault("pyautogui", dummy_pg)
+sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
+sys.modules.setdefault(
+    "cv2",
+    types.SimpleNamespace(
+        cvtColor=lambda src, code: src,
+        resize=lambda img, *a, **k: img,
+        matchTemplate=lambda *a, **k: np.zeros((1, 1), dtype=np.float32),
+        minMaxLoc=lambda *a, **k: (0, 0, (0, 0), (0, 0)),
+        imread=lambda *a, **k: np.zeros((1, 1), dtype=np.uint8),
+        imwrite=lambda *a, **k: True,
+        medianBlur=lambda src, k: src,
+        bitwise_not=lambda src: src,
+        threshold=lambda src, *a, **k: (None, src),
+        rectangle=lambda img, pt1, pt2, color, thickness: img,
+        IMREAD_GRAYSCALE=0,
+        COLOR_BGR2GRAY=0,
+    ),
+)
+os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 import tools.campaign_bot as cb
 
@@ -39,7 +80,16 @@ class TestGatherHudStats(TestCase):
         with patch("tools.campaign_bot.locate_resource_panel", return_value={}), \
              patch("tools.campaign_bot._grab_frame", side_effect=fake_grab_frame), \
              patch("tools.campaign_bot._ocr_digits_better", side_effect=fake_ocr), \
-             patch("tools.campaign_bot._read_population_from_roi", side_effect=fake_pop):
+             patch("tools.campaign_bot._read_population_from_roi", side_effect=fake_pop), \
+             patch("tools.campaign_bot.resources.detect_resource_regions", return_value={
+                 "wood_stockpile": (0, 0, 90, 52),
+                 "food_stockpile": (90, 0, 90, 52),
+                 "gold_stockpile": (180, 0, 90, 52),
+                 "stone_stockpile": (270, 0, 90, 52),
+                 "population_limit": (360, 0, 90, 52),
+                 "idle_villager": (450, 0, 98, 52),
+             }), \
+             patch("tools.campaign_bot.resources.pytesseract.image_to_string", return_value="600"):
             res, pop = cb.gather_hud_stats()
 
         expected_res = {
@@ -52,7 +102,60 @@ class TestGatherHudStats(TestCase):
         }
         self.assertEqual(res, expected_res)
         self.assertEqual(pop, (123, 200))
-        expected_shapes = [(52, 90), (52, 90), (52, 90), (52, 90), (52, 98)]
+        expected_shapes = [(52, 90), (52, 90), (52, 90), (52, 90)]
         self.assertEqual(roi_shapes, expected_shapes)
         self.assertEqual(pop_shapes, [(52, 90)])
         self.assertEqual(grab_calls, [None])
+
+    def test_missing_icons_become_optional(self):
+        anchor = {"left": 10, "top": 20, "width": 600, "height": 60, "asset": "assets/resources.png"}
+        cb.HUD_ANCHOR = anchor.copy()
+
+        digits_iter = iter(["100", "200"])
+
+        def fake_grab_frame(bbox=None):
+            return np.zeros((200, 800, 3), dtype=np.uint8)
+
+        def fake_ocr(gray):
+            d = next(digits_iter)
+            return d, {"text": [d]}
+
+        with patch("tools.campaign_bot.locate_resource_panel", return_value={}), \
+             patch("tools.campaign_bot._grab_frame", side_effect=fake_grab_frame), \
+             patch("tools.campaign_bot._ocr_digits_better", side_effect=fake_ocr), \
+             patch(
+                 "tools.campaign_bot.resources.detect_resource_regions",
+                 return_value={
+                     "wood_stockpile": (0, 0, 50, 50),
+                     "food_stockpile": (50, 0, 50, 50),
+                 },
+             ):
+            res, pop = cb.gather_hud_stats()
+
+        self.assertEqual(res, {"wood_stockpile": 100, "food_stockpile": 200})
+        self.assertEqual(pop, (None, None))
+
+    def test_scenario_defined_icons(self):
+        anchor = {"left": 10, "top": 20, "width": 600, "height": 60, "asset": "assets/resources.png"}
+        cb.HUD_ANCHOR = anchor.copy()
+
+        def fake_grab_frame(bbox=None):
+            return np.zeros((200, 800, 3), dtype=np.uint8)
+
+        def fake_ocr(gray):
+            return "100", {"text": ["100"]}
+
+        with patch("tools.campaign_bot.locate_resource_panel", return_value={}), \
+             patch("tools.campaign_bot._grab_frame", side_effect=fake_grab_frame), \
+             patch("tools.campaign_bot._ocr_digits_better", side_effect=fake_ocr), \
+             patch(
+                 "tools.campaign_bot.resources.detect_resource_regions",
+                 return_value={"wood_stockpile": (0, 0, 50, 50)},
+             ):
+            res, pop = cb.gather_hud_stats(
+                required_icons=["wood_stockpile"],
+                optional_icons=["food_stockpile"],
+            )
+
+        self.assertEqual(res, {"wood_stockpile": 100})
+        self.assertEqual(pop, (None, None))


### PR DESCRIPTION
## Summary
- allow `gather_hud_stats` to auto-drop HUD icons not detected on screen
- document and test defining required/optional icons for individual scenarios

## Testing
- `PYTHONPATH=. pytest tests/test_gather_hud_stats.py -q`
- `PYTHONPATH=. pytest -q` *(fails: Lists differ and cv2 errors in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68afb286271c832592964aeadd9e177f