### PR TITLE
Improve digit OCR robustness

### DIFF
--- a/config.json
+++ b/config.json
@@ -11,6 +11,7 @@
   "//ocr_conf_threshold": "Minimum OCR confidence (0-100); default 60. Tight ROIs may require 45-50.",
   "ocr_kernel_size": 1,
   "ocr_psm_list": [7],
+  "ocr_zero_variance": 15,
   "tesseract_path": "C:\\Program Files\\Tesseract-OCR\\tesseract.exe",
   "resource_cache_ttl": 1.5,
   "resource_cache_max_age": null,
@@ -26,16 +27,16 @@
     "resource_panel": {
         "match_threshold": 0.8,
         "scales": [0.9, 0.95, 1.0, 1.05, 1.1],
-        "roi_padding_left": [0,0,0,0,0,0],
-        "roi_padding_right": [0,0,0,0,0,0],
-        "max_width": 999,
-        "min_width": [1, 1, 1, 1, 1, 1],
+        "roi_padding_left": [0, 0, 0, 0, 0, 0],
+        "roi_padding_right": [0, 0, 0, 0, 0, 0],
+        "max_width": 160,
+        "min_width": [5, 5, 5, 5, 5, 4],
         "min_required_width": 0,
         "idle_roi_extra_width": 24,
-        "top_pct": 0.20,
-        "height_pct": 0.60,
-        "icon_trim_pct": [0,0,0,0,0,0],
-        "right_trim_pct": 0.00,
+        "top_pct": 0.06,
+        "height_pct": 0.88,
+        "icon_trim_pct": [0.25, 0.25, 0.25, 0.25, 0.20, 0.00],
+        "right_trim_pct": 0.02,
         "debug_failed_ocr": true
       },
   "hud_icons": {
@@ -49,40 +50,40 @@
     ],
     "optional": []
   },
-  "wood_stockpile_roi": {
-    "top_pct": 0.112,
-    "height_pct": 0.025,
-    "left_pct": 0.186,
-    "width_pct": 0.03
-  },
-  "food_stockpile_roi": {
-    "top_pct": 0.112,
-    "height_pct": 0.025,
-    "left_pct": 0.233,
-    "width_pct": 0.03
-  },
-  "gold_stockpile_roi": {
-    "top_pct": 0.112,
-    "height_pct": 0.025,
-    "left_pct": 0.28,
-    "width_pct": 0.03
-  },
-  "stone_stockpile_roi": {
-    "top_pct": 0.112,
-    "height_pct": 0.025,
-    "left_pct": 0.327,
-    "width_pct": 0.03
-  },
-  "population_limit_roi": {
-    "top_pct": 0.112,
-    "height_pct": 0.025,
-    "left_pct": 0.374,
-    "width_pct": 0.03
-  },
   "idle_villager_roi": {
     "top_pct": 0.10,
     "height_pct": 0.06,
     "left_pct": 0.84,
+    "width_pct": 0.05
+  },
+  "wood_stockpile_roi": {
+    "top_pct": 0.06,
+    "height_pct": 0.88,
+    "left_pct": 0.05,
+    "width_pct": 0.05
+  },
+  "food_stockpile_roi": {
+    "top_pct": 0.06,
+    "height_pct": 0.88,
+    "left_pct": 0.15,
+    "width_pct": 0.05
+  },
+  "gold_stockpile_roi": {
+    "top_pct": 0.06,
+    "height_pct": 0.88,
+    "left_pct": 0.25,
+    "width_pct": 0.05
+  },
+  "stone_stockpile_roi": {
+    "top_pct": 0.06,
+    "height_pct": 0.88,
+    "left_pct": 0.35,
+    "width_pct": 0.05
+  },
+  "population_limit_roi": {
+    "top_pct": 0.06,
+    "height_pct": 0.88,
+    "left_pct": 0.45,
     "width_pct": 0.05
   },
   "profiles": {

--- a/config.sample.json
+++ b/config.sample.json
@@ -11,6 +11,7 @@
   "//ocr_conf_threshold": "Minimum OCR confidence (0-100); default 60. Tight ROIs may require 45-50.",
   "ocr_kernel_size": 1,
   "ocr_psm_list": [7],
+  "ocr_zero_variance": 15,
   "tesseract_path": "C:\\Program Files\\Tesseract-OCR\\tesseract.exe",
   "resource_cache_ttl": 1.5,
   "resource_cache_max_age": null,

--- a/tests/test_resource_min_required_width.py
+++ b/tests/test_resource_min_required_width.py
@@ -4,25 +4,33 @@ import types
 import numpy as np
 import os
 
-cv2_stub = types.SimpleNamespace(
-    cvtColor=lambda src, code: src,
-    resize=lambda img, *a, **k: img,
-    matchTemplate=lambda *a, **k: np.zeros((1, 1), dtype=np.float32),
-    minMaxLoc=lambda *a, **k: (0, 0, (0, 0), (0, 0)),
-    imread=lambda *a, **k: np.zeros((1, 1), dtype=np.uint8),
-    imwrite=lambda *a, **k: True,
-    medianBlur=lambda src, k: src,
-    bitwise_not=lambda src: src,
-    rectangle=lambda img, pt1, pt2, color, thickness: img,
-    threshold=lambda src, *a, **k: (None, src),
-    IMREAD_GRAYSCALE=0,
-    COLOR_BGR2GRAY=0,
-    INTER_LINEAR=0,
-    THRESH_BINARY=0,
-    THRESH_OTSU=0,
-    TM_CCOEFF_NORMED=0,
-)
-sys.modules.setdefault("cv2", cv2_stub)
+try:  # pragma: no cover
+    import cv2  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover
+    cv2_stub = types.SimpleNamespace(
+        cvtColor=lambda src, code: src,
+        resize=lambda img, *a, **k: img,
+        matchTemplate=lambda *a, **k: np.zeros((1, 1), dtype=np.float32),
+        minMaxLoc=lambda *a, **k: (0, 0, (0, 0), (0, 0)),
+        imread=lambda *a, **k: np.zeros((1, 1), dtype=np.uint8),
+        imwrite=lambda *a, **k: True,
+        medianBlur=lambda src, k: src,
+        bitwise_not=lambda src: src,
+        rectangle=lambda img, pt1, pt2, color, thickness: img,
+        threshold=lambda src, *a, **k: (None, src),
+        bilateralFilter=lambda src, d, sigmaColor, sigmaSpace: src,
+        adaptiveThreshold=lambda src, maxValue, adaptiveMethod, thresholdType, blockSize, C: src,
+        dilate=lambda src, kernel, iterations=1: src,
+        equalizeHist=lambda src: src,
+        countNonZero=lambda src: int(np.count_nonzero(src)),
+        IMREAD_GRAYSCALE=0,
+        COLOR_BGR2GRAY=0,
+        INTER_LINEAR=0,
+        THRESH_BINARY=0,
+        THRESH_OTSU=0,
+        TM_CCOEFF_NORMED=0,
+    )
+    sys.modules.setdefault("cv2", cv2_stub)
 sys.modules.setdefault("pytesseract", types.SimpleNamespace())
 sys.modules.setdefault("pyautogui", types.SimpleNamespace())
 sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: None))


### PR DESCRIPTION
## Summary
- enhance `_ocr_digits_better` with contrast enhancement, Otsu fallback and variance-based zero handling
- expose configurable `ocr_zero_variance`
- add test coverage for gray zero ROIs

## Testing
- `pytest -q` *(fails: Lists differ for ROI shapes; population ROI errors)*

------
https://chatgpt.com/codex/tasks/task_e_68afb71c97cc832585a4f3e1ba98b7eb