### PR TITLE
Calibrate gold and stone resource ROIs

### DIFF
--- a/config.json
+++ b/config.json
@@ -27,15 +27,15 @@
     "resource_panel": {
         "match_threshold": 0.8,
         "scales": [0.9, 0.95, 1.0, 1.05, 1.1],
-        "roi_padding_left": [0, 0, 0, 0, 0, 0],
-        "roi_padding_right": [0, 0, 0, 0, 0, 0],
+        "roi_padding_left": [0, 0, -2, -2, 0, 0],
+        "roi_padding_right": [0, 0, -2, -2, 0, 0],
         "max_width": 160,
         "min_width": [5, 5, 5, 5, 5, 4],
         "min_required_width": 0,
         "idle_roi_extra_width": 24,
         "top_pct": 0.06,
         "height_pct": 0.88,
-        "icon_trim_pct": [0.25, 0.25, 0.25, 0.25, 0.20, 0.00],
+        "icon_trim_pct": [0.25, 0.25, 0.30, 0.30, 0.20, 0.00],
         "right_trim_pct": 0.02,
         "debug_failed_ocr": true
       },

--- a/script/resources.py
+++ b/script/resources.py
@@ -188,6 +188,11 @@ def compute_resource_rois(
 
         left = cur_right + pad_l
         right = next_left - pad_r
+
+        # Clamp ROI boundaries to the panel limits after applying padding
+        left = max(panel_left, left)
+        right = min(panel_right, right)
+
         if right <= left:
             logger.warning(
                 "Skipping ROI for icon '%s' due to non-positive span (left=%d, right=%d)",


### PR DESCRIPTION
## Summary
- clamp resource ROI calculations to HUD panel bounds
- tweak gold and stone ROI padding and icon trimming in config

## Testing
- `python tools/roi_calibrator.py` *(fails: $DISPLAY not set)*
- `pytest -q` *(fails: Lists differ: [(176, 10), ...])*


------
https://chatgpt.com/codex/tasks/task_e_68afba3b3f408325b5a12b10e862d460