### PR TITLE
Handle repeated OCR failures

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,6 +9,8 @@
   "verbose_logging": false,
   "ocr_conf_threshold": 45,
   "//ocr_conf_threshold": "Minimum OCR confidence (0-100); default 60. Tight ROIs may require 45-50.",
+  "ocr_retry_limit": 3,
+  "//ocr_retry_limit": "Consecutive OCR failures before using fallback value.",
   "ocr_kernel_size": 1,
   "ocr_psm_list": [7],
   "ocr_zero_variance": 15,

--- a/config.sample.json
+++ b/config.sample.json
@@ -9,6 +9,8 @@
   "verbose_logging": false,
   "ocr_conf_threshold": 45,
   "//ocr_conf_threshold": "Minimum OCR confidence (0-100); default 60. Tight ROIs may require 45-50.",
+  "ocr_retry_limit": 3,
+  "//ocr_retry_limit": "Consecutive OCR failures before using fallback value.",
   "ocr_kernel_size": 1,
   "ocr_psm_list": [7],
   "ocr_zero_variance": 15,


### PR DESCRIPTION
## Summary
- fallback to cached or zero values after repeated OCR failures
- expose retry limit via `ocr_retry_limit` config option
- test that default values are returned after exceeding retry threshold

## Testing
- `pytest -q` *(fails: AssertionError in hud_anchor tests; OpenCV errors in population ROI tests; ResourceReadError not raised)*


------
https://chatgpt.com/codex/tasks/task_e_68afbd0ed53083259b170a912310db7c