### PR TITLE
Use image_to_data for idle villager OCR

### DIFF
--- a/tests/test_gather_hud_stats.py
+++ b/tests/test_gather_hud_stats.py
@@ -89,7 +89,10 @@ class TestGatherHudStats(TestCase):
                  "population_limit": (360, 0, 90, 52),
                  "idle_villager": (450, 0, 98, 52),
              }), \
-             patch("tools.campaign_bot.resources.pytesseract.image_to_string", return_value="600"):
+             patch(
+                 "tools.campaign_bot.resources.pytesseract.image_to_data",
+                 return_value={"text": ["600"], "conf": ["90"]},
+             ):
             res, pop = cb.gather_hud_stats()
 
         expected_res = {

--- a/tests/test_hud_anchor.py
+++ b/tests/test_hud_anchor.py
@@ -76,8 +76,14 @@ class TestHudAnchor(TestCase):
         with patch("script.resources.locate_resource_panel", return_value={}), \
              patch("script.screen_utils._grab_frame", side_effect=fake_grab_frame), \
              patch("script.resources._ocr_digits_better", side_effect=fake_ocr), \
-             patch("script.resources.pytesseract.image_to_string", return_value="600"), \
-             patch("script.resources._read_population_from_roi", return_value=(500, 500)):
+             patch("script.resources.preprocess_roi", side_effect=lambda roi: np.zeros((52, 90), dtype=np.uint8)), \
+             patch(
+                 "script.resources.pytesseract.image_to_data",
+                 return_value={"text": ["600"], "conf": ["90"]},
+             ), \
+             patch("script.resources._read_population_from_roi", return_value=(500, 500)), \
+             patch("script.input_utils._screen_size", return_value=(1920, 1080)), \
+             patch("script.resources.cv2.imwrite"):
             result, _ = resources.read_resources_from_hud()
 
         expected = {
@@ -140,8 +146,14 @@ class TestHudAnchorTools(TestCase):
              patch("tools.campaign_bot._grab_frame", side_effect=fake_grab_frame), \
              patch("tools.campaign_bot._ocr_digits_better", side_effect=fake_ocr), \
              patch("script.resources._ocr_digits_better", side_effect=fake_ocr), \
-             patch("script.resources.pytesseract.image_to_string", return_value="600"), \
-             patch("script.resources._read_population_from_roi", return_value=(500, 500)):
+             patch("script.resources.preprocess_roi", side_effect=lambda roi: np.zeros((52, 90), dtype=np.uint8)), \
+             patch(
+                 "script.resources.pytesseract.image_to_data",
+                 return_value={"text": ["600"], "conf": ["90"]},
+             ), \
+             patch("script.resources._read_population_from_roi", return_value=(500, 500)), \
+             patch("script.input_utils._screen_size", return_value=(1920, 1080)), \
+             patch("script.resources.cv2.imwrite"):
             result, _ = cb.read_resources_from_hud([
                 "wood_stockpile",
                 "food_stockpile",

--- a/tests/test_hunting_scenario.py
+++ b/tests/test_hunting_scenario.py
@@ -37,6 +37,8 @@ sys.modules.setdefault(
     types.SimpleNamespace(
         pytesseract=types.SimpleNamespace(tesseract_cmd=""),
         image_to_string=lambda *a, **k: "",
+        image_to_data=lambda *a, **k: {"text": [""], "conf": ["0"]},
+        Output=types.SimpleNamespace(DICT=0),
     ),
 )
 

--- a/tests/test_population_roi.py
+++ b/tests/test_population_roi.py
@@ -28,6 +28,21 @@ class DummyMSS:
 
 sys.modules.setdefault("pyautogui", dummy_pg)
 sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
+sys.modules.setdefault(
+    "cv2",
+    types.SimpleNamespace(
+        cvtColor=lambda src, code: src,
+        resize=lambda img, *a, **k: img,
+        threshold=lambda img, *a, **k: (None, img),
+        imread=lambda *a, **k: np.zeros((1, 1), dtype=np.uint8),
+        IMREAD_GRAYSCALE=0,
+        COLOR_BGR2GRAY=0,
+        INTER_LINEAR=0,
+        THRESH_BINARY=0,
+        THRESH_OTSU=0,
+    ),
+)
+os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
@@ -38,6 +53,7 @@ class TestPopulationROI(TestCase):
     def test_population_roi_outside_screen_raises_error(self):
         with patch("script.input_utils._screen_size", return_value=(200, 200)), \
             patch.dict(common.CFG["areas"], {"pop_box": [2.0, 2.0, 0.1, 0.1]}), \
+            patch.dict(common.CFG, {"population_limit_roi": None}, clear=False), \
             patch("script.resources.locate_resource_panel", return_value={}), \
             patch("script.screen_utils._grab_frame", return_value=np.zeros((1, 1, 3))) as grab_mock, \
             patch("script.hud.pytesseract.image_to_data") as ocr_mock:
@@ -64,6 +80,7 @@ class TestPopulationROI(TestCase):
             patch("script.resources.locate_resource_panel", return_value={}), \
             patch("script.input_utils._screen_size", return_value=(200, 200)), \
             patch.dict(common.CFG["areas"], {"pop_box": [0.1, 0.1, 0.5, 0.5]}), \
+            patch.dict(common.CFG, {"population_limit_roi": None}, clear=False), \
             patch("script.hud.cv2.cvtColor", side_effect=lambda img, code: img), \
             patch("script.hud.cv2.resize", side_effect=lambda img, *a, **k: img), \
             patch("script.hud.cv2.threshold", side_effect=lambda img, *a, **k: (None, img)), \
@@ -102,6 +119,7 @@ class TestPopulationROI(TestCase):
             patch("script.resources.locate_resource_panel", return_value={}), \
             patch("script.input_utils._screen_size", return_value=(200, 200)), \
             patch.dict(common.CFG["areas"], {"pop_box": pop_box}), \
+            patch.dict(common.CFG, {"population_limit_roi": None}, clear=False), \
             patch("script.common.HUD_ANCHOR", {"left": 50, "top": 60, "width": 10, "height": 10}), \
             patch("script.hud.cv2.cvtColor", side_effect=fake_cvtColor), \
             patch("script.hud.cv2.resize", side_effect=lambda img, *a, **k: img), \
@@ -138,6 +156,7 @@ class TestPopulationROI(TestCase):
     def test_non_positive_population_roi_raises_before_ocr(self):
         with patch("script.input_utils._screen_size", return_value=(200, 200)), \
             patch.dict(common.CFG["areas"], {"pop_box": [0.1, 0.1, -0.5, 0.2]}), \
+            patch.dict(common.CFG, {"population_limit_roi": None}, clear=False), \
             patch("script.resources.locate_resource_panel", return_value={}), \
             patch("script.screen_utils._grab_frame", return_value=np.zeros((1, 1, 3))) as grab_mock, \
             patch("script.hud.pytesseract.image_to_data") as ocr_mock, \

--- a/tests/test_resource_debug_images.py
+++ b/tests/test_resource_debug_images.py
@@ -67,6 +67,10 @@ class TestResourceDebugImages(TestCase):
                  },
              ), \
             patch("script.resources._ocr_digits_better", side_effect=fake_ocr), \
+            patch(
+                "script.resources.pytesseract.image_to_data",
+                return_value={"text": [""], "conf": ["0"]},
+            ), \
             patch("script.resources.pytesseract.image_to_string", return_value=""), \
             patch("script.resources._read_population_from_roi", return_value=(0, 0)), \
             patch("script.resources.cv2.imwrite") as imwrite_mock:
@@ -119,9 +123,11 @@ class TestResourceDebugImages(TestCase):
              ), \
              patch("script.resources._ocr_digits_better", side_effect=fake_ocr), \
             patch(
-                "script.resources.pytesseract.image_to_string",
-                side_effect=[""] * 20 + ["0"],
+                "script.resources.pytesseract.image_to_data",
+                side_effect=[{"text": [""], "conf": ["0"]}] * 20
+                + [{"text": ["0"], "conf": ["90"]}],
             ), \
+            patch("script.resources.pytesseract.image_to_string", return_value=""), \
             patch("script.resources._read_population_from_roi", return_value=(0, 0)), \
             patch("script.resources.cv2.imwrite") as imwrite_mock:
             with self.assertRaises(common.ResourceReadError) as ctx:

--- a/tests/test_resource_helpers.py
+++ b/tests/test_resource_helpers.py
@@ -41,7 +41,9 @@ class TestDetectResourceRegions(TestCase):
         frame = np.zeros((100, 100, 3), dtype=np.uint8)
         required = ["wood_stockpile", "food_stockpile"]
         with patch("script.resources.locate_resource_panel", return_value={"wood_stockpile": (0, 0, 10, 10)}), \
-             patch.object(common, "HUD_ANCHOR", None):
+             patch.object(common, "HUD_ANCHOR", None), \
+             patch("script.resources._auto_calibrate_from_icons", return_value=None), \
+             patch.dict(resources.CFG, {"food_stockpile_roi": None}, clear=False):
             with self.assertRaises(common.ResourceReadError):
                 resources.detect_resource_regions(frame, required)
 

--- a/tests/test_resource_ocr_failure.py
+++ b/tests/test_resource_ocr_failure.py
@@ -96,12 +96,16 @@ class TestResourceOcrFailure(TestCase):
                 "idle_villager": (250, 0, 50, 50),
             },
         ), patch("script.resources._ocr_digits_better", side_effect=fake_ocr), patch(
+            "script.resources.pytesseract.image_to_data",
+            return_value={"text": [""], "conf": ["0"]},
+        ), patch(
             "script.resources.pytesseract.image_to_string", return_value="123"
         ), patch("script.resources._read_population_from_roi", return_value=(0, 0)):
+            icons = resources.RESOURCE_ICON_ORDER[:-1]
             result, _ = resources._read_resources(
                 frame,
-                resources.RESOURCE_ICON_ORDER,
-                resources.RESOURCE_ICON_ORDER,
+                icons,
+                icons,
             )
             self.assertEqual(result["wood_stockpile"], 123)
 


### PR DESCRIPTION
## Summary
- switch idle villager OCR to `pytesseract.image_to_data` and honor confidence thresholds
- treat low-confidence idle villager reads as missing
- add tests for high/low confidence idle villager OCR and update affected tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afc51c3c608325a7639a9d2d36aa97