### PR TITLE
Expand OCR PSM options

### DIFF
--- a/script/resources.py
+++ b/script/resources.py
@@ -410,7 +410,9 @@ def _ocr_digits_better(gray):
 
     kernel_size = CFG.get("ocr_kernel_size", 2)
     kernel = np.ones((kernel_size, kernel_size), np.uint8)
-    psms = CFG.get("ocr_psm_list", [6, 7, 8, 10, 13])
+    psms = list(
+        dict.fromkeys(CFG.get("ocr_psm_list", []) + [6, 7, 8, 10, 13])
+    )
 
     debug = CFG.get("ocr_debug")
     debug_dir = ROOT / "debug" if debug else None

--- a/tests/test_ocr_config.py
+++ b/tests/test_ocr_config.py
@@ -41,6 +41,7 @@ class TestOcrConfig(TestCase):
         gray = np.zeros((10, 10), dtype=np.uint8)
         kernels = []
         psms = []
+        expected_psms = list(dict.fromkeys([4, 5] + [6, 7, 8, 10, 13]))
 
         def fake_dilate(src, kernel, iterations=1):
             kernels.append(kernel.shape)
@@ -50,7 +51,7 @@ class TestOcrConfig(TestCase):
 
         def fake_image_to_data(image, config="", output_type=None):
             call_count[0] += 1
-            if call_count[0] <= 4:
+            if call_count[0] <= len(expected_psms) * 2:
                 return {"text": [""]}
             m = re.search(r"--psm (\d+)", config)
             if m:
@@ -65,5 +66,5 @@ class TestOcrConfig(TestCase):
             resources._ocr_digits_better(gray)
 
         self.assertIn((3, 3), kernels)
-        self.assertEqual(sorted(set(psms)), [4, 5])
+        self.assertEqual(sorted(set(psms)), sorted(expected_psms))
 


### PR DESCRIPTION
## Summary
- ensure OCR digit reader always tries multiple Tesseract PSM modes by merging config list with common defaults
- adapt OCR config test to expect merged PSM list

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afe05c0f9c8325aaff8c25380a7104