### PR TITLE
Add OCR success debug flag and enhance failure logging

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -6,6 +6,8 @@
   "loop_minutes": 6,
   "debug": false,
   "ocr_debug": true,
+  "ocr_debug_success": false,
+  "//ocr_debug_success": "Save grayscale and threshold images even when OCR succeeds.",
   "verbose_logging": false,
   "ocr_conf_threshold": 45,
   "//ocr_conf_threshold": "Minimum OCR confidence (0-100); default 60. Tight ROIs may require 45-50.",


### PR DESCRIPTION
## Summary
- log ROI coordinates and dimensions when OCR fails
- allow saving ROI grayscale and threshold images on successful OCR via `ocr_debug_success`
- expose new `ocr_debug_success` flag in sample config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0ba67b1f083259c602e69f94536c4