### PR TITLE
Handle low-confidence single-digit OCR as failures

### DIFF
--- a/script/resources.py
+++ b/script/resources.py
@@ -868,22 +868,14 @@ def execute_ocr(gray, conf_threshold=None, allow_fallback=True):
             digits = ""
             low_conf = True
         elif mean_conf < conf_threshold or max_conf < conf_threshold:
-            if len(digits) == 1:
-                logger.warning(
-                    "Accepting low-confidence OCR result: mean=%.1f max=%.1f digits=%s",
-                    mean_conf,
-                    max_conf,
-                    digits,
-                )
-            else:
-                logger.debug(
-                    "Clearing low-confidence OCR result: mean=%.1f max=%.1f digits=%s",
-                    mean_conf,
-                    max_conf,
-                    digits,
-                )
-                digits = ""
-                low_conf = True
+            logger.debug(
+                "Clearing low-confidence OCR result: mean=%.1f max=%.1f digits=%s",
+                mean_conf,
+                max_conf,
+                digits,
+            )
+            digits = ""
+            low_conf = True
     if low_conf:
         alt_gray = cv2.bitwise_not(gray)
         digits2, data2, mask2 = _ocr_digits_better(alt_gray)


### PR DESCRIPTION
## Summary
- treat all low-confidence OCR results, including single digits, as failures and retry
- add regression test for low-confidence single-digit handling

## Testing
- `pytest tests/test_resource_ocr_failure.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0c431ab308325bf266621f812985a