### PR TITLE
Save OCR failure ROIs for debugging

### DIFF
--- a/script/resources.py
+++ b/script/resources.py
@@ -931,18 +931,23 @@ def execute_ocr(gray, conf_threshold=None, allow_fallback=True):
         if mask is not None:
             mask_path = debug_dir / f"ocr_fail_mask_{ts}.png"
             cv2.imwrite(str(mask_path), mask)
+        roi_path = debug_dir / f"ocr_fail_roi_{ts}.png"
+        cv2.imwrite(str(roi_path), gray)
         text_path = debug_dir / f"ocr_fail_text_{ts}.txt"
         with open(text_path, "w", encoding="utf-8") as f:
             f.write("\n".join(data.get("text", [])))
         if mask_path is not None:
             logger.warning(
-                "OCR returned no digits; mask saved to %s; text output saved to %s",
+                "OCR returned no digits; mask saved to %s; ROI saved to %s; text output saved to %s",
                 mask_path,
+                roi_path,
                 text_path,
             )
         else:
             logger.warning(
-                "OCR returned no digits; text output saved to %s", text_path
+                "OCR returned no digits; ROI saved to %s; text output saved to %s",
+                roi_path,
+                text_path,
             )
     return digits, data, mask
 

--- a/tests/test_resource_debug_images.py
+++ b/tests/test_resource_debug_images.py
@@ -81,6 +81,7 @@ class TestResourceDebugImages(TestCase):
         self.assertGreaterEqual(imwrite_mock.call_count, 2)
         self.assertTrue(any("resource_panel_fail" in p for p in paths))
         self.assertTrue(any("resource_wood_stockpile_roi" in p for p in paths))
+        self.assertTrue(any("ocr_fail_roi" in p for p in paths))
         self.assertTrue(all(str(debug_dir) in p for p in paths))
 
     def test_roi_images_written_when_single_resource_missing(self):
@@ -139,4 +140,5 @@ class TestResourceDebugImages(TestCase):
         debug_dir = common.ROOT / "debug"
         self.assertTrue(any("resource_food_stockpile_roi" in p for p in paths))
         self.assertTrue(any("resource_food_stockpile_thresh" in p for p in paths))
+        self.assertTrue(any("ocr_fail_roi" in p for p in paths))
         self.assertTrue(all(str(debug_dir) in p for p in paths))


### PR DESCRIPTION
## Summary
- Save the grayscale ROI when OCR finds no digits and include its path in warnings
- Verify ROI failure images are emitted in debug image tests

## Testing
- `pytest tests/test_resource_debug_images.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0c5ccc2f08325b750c3d9389cde27