### PR TITLE
Fallback to PATH for Tesseract lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
    - setting the `tesseract_path` value in `config.json`, or
    - setting the `TESSERACT_CMD` environment variable to the executable path.
 
-If neither option is provided, `pytesseract` will attempt to find `tesseract` on the system `PATH`.
+If the supplied path is missing or invalid, the bot searches for `tesseract` on the system `PATH`. A warning is logged when
+falling back to the `PATH` entry. Only when no executable can be located will an error be raised.
 
 ## Configuration notes
 


### PR DESCRIPTION
## Summary
- search for tesseract on PATH when configured path is missing or invalid
- warn when falling back to PATH for OCR
- document tesseract lookup fallback in README

## Testing
- `pytest tests/test_population_roi.py::TestPopulationROI::test_read_population_raises_when_no_digits tests/test_resource_helpers.py::TestExecuteOcr::test_execute_ocr_accepts_low_conf_single_digit -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'matchTemplate'; AttributeError: 'types.SimpleNamespace' object has no attribute 'bitwise_not')*


------
https://chatgpt.com/codex/tasks/task_e_68b0c9d7c1e083258fa0cb781a81a385