### PR TITLE
Auto-calibrate low-contrast HUD ROIs

### DIFF
--- a/config.json
+++ b/config.json
@@ -21,6 +21,8 @@
   "tesseract_path": "C:\\Program Files\\Tesseract-OCR\\tesseract.exe",
   "resource_cache_ttl": 1.5,
   "resource_cache_max_age": null,
+  "disable_roi_overrides_on_calibration": false,
+  "roi_variance_threshold": 5,
   "keys": {
     "idle_vill": ".",
     "build_menu": "b",

--- a/config.sample.json
+++ b/config.sample.json
@@ -27,6 +27,8 @@
   "tesseract_path": "C:\\Program Files\\Tesseract-OCR\\tesseract.exe",
   "resource_cache_ttl": 1.5,
   "resource_cache_max_age": null,
+  "disable_roi_overrides_on_calibration": false,
+  "roi_variance_threshold": 5,
   "keys": {
     "idle_vill": ".",
     "build_menu": "b",

--- a/tests/test_idle_villager_roi.py
+++ b/tests/test_idle_villager_roi.py
@@ -38,6 +38,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
 import script.resources as resources
 import script.units.villager as villager
+import script.screen_utils as screen_utils
 
 
 class TestIdleVillagerROI(TestCase):
@@ -75,6 +76,7 @@ class TestIdleVillagerROI(TestCase):
             patch("script.resources.cv2.matchTemplate", side_effect=fake_match), \
             patch("script.resources.cv2.minMaxLoc", side_effect=fake_minmax), \
             patch("script.resources.cv2.imread", side_effect=fake_imread), \
+            patch.dict(screen_utils.ICON_TEMPLATES, {}, clear=True), \
             patch.dict(
                 common.CFG["resource_panel"],
                 {

--- a/tests/test_population_roi.py
+++ b/tests/test_population_roi.py
@@ -81,6 +81,7 @@ class TestPopulationROI(TestCase):
             patch("script.input_utils._screen_size", return_value=(200, 200)), \
             patch.dict(common.CFG["areas"], {"pop_box": [0.1, 0.1, 0.5, 0.5]}), \
             patch.dict(common.CFG, {"population_limit_roi": None}, clear=False), \
+            patch("script.resources._auto_calibrate_from_icons", return_value={}), \
             patch("script.resources.cv2.cvtColor", side_effect=lambda img, code: img), \
             patch("script.resources.cv2.resize", side_effect=lambda img, *a, **k: img), \
             patch("script.resources.cv2.threshold", side_effect=lambda img, *a, **k: (None, img)), \

--- a/tests/test_resource_roi_validation.py
+++ b/tests/test_resource_roi_validation.py
@@ -90,3 +90,28 @@ class TestResourceRoiValidation(TestCase):
                     ["wood_stockpile"],
                     ["wood_stockpile"],
                 )
+
+    def test_misaligned_roi_triggers_auto_calibration(self):
+        frame = np.zeros((100, 100, 3), dtype=np.uint8)
+        block = np.arange(10 * 20 * 3, dtype=np.uint8).reshape(10, 20, 3)
+        frame[5:15, 50:70] = block
+        misaligned = {"wood_stockpile": (0, 0, 10, 10)}
+        calibrated = {"wood_stockpile": (50, 5, 20, 10)}
+
+        def fake_auto_calibrate(_frame, _cache):
+            resources._LAST_REGION_SPANS["wood_stockpile"] = (
+                calibrated["wood_stockpile"][0],
+                calibrated["wood_stockpile"][0] + calibrated["wood_stockpile"][2],
+            )
+            return calibrated
+
+        with patch("script.resources.locate_resource_panel", return_value=misaligned), \
+            patch("script.resources._auto_calibrate_from_icons", side_effect=fake_auto_calibrate) as mock_calib, \
+            patch.dict(resources.CFG, {"wood_stockpile_roi": None}, clear=False):
+            regions = resources.detect_resource_regions(frame, ["wood_stockpile"])
+
+        self.assertTrue(mock_calib.called)
+        self.assertEqual(regions["wood_stockpile"], calibrated["wood_stockpile"])
+        span = resources._LAST_REGION_SPANS.get("wood_stockpile")
+        self.assertEqual(span, (50, 70))
+        self.assertGreater(span[1], span[0])


### PR DESCRIPTION
## Summary
- Recalibrate resource ROIs when contrast is too low, optionally skipping custom overrides
- Add config flags for ROI variance threshold and bypassing overrides on calibration
- Test misaligned resource ROIs trigger auto-calibration and return valid spans

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0d02a141083259969aa7308f8c12a