### PR TITLE
Add configurable contrast stretch for OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Two fields in `config.json` allow adjusting how resource numbers are read:
   consider lowering this to `45–50`.
 * `ocr_kernel_size` – size of the square kernel used for morphological dilation
   before running OCR (default `2`).
+* `ocr_contrast_stretch` – rescale grayscale intensities before thresholding;
+  set `true` for default min–max stretching or provide an object with
+  `alpha`/`beta` limits (default `false`).
 * `ocr_psm_list` – list of Tesseract [page segmentation modes](https://tesseract-ocr.github.io/tessdoc/ImproveQuality.html#page-segmentation-method)
   tried in order when extracting digits (default `[6, 7, 8, 10, 13]`).
 

--- a/config.json
+++ b/config.json
@@ -18,6 +18,7 @@
     "ocr_kernel_size": 1,
   "ocr_bilateral": [7, 60, 60],
   "ocr_equalize_hist": true,
+  "ocr_contrast_stretch": false,
   "ocr_psm_list": [7],
   "ocr_zero_variance": 15,
   "tesseract_path": "C:\\Program Files\\Tesseract-OCR\\tesseract.exe",

--- a/config.sample.json
+++ b/config.sample.json
@@ -24,6 +24,8 @@
   "//ocr_bilateral": "Bilateral filter params [d, sigmaColor, sigmaSpace]; set null or [] to disable.",
   "ocr_equalize_hist": true,
   "//ocr_equalize_hist": "Apply histogram equalization; false to disable or object for CLAHE.",
+  "ocr_contrast_stretch": false,
+  "//ocr_contrast_stretch": "Rescale intensities before thresholding; true for min-max or object with {alpha,beta}.",
   "ocr_psm_list": [7],
   "ocr_zero_variance": 15,
   "tesseract_path": "C:\\Program Files\\Tesseract-OCR\\tesseract.exe",

--- a/script/resources.py
+++ b/script/resources.py
@@ -437,6 +437,16 @@ def _ocr_digits_better(gray):
         else:
             gray = cv2.equalizeHist(gray)
 
+    contrast = CFG.get("ocr_contrast_stretch")
+    if contrast:
+        if isinstance(contrast, dict):
+            alpha = contrast.get("alpha", 0)
+            beta = contrast.get("beta", 255)
+            norm_type = getattr(cv2, contrast.get("norm_type", "NORM_MINMAX"), cv2.NORM_MINMAX)
+            gray = cv2.normalize(gray, None, alpha=alpha, beta=beta, norm_type=norm_type)
+        else:
+            gray = cv2.normalize(gray, None, 0, 255, cv2.NORM_MINMAX)
+
     kernel_size = CFG.get("ocr_kernel_size", 2)
     kernel = np.ones((kernel_size, kernel_size), np.uint8)
     psms = list(


### PR DESCRIPTION
## Summary
- add optional contrast stretching before adaptive thresholding
- expose `ocr_contrast_stretch` flag in configs and document tuning

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0e631e93c8325a9a8762156bd8f4e