### PR TITLE
Increase stockpile ROI width

### DIFF
--- a/config.json
+++ b/config.json
@@ -65,25 +65,25 @@
     "top_pct": 0.111,
     "height_pct": 0.025,
     "left_pct": 0.186,
-    "width_pct": 0.029
+    "width_pct": 0.039
   },
   "food_stockpile_roi": {
     "top_pct": 0.111,
     "height_pct": 0.025,
     "left_pct": 0.233,
-    "width_pct": 0.029
+    "width_pct": 0.039
   },
   "gold_stockpile_roi": {
     "top_pct": 0.111,
     "height_pct": 0.025,
     "left_pct": 0.280,
-    "width_pct": 0.029
+    "width_pct": 0.039
   },
   "stone_stockpile_roi": {
     "top_pct": 0.111,
     "height_pct": 0.025,
     "left_pct": 0.327,
-    "width_pct": 0.029
+    "width_pct": 0.039
   },
   "population_limit_roi": {
     "top_pct": 0.111,


### PR DESCRIPTION
## Summary
- widen resource stockpile ROIs to ensure full values are captured

## Testing
- `pytest`
- `pytest tests/test_resource_debug_images.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0e95d3fe88325bfcff4b2e762604b