### PR TITLE
Handle low-confidence OCR digits with retries

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
   "debug": false,
   "ocr_debug": true,
   "verbose_logging": false,
-  "ocr_conf_threshold": 45,
+  "ocr_conf_threshold": 58,
   "//ocr_conf_threshold": "Minimum OCR confidence (0-100); default 60. Tight ROIs may require 45-50.",
     "ocr_retry_limit": 3,
     "//ocr_retry_limit": "Consecutive OCR failures before using fallback value.",

--- a/script/resources.py
+++ b/script/resources.py
@@ -1334,7 +1334,7 @@ def _read_resources(
                     digits_exp, data_exp, mask_exp = execute_ocr(
                         gray_expanded, conf_threshold=conf_threshold
                     )
-                if digits_exp:
+                if digits_exp and not data_exp.get("low_conf_single"):
                     digits, data, mask = digits_exp, data_exp, mask_exp
                     roi, gray = roi_expanded, gray_expanded
                     x, y = x0, y0
@@ -1370,7 +1370,7 @@ def _read_resources(
                             conf_threshold=conf_threshold,
                             allow_fallback=False,
                         )
-                    if digits_retry:
+                    if digits_retry and not data_retry.get("low_conf_single"):
                         digits, data, mask = digits_retry, data_retry, mask_retry
                         roi, gray = roi_retry, gray_retry
                         x, w = cand_x, cand_w


### PR DESCRIPTION
## Summary
- Raise `ocr_conf_threshold` closer to 60 for stricter digit validation
- Retry OCR when digits have low confidence before accepting resource values

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0ebaa721083258c916d845dc985eb