### PR TITLE
Allow per-resource OCR top crop

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,6 +16,8 @@
     "ocr_roi_expand_step": 2,
     "//ocr_roi_expand_step": "Additional pixels to grow the OCR ROI per consecutive failure.",
     "ocr_kernel_size": 1,
+    "ocr_top_crop": 1,
+    "ocr_top_crop_overrides": {"wood_stockpile": 0},
   "ocr_bilateral": [7, 60, 60],
   "ocr_equalize_hist": true,
   "ocr_contrast_stretch": false,

--- a/config.sample.json
+++ b/config.sample.json
@@ -18,6 +18,8 @@
     "ocr_roi_expand_step": 2,
     "//ocr_roi_expand_step": "Additional pixels to grow the OCR ROI per consecutive failure.",
     "ocr_kernel_size": 1,
+    "ocr_top_crop": 2,
+    "ocr_top_crop_overrides": {},
   "ocr_blur_kernel": 3,
   "//ocr_blur_kernel": "Median blur kernel before OCR; increase or set 0 to disable when digits are small.",
   "ocr_bilateral": [7, 60, 60],


### PR DESCRIPTION
## Summary
- make OCR top cropping configurable per resource
- lower default top crop and override wood stockpile to avoid clipping digits
- document new settings in sample config

## Testing
- `pytest tests/test_resource_helpers.py::TestExecuteOcr::test_execute_ocr_fallback -q`
- `pytest tests/test_resource_ocr_failure.py::TestResourceOcrFailure::test_read_resources_fallback -q`
- `pytest tests/test_ocr_config.py::TestOcrConfig::test_custom_kernel_and_psm_list -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0f1088474832590d33f63bbd492df