### PR TITLE
Add starting resource validation

### DIFF
--- a/campaign.py
+++ b/campaign.py
@@ -62,6 +62,12 @@ def main():
                 required_icons=icon_cfg.get("required"),
                 optional_icons=icon_cfg.get("optional"),
             )
+            resources.validate_starting_resources(
+                res,
+                info.starting_resources,
+                tolerance=10,
+                raise_on_error=True,
+            )
             logger.info(
                 "Detected resources: wood=%s, food=%s, gold=%s, stone=%s",
                 res.get("wood_stockpile"),

--- a/script/config_utils.py
+++ b/script/config_utils.py
@@ -130,6 +130,8 @@ class ScenarioInfo:
     starting_villagers: int = 0
     population_limit: int = 0
     objective_villagers: int = 0
+    # Expected starting resources keyed by resource name used in OCR routines
+    starting_resources: dict[str, int] | None = None
 
 
 def parse_scenario_info(path: str | Path) -> ScenarioInfo:
@@ -152,6 +154,13 @@ def parse_scenario_info(path: str | Path) -> ScenarioInfo:
                     m = re.search(r"(\d+)\s+villagers", line, re.IGNORECASE)
                     if m:
                         info.starting_villagers = int(m.group(1))
+                elif lower.startswith("starting resources"):
+                    res = {}
+                    for name in ("wood", "food", "gold", "stone"):
+                        m = re.search(rf"(\d+)\s+{name}", line, re.IGNORECASE)
+                        if m:
+                            res[f"{name}_stockpile"] = int(m.group(1))
+                    info.starting_resources = res or None
                 elif lower.startswith("objectives"):
                     in_objectives = True
                     continue

--- a/script/resources.py
+++ b/script/resources.py
@@ -1685,3 +1685,51 @@ def gather_hud_stats(
         max_cache_age,
         conf_threshold,
     )
+
+
+def validate_starting_resources(
+    current: dict[str, int],
+    expected: dict[str, int] | None,
+    *,
+    tolerance: int = 10,
+    raise_on_error: bool = False,
+) -> None:
+    """Validate OCR resource readings against expected starting values.
+
+    Parameters
+    ----------
+    current:
+        Mapping of resource names to the values read via OCR.
+    expected:
+        Mapping of expected starting resource values. When ``None`` or empty,
+        the function performs no validation.
+    tolerance:
+        Acceptable absolute difference before flagging a deviation.
+    raise_on_error:
+        If ``True`` a :class:`ValueError` is raised when a deviation is
+        detected; otherwise a warning is logged.
+    """
+
+    if not expected:
+        return
+
+    for name, exp in expected.items():
+        actual = current.get(name)
+        if actual is None:
+            msg = f"Missing OCR reading for '{name}'"
+            if raise_on_error:
+                logger.error(msg)
+                raise ValueError(msg)
+            logger.warning(msg)
+            continue
+
+        if abs(actual - exp) > tolerance:
+            msg = (
+                f"{name} reading {actual} deviates from expected {exp} "
+                f"(±{tolerance})"
+            )
+            if raise_on_error:
+                logger.error(msg)
+                raise ValueError(msg)
+            logger.warning(msg)
+

--- a/tests/test_internal_population.py
+++ b/tests/test_internal_population.py
@@ -45,6 +45,15 @@ class TestInternalPopulation(TestCase):
         self.assertEqual(info.starting_villagers, 3)
         self.assertEqual(info.population_limit, 50)
         self.assertEqual(info.objective_villagers, 7)
+        self.assertEqual(
+            info.starting_resources,
+            {
+                "wood_stockpile": 80,
+                "food_stockpile": 140,
+                "gold_stockpile": 0,
+                "stone_stockpile": 0,
+            },
+        )
 
     def test_train_villagers_updates_population_without_ocr(self):
         common.CURRENT_POP = 3

--- a/tests/test_resource_helpers.py
+++ b/tests/test_resource_helpers.py
@@ -181,3 +181,24 @@ class TestHandleOcrFailure(TestCase):
             )
         self.assertEqual(results["wood_stockpile"], 99)
         self.assertEqual(warn_mock.call_count, 1)
+
+
+class TestValidateStartingResources(TestCase):
+    def test_deviation_raises_error(self):
+        with self.assertRaises(ValueError):
+            resources.validate_starting_resources(
+                {"wood_stockpile": 50},
+                {"wood_stockpile": 80},
+                tolerance=10,
+                raise_on_error=True,
+            )
+
+    def test_logs_warning_without_raise(self):
+        with patch("script.resources.logger.warning") as warn_mock:
+            resources.validate_starting_resources(
+                {"wood_stockpile": 50},
+                {"wood_stockpile": 80},
+                tolerance=10,
+                raise_on_error=False,
+            )
+            warn_mock.assert_called_once()


### PR DESCRIPTION
## Summary
- parse starting resources from scenario configuration
- validate OCR readings against expected mission resource defaults
- add tests for starting resource parsing and validation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0f9880294832582d7a73942bc305f