### PR TITLE
Handle low-confidence OCR digits as failures

### DIFF
--- a/script/resources.py
+++ b/script/resources.py
@@ -938,6 +938,8 @@ def execute_ocr(gray, conf_threshold=None, allow_fallback=True, roi=None):
                     digits,
                 )
                 data["low_conf_multi"] = True
+            digits = ""
+            low_conf = True
     if low_conf:
         alt_gray = cv2.bitwise_not(gray)
         digits2, data2, mask2 = _ocr_digits_better(alt_gray)

--- a/tests/test_resource_helpers.py
+++ b/tests/test_resource_helpers.py
@@ -100,10 +100,10 @@ class TestExecuteOcr(TestCase):
              patch("script.resources.pytesseract.image_to_string", return_value="") as img2str_mock, \
              patch("script.resources.logger.warning") as warn_mock:
             digits, data_out, _ = resources.execute_ocr(gray, conf_threshold=60)
-        self.assertEqual(digits, "123")
+        self.assertEqual(digits, "")
         self.assertTrue(data_out.get("low_conf_multi"))
-        img2str_mock.assert_not_called()
-        warn_mock.assert_called_once()
+        img2str_mock.assert_called_once()
+        self.assertGreaterEqual(warn_mock.call_count, 1)
 
     def test_execute_ocr_warns_low_mean_confidence(self):
         gray = np.zeros((5, 5), dtype=np.uint8)
@@ -112,10 +112,10 @@ class TestExecuteOcr(TestCase):
              patch("script.resources.pytesseract.image_to_string", return_value="") as img2str_mock, \
              patch("script.resources.logger.warning") as warn_mock:
             digits, data_out, _ = resources.execute_ocr(gray, conf_threshold=60)
-        self.assertEqual(digits, "12")
+        self.assertEqual(digits, "")
         self.assertTrue(data_out.get("low_conf_multi"))
-        img2str_mock.assert_not_called()
-        warn_mock.assert_called_once()
+        img2str_mock.assert_called_once()
+        self.assertGreaterEqual(warn_mock.call_count, 1)
 
     def test_execute_ocr_accepts_low_conf_single_digit(self):
         gray = np.zeros((5, 5), dtype=np.uint8)
@@ -123,10 +123,11 @@ class TestExecuteOcr(TestCase):
         with patch("script.resources._ocr_digits_better", return_value=("0", data, None)), \
              patch("script.resources.pytesseract.image_to_string", return_value="") as img2str_mock, \
              patch("script.resources.logger.warning") as warn_mock:
-            digits, _, _ = resources.execute_ocr(gray, conf_threshold=60)
-        self.assertEqual(digits, "0")
-        img2str_mock.assert_not_called()
-        warn_mock.assert_called_once()
+            digits, data_out, _ = resources.execute_ocr(gray, conf_threshold=60)
+        self.assertEqual(digits, "")
+        self.assertTrue(data_out.get("low_conf_single"))
+        img2str_mock.assert_called_once()
+        self.assertGreaterEqual(warn_mock.call_count, 1)
 
     def test_execute_ocr_second_attempt_success(self):
         gray = np.zeros((5, 5), dtype=np.uint8)


### PR DESCRIPTION
## Summary
- clear OCR digits when mean or max confidence falls below threshold
- adjust tests to expect retries instead of returning low-confidence digits
- ensure low-confidence OCR triggers cache fallback in resource reads

## Testing
- `pytest -q`
- manual low-confidence read showing cached fallback


------
https://chatgpt.com/codex/tasks/task_e_68b100eb78a483259751e2c5c571b5b8