### PR TITLE
Skip OCR for uniform ROIs and handle zero stone

### DIFF
--- a/tests/test_ocr_config.py
+++ b/tests/test_ocr_config.py
@@ -39,6 +39,7 @@ import script.resources as resources
 class TestOcrConfig(TestCase):
     def test_custom_kernel_and_psm_list(self):
         gray = np.zeros((10, 10), dtype=np.uint8)
+        gray[0, 0] = 255
         kernels = []
         psms = []
         expected_psms = list(dict.fromkeys([4, 5] + [6, 7, 8, 10, 13]))

--- a/tests/test_resource_helpers.py
+++ b/tests/test_resource_helpers.py
@@ -141,6 +141,22 @@ class TestExecuteOcr(TestCase):
         self.assertEqual(digits, "789")
         img2str_mock.assert_not_called()
 
+    def test_execute_ocr_zero_variance_shortcut(self):
+        gray = np.zeros((5, 5), dtype=np.uint8)
+        with patch(
+            "script.resources._ocr_digits_better",
+            return_value=("0", {"zero_variance": True}, None),
+        ), patch("script.resources.pytesseract.image_to_string") as img2str_mock, patch(
+            "script.resources.logger.warning"
+        ) as warn_mock:
+            digits, data_out, mask = resources.execute_ocr(gray, conf_threshold=60)
+        self.assertEqual(digits, "0")
+        self.assertFalse(data_out.get("low_conf_single"))
+        self.assertFalse(data_out.get("low_conf_multi"))
+        self.assertIsNone(mask)
+        img2str_mock.assert_not_called()
+        warn_mock.assert_not_called()
+
 
 class TestHandleOcrFailure(TestCase):
     def test_handle_ocr_failure_raises(self):

--- a/tests/test_resource_ocr_failure.py
+++ b/tests/test_resource_ocr_failure.py
@@ -257,7 +257,7 @@ class TestResourceOcrFailure(TestCase):
         ):
             digits, data, _ = resources._ocr_digits_better(gray)
         self.assertEqual(digits, "0")
-        self.assertEqual(data, {})
+        self.assertTrue(data.get("zero_variance"))
 
     def test_gold_and_stone_zero_digits_return_zero(self):
         def make_gold_roi():


### PR DESCRIPTION
## Summary
- Avoid expensive OCR steps by returning `'0'` immediately for near-uniform ROIs
- Bypass confidence checks when `_ocr_digits_better` triggers zero-variance shortcut
- Cover zero stone stockpile and zero-variance path with new tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b111ef2404832594cd747ed836da61