### PR TITLE
Add Foraging scenario automation

### DIFF
--- a/campaigns/Ascent_of_Egypt/2.Foraging.py
+++ b/campaigns/Ascent_of_Egypt/2.Foraging.py
@@ -1,0 +1,71 @@
+"""Automation for the *Foraging* scenario of the Ascent of Egypt campaign.
+
+This module orchestrates the second tutorial mission of Age of Empires
+Definitive Edition. The objective of the scenario is to collect food and
+construct a Granary, Storage Pit and Dock. The script performs the
+scenario specific setup such as reading the scenario information from the
+accompanying text file and initialising the population and resource
+counters.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+
+import script.common as common
+import script.hud as hud
+import script.resources as resources
+from script.config_utils import parse_scenario_info
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    """Run the automation routine for the *Foraging* mission.
+
+    The function performs the following high level steps:
+
+    1.  Wait for the game HUD to be detected on screen (with a fallback
+        attempt if the first detection fails).
+    2.  Parse the scenario information from ``2.Foraging.txt`` which
+        lives alongside this file.
+    3.  Initialise the internal resource and population counters so that
+        the rest of the automation knows the correct starting state.
+    """
+
+    logger.info(
+        "Enter the campaign mission (Foraging). The script starts when the HUD is detected…"
+    )
+
+    try:
+        anchor, asset = hud.wait_hud(timeout=90)
+        logger.info("HUD detected at %s using '%s'.", anchor, asset)
+    except RuntimeError as exc:  # pragma: no cover - retry branch is defensive
+        logger.error(str(exc))
+        logger.info("Giving another 25s for you to adjust the camera/HUD (fallback)…")
+        time.sleep(25)
+        anchor, asset = hud.wait_hud(timeout=90)
+        logger.info("HUD detected at %s using '%s'.", anchor, asset)
+
+    scenario_txt = Path(__file__).with_suffix(".txt")
+    info = parse_scenario_info(scenario_txt)
+
+    # Configuração inicial de população
+    common.CURRENT_POP = info.starting_villagers
+    common.POP_CAP = 4  # População suportada pelo Town Center inicial
+    common.TARGET_POP = info.objective_villagers
+
+    # Inicialização de recursos com base no cenário
+    if info.starting_resources:
+        now = time.time()
+        resources.RESOURCE_CACHE.last_resource_values.update(info.starting_resources)
+        for name in info.starting_resources:
+            resources.RESOURCE_CACHE.last_resource_ts[name] = now
+
+    logger.info("Setup complete.")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution entry point
+    main()

--- a/tests/test_foraging_scenario.py
+++ b/tests/test_foraging_scenario.py
@@ -1,0 +1,90 @@
+import os
+import runpy
+import sys
+import types
+from unittest import TestCase
+from unittest.mock import patch
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Stub out heavy external modules before importing any of the project code.
+# ---------------------------------------------------------------------------
+
+dummy_pg = types.SimpleNamespace(
+    PAUSE=0,
+    FAILSAFE=False,
+    size=lambda: (200, 200),
+    click=lambda *a, **k: None,
+    moveTo=lambda *a, **k: None,
+    press=lambda *a, **k: None,
+)
+
+
+class DummyMSS:
+    monitors = [{}, {"left": 0, "top": 0, "width": 200, "height": 200}]
+
+    def grab(self, region):
+        h, w = region["height"], region["width"]
+        return np.zeros((h, w, 4), dtype=np.uint8)
+
+
+sys.modules.setdefault("pyautogui", dummy_pg)
+sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
+sys.modules.setdefault(
+    "pytesseract",
+    types.SimpleNamespace(
+        pytesseract=types.SimpleNamespace(tesseract_cmd=""),
+        image_to_string=lambda *a, **k: "",
+        image_to_data=lambda *a, **k: {"text": [""], "conf": ["0"]},
+        Output=types.SimpleNamespace(DICT=0),
+    ),
+)
+
+os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import script.common as common
+import script.config_utils as config_utils
+import script.resources as resources
+
+
+class TestForagingScenario(TestCase):
+    """Ensure the Foraging scenario script wires up common routines correctly."""
+
+    def test_main_initialises_counters(self):
+        info = config_utils.ScenarioInfo(
+            starting_villagers=3,
+            population_limit=50,
+            starting_resources={
+                "wood_stockpile": 200,
+                "food_stockpile": 200,
+                "gold_stockpile": 0,
+                "stone_stockpile": 100,
+            },
+            objective_villagers=0,
+        )
+
+        with patch(
+            "script.hud.wait_hud", return_value=((0, 0, 0, 0), "asset")
+        ) as wait_mock, patch(
+            "script.config_utils.parse_scenario_info", return_value=info
+        ) as parse_mock, patch.object(
+            resources, "RESOURCE_CACHE", resources.ResourceCache()
+        ):
+            runpy.run_path(
+                os.path.join("campaigns", "Ascent_of_Egypt", "2.Foraging.py"),
+                run_name="__main__",
+            )
+
+            self.assertEqual(common.CURRENT_POP, info.starting_villagers)
+            self.assertEqual(common.POP_CAP, 4)
+            self.assertEqual(common.TARGET_POP, info.objective_villagers)
+            self.assertEqual(
+                resources.RESOURCE_CACHE.last_resource_values, info.starting_resources
+            )
+            for name in info.starting_resources:
+                self.assertIn(name, resources.RESOURCE_CACHE.last_resource_ts)
+
+            wait_mock.assert_called_once()
+            parse_mock.assert_called_once()


### PR DESCRIPTION
## Summary
- add automation entry point for the Foraging mission that primes population and resource state from scenario data
- cover Foraging script with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1197911b08325bb355f19f54ca0e2