### PR TITLE
Return best-effort OCR digits with low confidence flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Configuration options in `config.json` allow adjusting how resource numbers are 
   `alpha`/`beta` limits (default `false`).
 * `ocr_psm_list` – list of Tesseract [page segmentation modes](https://tesseract-ocr.github.io/tessdoc/ImproveQuality.html#page-segmentation-method)
   tried in order when extracting digits (default `[6, 7, 8, 10, 13]`).
+* `execute_ocr` returns a `(digits, data, mask, low_conf)` tuple. When no attempt
+  meets the confidence threshold, the highest-confidence digits are returned with
+  `low_conf=True` so callers can decide whether to accept or retry the value.
 
 ## Capturing `assets/resources.png`
 

--- a/tests/test_idle_villager_ocr.py
+++ b/tests/test_idle_villager_ocr.py
@@ -76,7 +76,7 @@ class TestIdleVillagerOCR(TestCase):
              ), \
              patch(
                  "script.resources.execute_ocr",
-                 return_value=("", {"text": [""], "conf": []}, None),
+                 return_value=("", {"text": [""], "conf": []}, None, True),
              ):
             result, _ = resources.read_resources_from_hud(
                 required_icons=[], icons_to_read=["idle_villager"]

--- a/tests/test_resource_helpers.py
+++ b/tests/test_resource_helpers.py
@@ -88,8 +88,9 @@ class TestExecuteOcr(TestCase):
         gray = np.zeros((5, 5), dtype=np.uint8)
         with patch("script.resources._ocr_digits_better", return_value=("", {}, None)), \
              patch("script.resources.pytesseract.image_to_string", return_value="456"):
-            digits, data, mask = resources.execute_ocr(gray)
+            digits, data, mask, low_conf = resources.execute_ocr(gray)
         self.assertEqual(digits, "456")
+        self.assertTrue(low_conf)
         self.assertEqual(data["text"], ["456"])
         np.testing.assert_array_equal(mask, gray)
 
@@ -99,8 +100,9 @@ class TestExecuteOcr(TestCase):
         with patch("script.resources._ocr_digits_better", return_value=("123", data, None)), \
              patch("script.resources.pytesseract.image_to_string", return_value="") as img2str_mock, \
              patch("script.resources.logger.warning") as warn_mock:
-            digits, data_out, _ = resources.execute_ocr(gray, conf_threshold=60)
-        self.assertEqual(digits, "")
+            digits, data_out, _, low_conf = resources.execute_ocr(gray, conf_threshold=60)
+        self.assertEqual(digits, "123")
+        self.assertTrue(low_conf)
         self.assertTrue(data_out.get("low_conf_multi"))
         img2str_mock.assert_called_once()
         self.assertGreaterEqual(warn_mock.call_count, 1)
@@ -112,8 +114,9 @@ class TestExecuteOcr(TestCase):
              patch("script.resources.pytesseract.image_to_string", return_value="") as img2str_mock, \
              patch("script.resources.logger.warning") as warn_mock, \
              patch.dict(resources.CFG, {"ocr_conf_decay": 1.0}, clear=False):
-            digits, data_out, _ = resources.execute_ocr(gray, conf_threshold=60)
-        self.assertEqual(digits, "")
+            digits, data_out, _, low_conf = resources.execute_ocr(gray, conf_threshold=60)
+        self.assertEqual(digits, "12")
+        self.assertTrue(low_conf)
         self.assertTrue(data_out.get("low_conf_multi"))
         img2str_mock.assert_called_once()
         self.assertGreaterEqual(warn_mock.call_count, 1)
@@ -124,8 +127,9 @@ class TestExecuteOcr(TestCase):
         with patch("script.resources._ocr_digits_better", return_value=("0", data, None)), \
              patch("script.resources.pytesseract.image_to_string", return_value="") as img2str_mock, \
              patch("script.resources.logger.warning") as warn_mock:
-            digits, data_out, _ = resources.execute_ocr(gray, conf_threshold=60)
-        self.assertEqual(digits, "")
+            digits, data_out, _, low_conf = resources.execute_ocr(gray, conf_threshold=60)
+        self.assertEqual(digits, "0")
+        self.assertTrue(low_conf)
         self.assertTrue(data_out.get("low_conf_single"))
         img2str_mock.assert_called_once()
         self.assertGreaterEqual(warn_mock.call_count, 1)
@@ -138,8 +142,9 @@ class TestExecuteOcr(TestCase):
             "script.resources._ocr_digits_better",
             side_effect=[("123", data1, None), ("789", data2, None)],
         ), patch("script.resources.pytesseract.image_to_string") as img2str_mock:
-            digits, _, _ = resources.execute_ocr(gray, conf_threshold=60)
+            digits, _, _, low_conf = resources.execute_ocr(gray, conf_threshold=60)
         self.assertEqual(digits, "789")
+        self.assertFalse(low_conf)
         img2str_mock.assert_not_called()
 
     def test_execute_ocr_zero_variance_shortcut(self):
@@ -150,8 +155,9 @@ class TestExecuteOcr(TestCase):
         ), patch("script.resources.pytesseract.image_to_string") as img2str_mock, patch(
             "script.resources.logger.warning"
         ) as warn_mock:
-            digits, data_out, mask = resources.execute_ocr(gray, conf_threshold=60)
+            digits, data_out, mask, low_conf = resources.execute_ocr(gray, conf_threshold=60)
         self.assertEqual(digits, "0")
+        self.assertFalse(low_conf)
         self.assertFalse(data_out.get("low_conf_single"))
         self.assertFalse(data_out.get("low_conf_multi"))
         self.assertIsNone(mask)
@@ -167,8 +173,9 @@ class TestExecuteOcr(TestCase):
         with patch("script.resources._ocr_digits_better", side_effect=side_effect) as ocr_mock, \
              patch("script.resources.pytesseract.image_to_string", return_value="") as img2str_mock, \
              patch.dict(resources.CFG, {"ocr_conf_min": 30, "ocr_conf_decay": 0.5}, clear=False):
-            digits, data_out, _ = resources.execute_ocr(gray, conf_threshold=60)
+            digits, data_out, _, low_conf = resources.execute_ocr(gray, conf_threshold=60)
         self.assertEqual(digits, "12")
+        self.assertFalse(low_conf)
         self.assertNotIn("low_conf_multi", data_out)
         img2str_mock.assert_not_called()
         self.assertGreaterEqual(ocr_mock.call_count, 3)

--- a/tests/test_resource_narrow_roi_expand.py
+++ b/tests/test_resource_narrow_roi_expand.py
@@ -95,7 +95,7 @@ class TestNarrowROIExpansion(TestCase):
             patch.object(
                 resources,
                 "execute_ocr",
-                return_value=("123", {"text": ["123"]}, np.zeros((1, 1), dtype=np.uint8)),
+                return_value=("123", {"text": ["123"]}, np.zeros((1, 1), dtype=np.uint8), False),
             ) as ocr_mock:
             results, _ = resources._read_resources(
                 frame, ["stone_stockpile"], ["stone_stockpile"]

--- a/tests/test_resource_ocr_failure.py
+++ b/tests/test_resource_ocr_failure.py
@@ -161,10 +161,10 @@ class TestResourceOcrFailure(TestCase):
             patch("script.screen_utils._grab_frame", side_effect=fake_grab_frame), \
             patch("script.resources._ocr_digits_better", side_effect=fake_ocr) as ocr_mock, \
             patch("script.resources.pytesseract.image_to_string", return_value="") as img2str_mock, \
-            patch("script.resources.cv2.imwrite"), \
-            self.assertRaises(common.ResourceReadError):
-            resources.read_resources_from_hud(["wood_stockpile"])
+            patch("script.resources.cv2.imwrite"):
+            result, _ = resources.read_resources_from_hud(["wood_stockpile"])
 
+        self.assertEqual(result["wood_stockpile"], 123)
         self.assertGreaterEqual(ocr_mock.call_count, 2)
         img2str_mock.assert_called()
 
@@ -190,10 +190,10 @@ class TestResourceOcrFailure(TestCase):
             patch("script.screen_utils._grab_frame", side_effect=fake_grab_frame), \
             patch("script.resources._ocr_digits_better", side_effect=fake_ocr) as ocr_mock, \
             patch("script.resources.pytesseract.image_to_string", return_value="") as img2str_mock, \
-            patch("script.resources.cv2.imwrite"), \
-            self.assertRaises(common.ResourceReadError):
-            resources.read_resources_from_hud(["wood_stockpile"])
+            patch("script.resources.cv2.imwrite"):
+            result, _ = resources.read_resources_from_hud(["wood_stockpile"])
 
+        self.assertEqual(result["wood_stockpile"], 7)
         self.assertGreaterEqual(ocr_mock.call_count, 2)
         self.assertGreaterEqual(img2str_mock.call_count, 1)
 
@@ -214,9 +214,9 @@ class TestResourceOcrFailure(TestCase):
             patch("script.screen_utils._grab_frame", side_effect=fake_grab_frame), \
             patch("script.resources._ocr_digits_better", side_effect=fake_ocr), \
             patch("script.resources.pytesseract.image_to_string", return_value="") as img2str_mock, \
-            patch("script.resources.cv2.imwrite"), \
-            self.assertRaises(common.ResourceReadError):
-            resources.read_resources_from_hud(["wood_stockpile"])
+            patch("script.resources.cv2.imwrite"):
+            result, _ = resources.read_resources_from_hud(["wood_stockpile"])
+        self.assertEqual(result["wood_stockpile"], 7)
         self.assertGreaterEqual(img2str_mock.call_count, 1)
 
     def test_cached_value_used_for_optional_failure(self):
@@ -364,8 +364,8 @@ class TestGatherHudStatsSliding(TestCase):
             x = int(round(mean - (w - 1) / 2))
             calls.append((x, w, allow_fallback))
             if mean > 80:
-                return "789", {"text": ["789"]}, None
-            return "", {"text": [""]}, None
+                return "789", {"text": ["789"]}, None, False
+            return "", {"text": [""]}, None, False
 
         with patch(
             "script.resources.detect_resource_regions", side_effect=fake_detect

--- a/tests/test_resource_read_retry.py
+++ b/tests/test_resource_read_retry.py
@@ -145,8 +145,8 @@ class TestResourceReadRetry(TestCase):
             x = int(round(mean - (w - 1) / 2))
             calls.append((x, w, allow_fallback))
             if mean > 80:
-                return "789", {"text": ["789"]}, None
-            return "", {"text": [""]}, None
+                return "789", {"text": ["789"]}, None, False
+            return "", {"text": [""]}, None, False
 
         with patch("script.resources.detect_resource_regions", side_effect=fake_detect), \
              patch("script.screen_utils._grab_frame", return_value=frame), \
@@ -220,7 +220,7 @@ class TestResourceReadRetry(TestCase):
         ):
             if roi is not None:
                 rois.append((roi, allow_fallback))
-            return "", {"text": [""]}, np.zeros((1, 1), dtype=np.uint8)
+            return "", {"text": [""]}, np.zeros((1, 1), dtype=np.uint8), False
 
         with patch("script.resources.detect_resource_regions", side_effect=fake_detect), \
              patch("script.screen_utils._grab_frame", return_value=frame), \


### PR DESCRIPTION
## Summary
- track the highest-confidence OCR digits during retries and return them with a `low_conf` flag when no attempt meets the threshold
- propagate low-confidence results to resource readers so caches and fallbacks can react appropriately
- document the new `execute_ocr` return value and update tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b127096c508325bb726f730fc9f96b