### PR TITLE
refactor: modularize resource panel helpers

### DIFF
--- a/script/resources/__init__.py
+++ b/script/resources/__init__.py
@@ -55,6 +55,9 @@ locate_resource_panel = panel.locate_resource_panel
 _auto_calibrate_from_icons = panel._auto_calibrate_from_icons
 _fallback_rois_from_slice = panel._fallback_rois_from_slice
 detect_resource_regions = panel.detect_resource_regions
+_apply_custom_rois = panel._apply_custom_rois
+_recalibrate_low_variance = panel._recalibrate_low_variance
+_remove_overlaps = panel._remove_overlaps
 
 # OCR functions
 preprocess_roi = ocr.preprocess_roi
@@ -482,6 +485,9 @@ __all__ = [
     "_get_resource_panel_cfg",
     "locate_resource_panel",
     "detect_resource_regions",
+    "_apply_custom_rois",
+    "_recalibrate_low_variance",
+    "_remove_overlaps",
     "preprocess_roi",
     "execute_ocr",
     "handle_ocr_failure",

--- a/tests/test_idle_villager_custom_roi.py
+++ b/tests/test_idle_villager_custom_roi.py
@@ -32,7 +32,6 @@ sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
 os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-import script.common as common
 import script.resources as resources
 
 
@@ -46,10 +45,9 @@ class TestIdleVillagerCustomROI(TestCase):
             "height_pct": 0.25,
         }
         expected = (40, 60, 50, 50)
-        with patch("script.resources.locate_resource_panel", return_value={}), \
-            patch("script.resources.input_utils._screen_size", return_value=(200, 200)), \
-            patch.dict(resources.CFG, {"idle_villager_roi": cfg}, clear=False), \
-            patch.object(common, "HUD_ANCHOR", None):
-            regions = resources.detect_resource_regions(frame, ["idle_villager"])
+        with patch(
+            "script.resources.input_utils._screen_size", return_value=(200, 200)
+        ), patch.dict(resources.CFG, {"idle_villager_roi": cfg}, clear=False):
+            regions = resources._apply_custom_rois(frame, {})
 
         self.assertEqual(regions["idle_villager"], expected)

--- a/tests/test_resource_custom_rois.py
+++ b/tests/test_resource_custom_rois.py
@@ -32,7 +32,6 @@ sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
 os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-import script.common as common
 import script.resources as resources
 
 
@@ -53,13 +52,13 @@ class TestResourceCustomROIs(TestCase):
             "stone_stockpile",
             "population_limit",
         ]
-        with patch("script.resources.locate_resource_panel", return_value={}), \
-            patch("script.resources.input_utils._screen_size", return_value=(200, 200)), \
-            patch.object(common, "HUD_ANCHOR", None):
+        with patch(
+            "script.resources.input_utils._screen_size", return_value=(200, 200)
+        ):
             for name in names:
                 with self.subTest(name=name):
                     key = f"{name}_roi"
                     with patch.dict(resources.CFG, {key: cfg}, clear=False):
-                        regions = resources.detect_resource_regions(frame, [name])
+                        regions = resources._apply_custom_rois(frame, {})
                     self.assertEqual(regions[name], expected)
 

--- a/tests/test_resource_ocr_failure.py
+++ b/tests/test_resource_ocr_failure.py
@@ -301,30 +301,13 @@ class TestResourceOcrFailure(TestCase):
         self.assertIn("narrow ROI span", str(ctx.exception))
 
     def test_overlapping_rois_are_trimmed(self):
-        frame = np.zeros((100, 100, 3), dtype=np.uint8)
-        with patch(
-            "script.resources.locate_resource_panel",
-            return_value={
-                "wood_stockpile": (0, 0, 50, 10),
-                "food_stockpile": (40, 0, 50, 10),
-            },
-        ), patch(
-            "script.resources.input_utils._screen_size", return_value=(200, 200)
-        ), patch.dict(
-            resources.CFG,
-            {
-                "wood_stockpile_roi": None,
-                "food_stockpile_roi": None,
-                "gold_stockpile_roi": None,
-                "stone_stockpile_roi": None,
-                "population_limit_roi": None,
-                "idle_villager_roi": None,
-            },
-            clear=False,
-        ):
-            regions = resources.detect_resource_regions(
-                frame, ["wood_stockpile", "food_stockpile"]
-            )
+        regions = {
+            "wood_stockpile": (0, 0, 50, 10),
+            "food_stockpile": (40, 0, 50, 10),
+        }
+        regions = resources._remove_overlaps(
+            regions, ["wood_stockpile", "food_stockpile"]
+        )
 
         self.assertEqual(regions["wood_stockpile"], (0, 0, 40, 10))
         self.assertEqual(regions["food_stockpile"], (40, 0, 50, 10))

--- a/tests/test_resource_roi_validation.py
+++ b/tests/test_resource_roi_validation.py
@@ -105,10 +105,13 @@ class TestResourceRoiValidation(TestCase):
             )
             return calibrated
 
-        with patch("script.resources.locate_resource_panel", return_value=misaligned), \
-            patch("script.resources._auto_calibrate_from_icons", side_effect=fake_auto_calibrate) as mock_calib, \
-            patch.dict(resources.CFG, {"wood_stockpile_roi": None}, clear=False):
-            regions = resources.detect_resource_regions(frame, ["wood_stockpile"])
+        with patch(
+            "script.resources.panel._auto_calibrate_from_icons",
+            side_effect=fake_auto_calibrate,
+        ) as mock_calib:
+            regions = resources._recalibrate_low_variance(
+                frame, misaligned, ["wood_stockpile"], resources.RESOURCE_CACHE
+            )
 
         self.assertTrue(mock_calib.called)
         self.assertEqual(regions["wood_stockpile"], calibrated["wood_stockpile"])


### PR DESCRIPTION
## Summary
- extract custom ROI, low variance calibration, and overlap trimming into dedicated helpers
- orchestrate helper functions inside `detect_resource_regions`
- re-export helpers and update tests to call them directly

## Testing
- `pytest tests/test_idle_villager_custom_roi.py tests/test_resource_custom_rois.py tests/test_resource_ocr_failure.py::TestResourceOcrFailure::test_overlapping_rois_are_trimmed tests/test_resource_roi_validation.py::TestResourceRoiValidation::test_misaligned_roi_triggers_auto_calibration -q`

------
https://chatgpt.com/codex/tasks/task_e_68b22e88fe74832596b8159620db5bb8