### PR TITLE
Return HUD score

### DIFF
--- a/script/resources/panel.py
+++ b/script/resources/panel.py
@@ -14,13 +14,13 @@ logger = logging.getLogger(__name__)
 
 
 def detect_hud(frame):
-    """Locate the resource panel and return its bounding box."""
+    """Locate the resource panel and return its bounding box and score."""
 
     from . import find_template
 
     tmpl = screen_utils.HUD_TEMPLATE
     if tmpl is None:
-        return None
+        return None, 0.0
 
     def _save_debug(img, heatmap):
         debug_dir = ROOT / "debug"
@@ -52,11 +52,11 @@ def detect_hud(frame):
                     score,
                 )
                 _save_debug(frame, heat)
-                return None
+                return None, score
         else:
-            return None
+            return None, score
 
-    return box
+    return box, score
 
 
 def compute_resource_rois(
@@ -238,7 +238,7 @@ def _get_resource_panel_cfg():
 def locate_resource_panel(frame, cache_obj: cache.ResourceCache = cache.RESOURCE_CACHE):
     """Locate the resource panel and return bounding boxes for each value."""
 
-    box = detect_hud(frame)
+    box, _score = detect_hud(frame)
     if not box:
         return {}
 

--- a/tests/test_detect_hud.py
+++ b/tests/test_detect_hud.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import types
+from unittest import TestCase
+from unittest.mock import patch
+
+import numpy as np
+
+# Stub modules requiring GUI
+dummy_pg = types.SimpleNamespace(
+    PAUSE=0,
+    FAILSAFE=False,
+    size=lambda: (200, 200),
+    click=lambda *a, **k: None,
+    moveTo=lambda *a, **k: None,
+    press=lambda *a, **k: None,
+)
+
+
+class DummyMSS:
+    monitors = [{}, {"left": 0, "top": 0, "width": 200, "height": 200}]
+
+    def grab(self, region):
+        h, w = region["height"], region["width"]
+        return np.zeros((h, w, 4), dtype=np.uint8)
+
+
+sys.modules.setdefault("pyautogui", dummy_pg)
+sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
+pytesseract_stub = types.SimpleNamespace(
+    pytesseract=types.SimpleNamespace(tesseract_cmd=""),
+    image_to_data=lambda *a, **k: {"text": [], "conf": []},
+)
+sys.modules.setdefault("pytesseract", pytesseract_stub)
+os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
+cv2_stub = types.SimpleNamespace(
+    cvtColor=lambda src, code: src,
+    resize=lambda img, *a, **k: img,
+    matchTemplate=lambda *a, **k: np.zeros((1, 1), dtype=np.float32),
+    minMaxLoc=lambda *a, **k: (0, 0, (0, 0), (0, 0)),
+    imread=lambda *a, **k: np.zeros((1, 1), dtype=np.uint8),
+    imwrite=lambda *a, **k: True,
+    medianBlur=lambda src, k: src,
+    bitwise_not=lambda src: src,
+    rectangle=lambda img, pt1, pt2, color, thickness: img,
+    threshold=lambda src, *a, **k: (None, src),
+    bilateralFilter=lambda src, d, sigmaColor, sigmaSpace: src,
+    adaptiveThreshold=lambda src, maxValue, adaptiveMethod, thresholdType, blockSize, C: src,
+    dilate=lambda src, kernel, iterations=1: src,
+    equalizeHist=lambda src: src,
+    countNonZero=lambda src: int(np.count_nonzero(src)),
+    normalize=lambda src, *a, **k: src,
+    NORM_MINMAX=0,
+    IMREAD_GRAYSCALE=0,
+    COLOR_BGR2GRAY=0,
+    TM_CCOEFF_NORMED=0,
+)
+sys.modules.setdefault("cv2", cv2_stub)
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import script.resources as resources
+
+
+class TestDetectHud(TestCase):
+    def test_returns_box_and_score(self):
+        frame = np.zeros((100, 100, 3), dtype=np.uint8)
+        dummy_template = np.zeros((10, 10, 3), dtype=np.uint8)
+        with patch.object(resources.screen_utils, "HUD_TEMPLATE", dummy_template), \
+             patch("script.resources.find_template", return_value=((1, 2, 3, 4), 0.9, None)):
+            box, score = resources.detect_hud(frame)
+        self.assertEqual(box, (1, 2, 3, 4))
+        self.assertEqual(score, 0.9)
+

--- a/tools/detect_hud.py
+++ b/tools/detect_hud.py
@@ -9,8 +9,8 @@ import script.resources as resources
 
 def main():
     frame = screen_utils._grab_frame()
-    box = resources.detect_hud(frame)
-    print(box)
+    box, score = resources.detect_hud(frame)
+    print(box, score)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- include match score in detect_hud results and adjust resource panel lookup
- show detection score in detect_hud tool
- add regression test for detect_hud score

## Testing
- `pytest` *(fails: execute_ocr_warns_low_mean_confidence, execute_ocr_warns_low_min_confidence, handle_ocr_failure_low_confidence_fallback, handle_ocr_failure_raises, stone_stockpile_expands_narrow_roi, low_confidence_single_digit_triggers_retry, low_confidence_triggers_retry, narrow_roi_failure_includes_note, optional_icon_failure_does_not_raise, read_resources_fallback, zero_confidence_triggers_failure, gather_hud_stats_succeeds_after_sliding, ocr_reads_values_from_rois, default_value_returned_after_threshold, expired_cache_used_after_consecutive_failures, required_icon_fallback, retry_succeeds_after_expansion, sliding_window_succeeds_when_anchor_right, per_icon_min_width)`

------
https://chatgpt.com/codex/tasks/task_e_68b2305a094c8325bca7a3f657c87a04