### PR TITLE
Handle mission functions requiring info

### DIFF
--- a/campaign.py
+++ b/campaign.py
@@ -5,6 +5,7 @@ import logging
 import re
 import time
 from pathlib import Path
+import inspect
 
 import script.common as common
 import script.hud as hud
@@ -158,7 +159,14 @@ def main():
             raise SystemExit(
                 f"Mission module '{module_name}' lacks run_mission or main"
             )
-        func()
+        sig = inspect.signature(func)
+        accepts_info = "info" in sig.parameters
+        logger.info("Starting mission '%s'.", module_name)
+        if accepts_info:
+            func(info)
+        else:
+            func()
+        logger.info("Mission '%s' completed.", module_name)
     finally:
         screen_utils.teardown_sct()
 


### PR DESCRIPTION
## Summary
- Load mission entry point and inspect its signature
- Pass scenario info to missions that accept it and log mission start/end

## Testing
- `pytest -q` *(fails: 9 failed, 26 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2440e72548325a5896763da45557d