### PR TITLE
Log OCR threshold decay

### DIFF
--- a/script/resources/ocr.py
+++ b/script/resources/ocr.py
@@ -164,10 +164,12 @@ def execute_ocr(
         if conf_threshold <= min_conf:
             digits, data, mask = best_digits, best_data, best_mask
             break
-        prev_conf = conf_threshold
+        old_threshold = conf_threshold
         conf_threshold = max(min_conf, conf_threshold * decay)
         logger.debug(
-            "Lowering OCR confidence threshold from %d to %d", prev_conf, conf_threshold
+            "Lowering OCR confidence threshold from %d to %d",
+            old_threshold,
+            conf_threshold,
         )
         attempts += 1
     else:

--- a/tests/test_ocr_conf_decay_logging.py
+++ b/tests/test_ocr_conf_decay_logging.py
@@ -1,0 +1,90 @@
+import os
+import sys
+import types
+from unittest import TestCase
+from unittest.mock import patch
+
+import numpy as np
+
+# Stub external dependencies before importing the module under test
+os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
+
+dummy_pg = types.SimpleNamespace(
+    PAUSE=0,
+    FAILSAFE=False,
+    size=lambda: (200, 200),
+    click=lambda *a, **k: None,
+    moveTo=lambda *a, **k: None,
+    press=lambda *a, **k: None,
+)
+
+
+class DummyMSS:
+    monitors = [{}, {"left": 0, "top": 0, "width": 200, "height": 200}]
+
+    def grab(self, region):
+        h, w = region["height"], region["width"]
+        return np.zeros((h, w, 4), dtype=np.uint8)
+
+
+dummy_cv2 = types.SimpleNamespace(
+    cvtColor=lambda src, code: src,
+    resize=lambda img, *a, **k: img,
+    matchTemplate=lambda *a, **k: np.zeros((1, 1), dtype=np.float32),
+    minMaxLoc=lambda *a, **k: (0, 0, (0, 0), (0, 0)),
+    imread=lambda *a, **k: np.zeros((1, 1), dtype=np.uint8),
+    imwrite=lambda *a, **k: True,
+    medianBlur=lambda src, k: src,
+    bitwise_not=lambda src: src,
+    threshold=lambda src, *a, **k: (None, src),
+    rectangle=lambda img, pt1, pt2, color, thickness: img,
+    IMREAD_GRAYSCALE=0,
+    COLOR_BGR2GRAY=0,
+    INTER_LINEAR=0,
+    THRESH_BINARY=0,
+    THRESH_OTSU=0,
+    TM_CCOEFF_NORMED=0,
+)
+
+sys.modules.setdefault("pyautogui", dummy_pg)
+sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
+sys.modules.setdefault("cv2", dummy_cv2)
+sys.modules.setdefault(
+    "pytesseract",
+    types.SimpleNamespace(
+        image_to_data=lambda *a, **k: {"text": [""], "conf": ["0"]},
+        image_to_string=lambda *a, **k: "",
+        Output=types.SimpleNamespace(DICT="dict"),
+        pytesseract=types.SimpleNamespace(tesseract_cmd=""),
+    ),
+)
+
+# Make sure the script package is importable
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import script.resources.ocr as ocr
+
+
+class TestOcrConfDecayLogging(TestCase):
+    def test_logs_old_and_new_threshold_after_decay(self):
+        gray = np.zeros((10, 10), dtype=np.uint8)
+
+        def fake_ocr(_gray):
+            return "1", {"text": ["1"], "conf": ["50"]}, None
+
+        with patch.object(ocr, "_ocr_digits_better", side_effect=fake_ocr):
+            with patch.dict(
+                ocr.CFG,
+                {"ocr_conf_threshold": 60, "ocr_conf_decay": 0.5},
+                clear=False,
+            ):
+                with self.assertLogs(ocr.logger, level="DEBUG") as cm:
+                    ocr.execute_ocr(gray)
+
+        record = next(
+            r for r in cm.records if "OCR confidence threshold" in r.getMessage()
+        )
+        old, new = record.args
+        self.assertNotEqual(old, new)
+        self.assertEqual(old, 60)
+        self.assertEqual(new, 30)


### PR DESCRIPTION
## Summary
- capture previous OCR confidence threshold before applying decay
- log both old and new thresholds to show decay progression
- add unit test ensuring log records distinct threshold values after decay step

## Testing
- `pytest tests/test_ocr_conf_decay_logging.py -q`
- `pytest -q` *(fails: ResourceReadError and other assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b2541da8f883259a502e33b8e44d45