### PR TITLE
Fix incorrect buildings module path

### DIFF
--- a/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
+++ b/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
@@ -20,7 +20,7 @@ import script.hud as hud
 import script.resources as resources
 import script.input_utils as input_utils
 from script.units import villager
-from script.buldings.town_center import train_villagers
+from script.buildings.town_center import train_villagers
 from script.config_utils import parse_scenario_info
 
 logger = logging.getLogger(__name__)

--- a/tests/test_internal_population.py
+++ b/tests/test_internal_population.py
@@ -33,7 +33,7 @@ os.environ.setdefault("TESSERACT_CMD", "/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
-import script.buldings.town_center as tc
+import script.buildings.town_center as tc
 import script.units.villager as villager
 import script.config_utils as config_utils
 import script.hud as hud
@@ -66,8 +66,8 @@ class TestInternalPopulation(TestCase):
             "script.resources.read_resources_from_hud",
             return_value=({"food_stockpile": 500}, (None, None)),
         ), \
-             patch("script.buldings.town_center.build_house", side_effect=fake_build_house) as build_house_mock, \
-             patch("script.buldings.town_center.select_idle_villager", return_value=True), \
+             patch("script.buildings.town_center.build_house", side_effect=fake_build_house) as build_house_mock, \
+             patch("script.buildings.town_center.select_idle_villager", return_value=True), \
              patch("script.hud.read_population_from_hud") as read_pop_mock:
             tc.train_villagers(7)
             self.assertEqual(common.CURRENT_POP, 7)

--- a/tests/test_missing_resource_bar.py
+++ b/tests/test_missing_resource_bar.py
@@ -31,7 +31,7 @@ sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
-import script.buldings.town_center as tc
+import script.buildings.town_center as tc
 import script.units.villager as villager
 
 
@@ -43,8 +43,8 @@ class TestMissingResourceBar(TestCase):
             "script.resources.read_resources_from_hud",
             side_effect=common.ResourceReadError("missing"),
         ), \
-             patch("script.buldings.town_center.select_idle_villager", return_value=True), \
-             patch("script.buldings.town_center.build_house"):
+             patch("script.buildings.town_center.select_idle_villager", return_value=True), \
+             patch("script.buildings.town_center.build_house"):
             tc.train_villagers(5)
         self.assertEqual(common.CURRENT_POP, 3)
 


### PR DESCRIPTION
## Summary
- rename imports from `script.buldings` to `script.buildings`
- update related test patches

## Testing
- `pytest` *(fails: 31 failed, 81 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b25564fec8832589d219c67bae41a4