### PR TITLE
Aggregate starting resource discrepancies

### DIFF
--- a/script/resources/__init__.py
+++ b/script/resources/__init__.py
@@ -491,15 +491,16 @@ def validate_starting_resources(
 ) -> None:
     if not expected:
         return
-
+    errors: list[str] = []
     for name, exp in expected.items():
         actual = current.get(name)
         if actual is None:
             msg = f"Missing OCR reading for '{name}'"
             if raise_on_error:
                 logger.error(msg)
-                raise ValueError(msg)
-            logger.warning(msg)
+                errors.append(msg)
+            else:
+                logger.warning(msg)
             continue
 
         if abs(actual - exp) > tolerance:
@@ -521,8 +522,12 @@ def validate_starting_resources(
                 msg += f"; ROI saved to {roi_path}"
             if raise_on_error:
                 logger.error(msg)
-                raise ValueError(msg)
-            logger.warning(msg)
+                errors.append(msg)
+            else:
+                logger.warning(msg)
+
+    if errors and raise_on_error:
+        raise ValueError("; ".join(errors))
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- accumulate all missing or mismatched resources before raising error in `validate_starting_resources`
- test aggregation of discrepancies and per-resource ROI saving

## Testing
- `pytest tests/test_resource_helpers.py::TestValidateStartingResources::test_aggregates_all_discrepancies_and_saves_each_roi -q`
- `pytest -q` *(fails: PopulationReadError and other assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b25ab8ff348325b4f74024fc2fef1a