### PR TITLE
Handle missing starting resources

### DIFF
--- a/campaign.py
+++ b/campaign.py
@@ -69,8 +69,15 @@ def main():
         common.TARGET_POP = info.objective_villagers
         try:
             icon_cfg = common.CFG.get("hud_icons", {})
-            non_zero = {k: v for k, v in info.starting_resources.items() if v}
-            zero_icons = {k for k, v in info.starting_resources.items() if v == 0}
+            if info.starting_resources is None:
+                logger.warning(
+                    "No starting resources specified; skipping validation."
+                )
+                starting_res = {}
+            else:
+                starting_res = info.starting_resources
+            non_zero = {k: v for k, v in starting_res.items() if v}
+            zero_icons = {k for k, v in starting_res.items() if v == 0}
             required = [i for i in icon_cfg.get("required", []) if i not in zero_icons]
             optional = [i for i in icon_cfg.get("optional", []) if i not in zero_icons]
             res, (cur_pop, pop_cap) = resources.gather_hud_stats(
@@ -78,57 +85,58 @@ def main():
                 required_icons=required,
                 optional_icons=optional,
             )
-            try:
-                resources.validate_starting_resources(
-                    res,
-                    non_zero,
-                    tolerance=10,
-                    raise_on_error=True,
-                )
-            except ValueError as e:
-                logger.warning("Starting resource validation failed: %s", e)
-                # Retry OCR once more and attempt to save ROI diagnostics
-                res, (cur_pop, pop_cap) = resources.gather_hud_stats(
-                    force_delay=0.2,
-                    required_icons=required,
-                    optional_icons=optional,
-                )
-                frame = screen_utils._grab_frame()
-                rois = getattr(resources, "_LAST_REGION_BOUNDS", {})
+            if non_zero:
                 try:
                     resources.validate_starting_resources(
                         res,
                         non_zero,
                         tolerance=10,
                         raise_on_error=True,
-                        frame=frame,
-                        rois=rois,
                     )
-                except ValueError as e2:
-                    logger.error(
-                        "Second resource validation failed: %s", e2
+                except ValueError as e:
+                    logger.warning("Starting resource validation failed: %s", e)
+                    # Retry OCR once more and attempt to save ROI diagnostics
+                    res, (cur_pop, pop_cap) = resources.gather_hud_stats(
+                        force_delay=0.2,
+                        required_icons=required,
+                        optional_icons=optional,
                     )
-                    max_dev = 0
-                    for k, v in non_zero.items():
-                        actual = res.get(k)
-                        if actual is None:
-                            max_dev = float("inf")
-                            break
-                        max_dev = max(max_dev, abs(actual - v))
-                    if max_dev <= 20:
-                        logger.warning(
-                            "Resource readings close to expected; continuing."
-                        )
+                    frame = screen_utils._grab_frame()
+                    rois = getattr(resources, "_LAST_REGION_BOUNDS", {})
+                    try:
                         resources.validate_starting_resources(
                             res,
                             non_zero,
                             tolerance=10,
-                            raise_on_error=False,
+                            raise_on_error=True,
                             frame=frame,
                             rois=rois,
                         )
-                    else:
-                        raise
+                    except ValueError as e2:
+                        logger.error(
+                            "Second resource validation failed: %s", e2
+                        )
+                        max_dev = 0
+                        for k, v in non_zero.items():
+                            actual = res.get(k)
+                            if actual is None:
+                                max_dev = float("inf")
+                                break
+                            max_dev = max(max_dev, abs(actual - v))
+                        if max_dev <= 20:
+                            logger.warning(
+                                "Resource readings close to expected; continuing.",
+                            )
+                            resources.validate_starting_resources(
+                                res,
+                                non_zero,
+                                tolerance=10,
+                                raise_on_error=False,
+                                frame=frame,
+                                rois=rois,
+                            )
+                        else:
+                            raise
             logger.info(
                 "Detected resources: wood=%s, food=%s, gold=%s, stone=%s",
                 res.get("wood_stockpile"),

--- a/tests/test_campaign_starting_resources_none.py
+++ b/tests/test_campaign_starting_resources_none.py
@@ -1,0 +1,68 @@
+import os
+import sys
+import types
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+# Ensure dummy modules for pyautogui and mss etc as in other tests
+
+dummy_pg = types.SimpleNamespace(
+    PAUSE=0,
+    FAILSAFE=False,
+    size=lambda: (200, 200),
+    click=lambda *a, **k: None,
+    moveTo=lambda *a, **k: None,
+    press=lambda *a, **k: None,
+)
+
+
+class DummyMSS:
+    monitors = [{}, {"left": 0, "top": 0, "width": 200, "height": 200}]
+
+    def grab(self, region):
+        h, w = region["height"], region["width"]
+        return np.zeros((h, w, 4), dtype=np.uint8)
+
+
+sys.modules.setdefault("pyautogui", dummy_pg)
+sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
+os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import campaign
+
+
+class TestCampaignNoStartingResources(TestCase):
+    def test_skips_validation_when_starting_resources_none(self):
+        info = types.SimpleNamespace(
+            starting_resources=None,
+            starting_villagers=3,
+            objective_villagers=5,
+        )
+
+        logger_mock = MagicMock()
+        validate_mock = MagicMock()
+
+        with patch("campaign.parse_scenario_info", return_value=info), \
+            patch(
+                "campaign.argparse.ArgumentParser.parse_args",
+                return_value=types.SimpleNamespace(scenario="dummy"),
+            ), \
+            patch("campaign.screen_utils.init_sct"), \
+            patch("campaign.screen_utils.teardown_sct"), \
+            patch("campaign.hud.wait_hud", return_value=({}, "asset")), \
+            patch("campaign.resources.gather_hud_stats", return_value=({}, (0, 0))), \
+            patch("campaign.resources.validate_starting_resources", validate_mock), \
+            patch("campaign.logging.getLogger", return_value=logger_mock):
+            campaign.main()
+
+        validate_mock.assert_not_called()
+        self.assertTrue(
+            any(
+                "starting resources" in str(c.args[0]).lower()
+                for c in logger_mock.warning.call_args_list
+            )
+        )


### PR DESCRIPTION
## Summary
- skip starting resource validation when scenario lacks resource data and warn
- add regression test for missing starting resource info

## Testing
- `pytest` *(fails: 22 failed, 92 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b25bcec92c83259e0d8bc0ddba5057