### PR TITLE
Reuse OCR confidence parsing and ignore negative values

### DIFF
--- a/script/resources/__init__.py
+++ b/script/resources/__init__.py
@@ -145,11 +145,7 @@ def _read_resources(
                 output_type=pytesseract.Output.DICT,
             )
             texts = [t for t in data.get("text", []) if t.strip()]
-            confidences = [
-                float(c)
-                for c in data.get("conf", [])
-                if c not in ("-1", "")
-            ]
+            confidences = ocr.parse_confidences(data)
             if texts and confidences and all(
                 c >= res_conf_threshold for c in confidences
             ):

--- a/script/resources/ocr.py
+++ b/script/resources/ocr.py
@@ -13,6 +13,20 @@ from . import cache
 logger = logging.getLogger(__name__)
 
 
+def parse_confidences(data):
+    """Convert OCR confidence values to floats, ignoring negatives."""
+
+    confs = []
+    for c in data.get("conf", []):
+        try:
+            val = float(c)
+        except (ValueError, TypeError):
+            continue
+        if val >= 0:
+            confs.append(val)
+    return confs
+
+
 def preprocess_roi(roi):
     """Convert ROI to a blurred grayscale image."""
 
@@ -156,7 +170,7 @@ def execute_ocr(
     attempts = 0
     max_attempts = CFG.get("ocr_conf_max_attempts", 10)
     while digits and data.get("conf") and attempts < max_attempts:
-        confs = [float(c) for c in data.get("conf", []) if c not in ("-1", "")]
+        confs = parse_confidences(data)
         if confs and min(confs) >= conf_threshold:
             low_conf = False
             break

--- a/tests/test_resource_helpers.py
+++ b/tests/test_resource_helpers.py
@@ -199,6 +199,18 @@ class TestExecuteOcr(TestCase):
         img2str_mock.assert_not_called()
         ocr_mock.assert_called_once()
 
+    def test_execute_ocr_ignores_negative_confidences(self):
+        gray = np.zeros((5, 5), dtype=np.uint8)
+        data = {"text": ["12"], "conf": [-1, "95"]}
+        with patch("script.resources.ocr._ocr_digits_better", return_value=("12", data, None)), \
+             patch("script.resources.pytesseract.image_to_string", return_value="") as img2str_mock:
+            digits, _, _, low_conf = resources.execute_ocr(
+                gray, conf_threshold=60, resource="wood_stockpile"
+            )
+        self.assertEqual(digits, "12")
+        self.assertFalse(low_conf)
+        img2str_mock.assert_not_called()
+
 
 class TestHandleOcrFailure(TestCase):
     def test_handle_ocr_failure_raises(self):


### PR DESCRIPTION
## Summary
- add `parse_confidences` helper to normalize OCR confidence values and drop negatives
- use helper in OCR paths and idle-villager OCR
- add tests ensuring negative confidence entries are ignored

## Testing
- `pytest tests/test_resource_helpers.py::TestExecuteOcr::test_execute_ocr_ignores_negative_confidences -q`
- `pytest tests/test_idle_villager_ocr.py::TestIdleVillagerOCR::test_idle_villager_ignores_negative_confidences -q`
- `pytest -q` *(fails: 22 failed, 94 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b25ea4fa6c8325ac93f7e8772cee52