### PR TITLE
Cap food ROI width and sanitize OCR results

### DIFF
--- a/script/resources/ocr.py
+++ b/script/resources/ocr.py
@@ -27,6 +27,21 @@ def parse_confidences(data):
     return confs
 
 
+def _sanitize_digits(digits: str) -> str:
+    """Trim OCR output to at most three significant digits.
+
+    Trailing zeros are stripped first; if the result still contains more
+    than three digits, only the three most significant digits are kept.
+    """
+
+    if len(digits) <= 3:
+        return digits
+    trimmed = digits.rstrip("0")
+    if len(trimmed) <= 3:
+        return trimmed
+    return trimmed[:3]
+
+
 def preprocess_roi(roi):
     """Convert ROI to a blurred grayscale image."""
 
@@ -207,6 +222,7 @@ def execute_ocr(
             mask = None
             low_conf = True
     if not digits and best_digits:
+        best_digits = _sanitize_digits(best_digits)
         return best_digits, best_data, best_mask, True
     if not digits:
         debug_dir = ROOT / "debug"
@@ -259,7 +275,10 @@ def execute_ocr(
                     roi_path,
                     text_path,
                 )
+        digits = _sanitize_digits(digits)
         return digits, data, mask, True
+    if digits:
+        digits = _sanitize_digits(digits)
     return digits, data, mask, low_conf
 
 

--- a/script/resources/panel.py
+++ b/script/resources/panel.py
@@ -78,7 +78,6 @@ def compute_resource_rois(
         min_requireds = [0] * len(RESOURCE_ICON_ORDER)
     if detected is None:
         detected = {}
-
     regions = {}
     spans = {}
     narrow = {}
@@ -91,6 +90,10 @@ def compute_resource_rois(
 
         pad_l = pad_left[idx] if idx < len(pad_left) else pad_left[-1]
         pad_r = pad_right[idx] if idx < len(pad_right) else pad_right[-1]
+
+        if current == "food_stockpile":
+            pad_l = max(pad_l, 2)
+            pad_r = max(pad_r, 2)
 
         cur_x, _cy, cur_w, _ch = cur_bounds
         cur_trim_val = icon_trims[idx] if idx < len(icon_trims) else icon_trims[-1]
@@ -128,6 +131,8 @@ def compute_resource_rois(
 
         available_width = right - left
         max_w = max_widths[idx] if idx < len(max_widths) else max_widths[-1]
+        if current == "food_stockpile":
+            max_w = min(max_w, 50)
         width = min(max_w, available_width)
 
         min_req = min_requireds[idx] if idx < len(min_requireds) else min_requireds[-1]


### PR DESCRIPTION
## Summary
- ensure `compute_resource_rois` limits `food_stockpile` to a narrow region (<50px) with minimum padding
- add `_sanitize_digits` to trim trailing zeros and keep at most three digits from OCR output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and PopulationReadError)*
- `pytest tests/test_resource_helpers.py::TestExecuteOcr::test_execute_ocr_accepts_after_threshold_decay -q` *(fails: expected mock called once)*

------
https://chatgpt.com/codex/tasks/task_e_68b2715386648325830228e1f35930eb