### PR TITLE
Fix digit sanitization and add unit tests

### DIFF
--- a/script/resources/ocr.py
+++ b/script/resources/ocr.py
@@ -30,15 +30,17 @@ def parse_confidences(data):
 def _sanitize_digits(digits: str) -> str:
     """Trim OCR output to at most three significant digits.
 
-    Trailing zeros are stripped first; if the result still contains more
-    than three digits, only the three most significant digits are kept.
+    Trailing zeros are stripped *after* limiting to three digits to ensure
+    values like ``1400`` are sanitised to ``140`` instead of ``14``.
     """
 
     if len(digits) <= 3:
         return digits
+
+    first_three = digits[:3]
     trimmed = digits.rstrip("0")
     if len(trimmed) <= 3:
-        return trimmed
+        return first_three
     return trimmed[:3]
 
 

--- a/tests/test_sanitize_digits.py
+++ b/tests/test_sanitize_digits.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import types
+from unittest import TestCase
+
+import numpy as np
+
+
+dummy_pg = types.SimpleNamespace(
+    PAUSE=0,
+    FAILSAFE=False,
+    size=lambda: (200, 200),
+    click=lambda *a, **k: None,
+    moveTo=lambda *a, **k: None,
+    press=lambda *a, **k: None,
+)
+
+
+class DummyMSS:
+    monitors = [{}, {"left": 0, "top": 0, "width": 200, "height": 200}]
+
+    def grab(self, region):
+        h, w = region["height"], region["width"]
+        return np.zeros((h, w, 4), dtype=np.uint8)
+
+
+sys.modules.setdefault("pyautogui", dummy_pg)
+sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
+
+dummy_cv2 = types.SimpleNamespace(
+    cvtColor=lambda src, code: src,
+    resize=lambda img, *a, **k: img,
+    matchTemplate=lambda *a, **k: np.zeros((1, 1), dtype=np.float32),
+    minMaxLoc=lambda *a, **k: (0, 0, (0, 0), (0, 0)),
+    imread=lambda *a, **k: np.zeros((1, 1), dtype=np.uint8),
+    imwrite=lambda *a, **k: True,
+    medianBlur=lambda src, k: src,
+    bitwise_not=lambda src: src,
+    threshold=lambda src, *a, **k: (None, src),
+    rectangle=lambda img, pt1, pt2, color, thickness: img,
+    IMREAD_GRAYSCALE=0,
+    COLOR_BGR2GRAY=0,
+    INTER_LINEAR=0,
+    THRESH_BINARY=0,
+    THRESH_OTSU=0,
+    TM_CCOEFF_NORMED=0,
+)
+sys.modules.setdefault("cv2", dummy_cv2)
+sys.modules.setdefault(
+    "pytesseract",
+    types.SimpleNamespace(
+        image_to_data=lambda *a, **k: {"text": [""], "conf": ["0"]},
+        image_to_string=lambda *a, **k: "",
+        Output=types.SimpleNamespace(DICT="dict"),
+        pytesseract=types.SimpleNamespace(tesseract_cmd=""),
+    ),
+)
+
+os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from script.resources.ocr import _sanitize_digits
+
+
+class TestSanitizeDigits(TestCase):
+    def test_1400(self):
+        self.assertEqual(_sanitize_digits("1400"), "140")
+
+    def test_800(self):
+        self.assertEqual(_sanitize_digits("800"), "800")
+
+    def test_1000(self):
+        self.assertEqual(_sanitize_digits("1000"), "100")


### PR DESCRIPTION
## Summary
- ensure `_sanitize_digits` keeps the first three digits before stripping trailing zeros
- add tests for digit sanitization edge cases

## Testing
- `python -m pytest tests/test_sanitize_digits.py -q`
- `TESSERACT_CMD=/usr/bin/true python -m pytest -q --maxfail=1` *(fails: SystemExit: Mission module 'dummy' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b27b61b7bc8325904793e6bc731f0d