### PR TITLE
Add food stockpile top crop override

### DIFF
--- a/config.json
+++ b/config.json
@@ -34,7 +34,11 @@
     "//ocr_roi_expand_growth": "Exponent controlling ROI growth rate; >1 grows faster.",
     "ocr_kernel_size": 1,
     "ocr_top_crop": 1,
-    "ocr_top_crop_overrides": {"wood_stockpile": 0},
+    "ocr_top_crop_overrides": {
+      "wood_stockpile": 0,
+      "food_stockpile": 0
+    },
+    "//ocr_top_crop_overrides": "Disable top cropping for wood and food stockpiles to avoid clipping digits.",
     "ocr_blur_kernel": 1,
     "//ocr_blur_kernel": "Median blur kernel before OCR; set >1 to enable; 0 disables.",
     "ocr_bilateral": [7, 60, 60],


### PR DESCRIPTION
## Summary
- avoid clipping digits on food stockpile by disabling top crop

## Testing
- `python -m json.tool config.json`
- `python - <<'PY'
import script.config_utils as cu
cu.load_config('config.json')
print('config OK')
PY`
- `pytest tests/test_resource_custom_rois.py tests/test_validate_keys.py tests/test_load_config_errors.py tests/test_idle_villager_custom_roi.py`
- `pytest tests/test_ocr_config.py tests/test_resource_custom_rois.py tests/test_validate_keys.py tests/test_load_config_errors.py tests/test_idle_villager_custom_roi.py` *(fails: AssertionError (3, 3) not found in [(1, 1)])*

------
https://chatgpt.com/codex/tasks/task_e_68b32159f0f08325ab6582d288724373