### PR TITLE
Add wood stockpile OCR mask and tests

### DIFF
--- a/tests/test_wood_stockpile_ocr.py
+++ b/tests/test_wood_stockpile_ocr.py
@@ -1,0 +1,58 @@
+import os
+import sys
+import types
+import shutil
+from unittest import TestCase
+
+import cv2
+import numpy as np
+
+# Stub modules requiring a display
+
+dummy_pg = types.SimpleNamespace(
+    PAUSE=0,
+    FAILSAFE=False,
+    size=lambda: (200, 200),
+    click=lambda *a, **k: None,
+    moveTo=lambda *a, **k: None,
+    press=lambda *a, **k: None,
+)
+
+
+class DummyMSS:
+    monitors = [{}, {"left": 0, "top": 0, "width": 200, "height": 200}]
+
+    def grab(self, region):
+        h, w = region["height"], region["width"]
+        return np.zeros((h, w, 4), dtype=np.uint8)
+
+
+sys.modules.setdefault("pyautogui", dummy_pg)
+sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
+
+_TESS_PATH = shutil.which("tesseract") or "/usr/bin/tesseract"
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import script.resources.ocr as ocr
+
+
+class TestWoodStockpileOCR(TestCase):
+    def setUp(self):
+        self._old_cmd = os.environ.get("TESSERACT_CMD")
+        os.environ["TESSERACT_CMD"] = _TESS_PATH
+
+    def tearDown(self):
+        if self._old_cmd is None:
+            os.environ.pop("TESSERACT_CMD", None)
+        else:
+            os.environ["TESSERACT_CMD"] = self._old_cmd
+    def test_wood_stockpile_high_confidence(self):
+        roi = np.full((60, 120, 3), (19, 69, 139), dtype=np.uint8)
+        cv2.putText(roi, "123", (5, 50), cv2.FONT_HERSHEY_SIMPLEX, 2, (255, 255, 255), 3)
+        gray = ocr.preprocess_roi(roi)
+        digits, data, _mask, low_conf = ocr.execute_ocr(gray, resource="wood_stockpile")
+        confs = ocr.parse_confidences(data)
+        threshold = ocr.CFG.get("ocr_conf_threshold", 60)
+        self.assertTrue(digits.isdigit())
+        self.assertGreaterEqual(np.median(confs), threshold)
+        self.assertFalse(low_conf)


### PR DESCRIPTION
## Summary
- pass resource context into `_ocr_digits_better`
- improve wood stockpile OCR with brown mask and morphology
- add high-confidence test for wood stockpile OCR

## Testing
- `python -m pytest tests/test_wood_stockpile_ocr.py::TestWoodStockpileOCR::test_wood_stockpile_high_confidence -q`
- `TESSERACT_CMD=/usr/bin/true pytest -q` *(fails: Mission module 'dummy' not found, PopulationReadError)*

------
https://chatgpt.com/codex/tasks/task_e_68b332c76cd88325813165002886e800