### PR TITLE
Clarify low-confidence OCR handling in resource detection

### DIFF
--- a/script/resources/__init__.py
+++ b/script/resources/__init__.py
@@ -367,6 +367,11 @@ def _read_resources(
                     )
                 else:
                     results[name] = None
+                    logger.warning(
+                        "Discarding %s=%d due to low-confidence OCR",
+                        name,
+                        value,
+                    )
                 low_confidence.add(name)
             else:
                 results[name] = value
@@ -376,7 +381,8 @@ def _read_resources(
                     cache_obj.resource_failure_counts[name] = 0
                 else:
                     low_confidence.add(name)
-            logger.info("Detected %s=%d", name, value)
+            if results.get(name) is not None:
+                logger.info("Detected %s=%d", name, value)
 
     filtered_regions = {n: regions[n] for n in resource_icons if n in regions}
     required_for_ocr = [n for n in required_icons if n != "population_limit"]


### PR DESCRIPTION
## Summary
- Warn when resource OCR is discarded for low confidence and log detected values only when results are valid
- Test low-confidence OCR logging behavior and ensure low-confidence reads return None

## Testing
- `pytest tests/test_resource_ocr_failure.py::TestResourceOcrFailure::test_low_confidence_logs_warning tests/test_resource_ocr_failure.py::TestResourceOcrFailure::test_low_confidence_returns_none -q`

------
https://chatgpt.com/codex/tasks/task_e_68b33705d1908325aa55605998d291b0