### PR TITLE
Adjust wood stockpile ROI for wider digit capture

### DIFF
--- a/config.json
+++ b/config.json
@@ -96,8 +96,8 @@
   "wood_stockpile_roi": {
     "top_pct": 0.111,
     "height_pct": 0.025,
-    "left_pct": 0.186,
-    "width_pct": 0.036
+    "left_pct": 0.191,
+    "width_pct": 0.042
   },
   "food_stockpile_roi": {
     "top_pct": 0.111,


### PR DESCRIPTION
## Summary
- expand `wood_stockpile_roi` to start after the icon and cover three digits

## Testing
- `pytest` *(fails: SystemExit: Invalid tesseract version and numerous assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68b33c963a4883259bc3e42cc85376ff