### PR TITLE
Calibrate wood and food stockpile ROIs

### DIFF
--- a/config.json
+++ b/config.json
@@ -96,14 +96,14 @@
   "wood_stockpile_roi": {
     "top_pct": 0.111,
     "height_pct": 0.025,
-    "left_pct": 0.191,
-    "width_pct": 0.042
+    "left_pct": 0.187,
+    "width_pct": 0.048
   },
   "food_stockpile_roi": {
     "top_pct": 0.111,
     "height_pct": 0.025,
-    "left_pct": 0.233,
-    "width_pct": 0.039
+    "left_pct": 0.240,
+    "width_pct": 0.048
   },
   "gold_stockpile_roi": {
     "top_pct": 0.111,


### PR DESCRIPTION
## Summary
- Expand wood and food stockpile ROI widths and adjust offsets for 1920×1080 screens

## Testing
- `TESSERACT_CMD=$(which tesseract) pytest -q` *(fails: Mission module 'dummy' not found; PopulationReadError, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b3431272a083259948de96ebc02888