### PR TITLE
Ignore non-positive OCR confidences

### DIFF
--- a/script/resources/ocr.py
+++ b/script/resources/ocr.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def parse_confidences(data):
-    """Convert OCR confidence values to floats, ignoring negatives."""
+    """Convert OCR confidence values to floats, ignoring non-positive entries."""
 
     confs = []
     for c in data.get("conf", []):
@@ -22,7 +22,7 @@ def parse_confidences(data):
             val = float(c)
         except (ValueError, TypeError):
             continue
-        if val >= 0:
+        if val > 0:
             confs.append(val)
     return confs
 
@@ -503,7 +503,7 @@ def _read_population_from_roi(roi, conf_threshold=None, save_debug=True):
         output_type=pytesseract.Output.DICT,
     )
     text = "".join(data.get("text", [])).replace(" ", "")
-    confidences = [c for c in map(int, data.get("conf", [])) if c >= 0]
+    confidences = [c for c in map(int, data.get("conf", [])) if c > 0]
     parts = [p for p in text.split("/") if p]
     if len(parts) >= 2 and (not confidences or min(confidences) >= conf_threshold):
         cur = int("".join(filter(str.isdigit, parts[0])) or 0)

--- a/tests/test_idle_villager_ocr.py
+++ b/tests/test_idle_villager_ocr.py
@@ -63,7 +63,7 @@ class TestIdleVillagerOCR(TestCase):
         )
         exec_mock.assert_not_called()
 
-    def test_idle_villager_ignores_negative_confidences(self):
+    def test_idle_villager_ignores_non_positive_confidences(self):
         def fake_detect(frame, required_icons, cache=None):
             return {"idle_villager": (0, 0, 50, 50)}
 
@@ -72,7 +72,7 @@ class TestIdleVillagerOCR(TestCase):
              patch("script.screen_utils._grab_frame", return_value=frame), \
              patch(
                  "script.resources.pytesseract.image_to_data",
-                 return_value={"text": ["1", "2"], "conf": [-1, "95"]},
+                 return_value={"text": ["1", "2"], "conf": [-1, "0", "95"]},
              ) as img2data, \
              patch("script.resources.execute_ocr") as exec_mock:
             result, _ = resources.read_resources_from_hud(["idle_villager"])

--- a/tests/test_population_ocr_conf.py
+++ b/tests/test_population_ocr_conf.py
@@ -28,11 +28,11 @@ import script.resources as resources
 
 
 class TestPopulationOcrConfidence(TestCase):
-    def test_negative_confidences_are_ignored(self):
+    def test_non_positive_confidences_are_ignored(self):
         roi = np.zeros((10, 10, 3), dtype=np.uint8)
         with patch(
             "script.resources.pytesseract.image_to_data",
-            return_value={"text": ["3/4"], "conf": ["-1", "-1", "95"]},
+            return_value={"text": ["3/4"], "conf": ["-1", "0", "95"]},
         ):
             cur, cap = resources._read_population_from_roi(
                 roi, conf_threshold=60, save_debug=False

--- a/tests/test_resource_helpers.py
+++ b/tests/test_resource_helpers.py
@@ -199,9 +199,9 @@ class TestExecuteOcr(TestCase):
         img2str_mock.assert_not_called()
         ocr_mock.assert_called_once()
 
-    def test_execute_ocr_ignores_negative_confidences(self):
+    def test_execute_ocr_ignores_non_positive_confidences(self):
         gray = np.zeros((5, 5), dtype=np.uint8)
-        data = {"text": ["12"], "conf": [-1, "95"]}
+        data = {"text": ["12"], "conf": [-1, "0", "95"]}
         with patch("script.resources.ocr._ocr_digits_better", return_value=("12", data, None)), \
              patch("script.resources.pytesseract.image_to_string", return_value="") as img2str_mock:
             digits, _, _, low_conf = resources.execute_ocr(


### PR DESCRIPTION
## Summary
- Ignore zero and negative confidence values when parsing OCR output
- Update population OCR to disregard non-positive confidences
- Expand tests to include zero alongside negative confidences

## Testing
- `python - <<'PY'
import cv2, pytest, sys
sys.exit(pytest.main(['tests/test_population_ocr_conf.py','-q']))
PY`
- `python - <<'PY'
import cv2, pytest, sys
sys.exit(pytest.main(['tests/test_resource_helpers.py','-q']))
PY`
- `python - <<'PY'
import cv2, pytest, sys
sys.exit(pytest.main(['tests/test_idle_villager_ocr.py','-q']))
PY`
- `python - <<'PY'
import cv2, pytest, sys
sys.exit(pytest.main(['tests/test_wood_stockpile_ocr.py','-q']))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b34504562c832584d46462a49a862b