### PR TITLE
Implement multi-attempt starting resource validation

### DIFF
--- a/campaign.py
+++ b/campaign.py
@@ -86,57 +86,71 @@ def main():
                 optional_icons=optional,
             )
             if non_zero:
-                try:
-                    resources.validate_starting_resources(
-                        res,
-                        non_zero,
-                        tolerance=10,
-                        raise_on_error=True,
-                    )
-                except ValueError as e:
-                    logger.warning("Starting resource validation failed: %s", e)
-                    # Retry OCR once more and attempt to save ROI diagnostics
-                    res, (cur_pop, pop_cap) = resources.gather_hud_stats(
-                        force_delay=0.2,
-                        required_icons=required,
-                        optional_icons=optional,
-                    )
+                retry_limit = common.CFG.get("resource_validation_retries", 3)
+                tolerance = 10
+                max_tolerance = 15
+                relaxed_threshold = 20
+                attempt = 1
+                while True:
                     frame = screen_utils._grab_frame()
                     rois = getattr(resources, "_LAST_REGION_BOUNDS", {})
+                    logger.info(
+                        "Starting resource validation attempt %d/%d (±%d)",
+                        attempt,
+                        retry_limit,
+                        tolerance,
+                    )
                     try:
                         resources.validate_starting_resources(
                             res,
                             non_zero,
-                            tolerance=10,
+                            tolerance=tolerance,
                             raise_on_error=True,
                             frame=frame,
                             rois=rois,
                         )
-                    except ValueError as e2:
-                        logger.error(
-                            "Second resource validation failed: %s", e2
+                        break
+                    except ValueError as e:
+                        logger.warning(
+                            "Starting resource validation attempt %d failed: %s",
+                            attempt,
+                            e,
                         )
-                        max_dev = 0
-                        for k, v in non_zero.items():
-                            actual = res.get(k)
-                            if actual is None:
-                                max_dev = float("inf")
+                        if attempt >= retry_limit:
+                            max_dev = 0
+                            for k, v in non_zero.items():
+                                actual = res.get(k)
+                                if actual is None:
+                                    max_dev = float("inf")
+                                    break
+                                max_dev = max(max_dev, abs(actual - v))
+                            if max_dev <= relaxed_threshold:
+                                logger.warning(
+                                    "Resource readings within ±%d; continuing.",
+                                    relaxed_threshold,
+                                )
+                                resources.validate_starting_resources(
+                                    res,
+                                    non_zero,
+                                    tolerance=tolerance,
+                                    raise_on_error=False,
+                                    frame=frame,
+                                    rois=rois,
+                                )
                                 break
-                            max_dev = max(max_dev, abs(actual - v))
-                        if max_dev <= 20:
-                            logger.warning(
-                                "Resource readings close to expected; continuing.",
+                            else:
+                                raise
+                        attempt += 1
+                        tolerance = min(max_tolerance, tolerance + 5)
+                        for k in non_zero:
+                            resources._NARROW_ROI_DEFICITS[k] = (
+                                resources._NARROW_ROI_DEFICITS.get(k, 0) + 2
                             )
-                            resources.validate_starting_resources(
-                                res,
-                                non_zero,
-                                tolerance=10,
-                                raise_on_error=False,
-                                frame=frame,
-                                rois=rois,
-                            )
-                        else:
-                            raise
+                        res, (cur_pop, pop_cap) = resources.gather_hud_stats(
+                            force_delay=0.1 * attempt,
+                            required_icons=required,
+                            optional_icons=optional,
+                        )
             logger.info(
                 "Detected resources: wood=%s, food=%s, gold=%s, stone=%s",
                 res.get("wood_stockpile"),

--- a/tests/test_campaign_starting_resources_none.py
+++ b/tests/test_campaign_starting_resources_none.py
@@ -46,6 +46,8 @@ class TestCampaignNoStartingResources(TestCase):
         logger_mock = MagicMock()
         validate_mock = MagicMock()
 
+        dummy_module = types.SimpleNamespace(run_mission=lambda *a, **k: None)
+
         with patch("campaign.parse_scenario_info", return_value=info), \
             patch(
                 "campaign.argparse.ArgumentParser.parse_args",
@@ -56,7 +58,9 @@ class TestCampaignNoStartingResources(TestCase):
             patch("campaign.hud.wait_hud", return_value=({}, "asset")), \
             patch("campaign.resources.gather_hud_stats", return_value=({}, (0, 0))), \
             patch("campaign.resources.validate_starting_resources", validate_mock), \
-            patch("campaign.logging.getLogger", return_value=logger_mock):
+            patch("campaign.logging.getLogger", return_value=logger_mock), \
+            patch("campaign.resources.cv2.imwrite"), \
+            patch("importlib.import_module", return_value=dummy_module):
             campaign.main()
 
         validate_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- add retry loop to validate starting resources with progressive tolerance and ROI expansion
- allow mission to proceed when resource readings converge within ±20 even after failed attempts
- adjust tests for multi-attempt validation and dummy mission import

## Testing
- `pytest tests/test_campaign_resource_validation.py tests/test_campaign_starting_resources_none.py -q`
- `pytest -q` *(fails: PopulationReadError and missing mission modules in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b3463d96e8832580d6bd4deb577734