### PR TITLE
refactor: extract resource reader utilities

### DIFF
--- a/campaign.py
+++ b/campaign.py
@@ -9,7 +9,7 @@ import inspect
 
 import script.common as common
 import script.hud as hud
-import script.resources as resources
+import script.resources.reader as resources
 import script.screen_utils as screen_utils
 from script.config_utils import parse_scenario_info
 

--- a/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
+++ b/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
@@ -17,7 +17,7 @@ import os
 
 import script.common as common
 import script.hud as hud
-import script.resources as resources
+import script.resources.reader as resources
 import script.input_utils as input_utils
 from script.units import villager
 from script.buildings.town_center import train_villagers

--- a/campaigns/Ascent_of_Egypt/Egypt_2_Foraging.py
+++ b/campaigns/Ascent_of_Egypt/Egypt_2_Foraging.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import script.common as common
 import script.hud as hud
-import script.resources as resources
+import script.resources.reader as resources
 from script.config_utils import parse_scenario_info
 
 logger = logging.getLogger(__name__)

--- a/script/buildings/town_center.py
+++ b/script/buildings/town_center.py
@@ -2,7 +2,7 @@ import logging
 import time
 
 import script.common as common
-import script.resources as resources
+import script.resources.reader as resources
 import script.input_utils as input_utils
 from script.units.villager import build_house, select_idle_villager
 

--- a/script/hud.py
+++ b/script/hud.py
@@ -16,6 +16,7 @@ from .template_utils import find_template
 from .config_utils import load_config
 from . import screen_utils
 from . import common, resources, input_utils
+from .resources import reader as resource_reader
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -129,7 +130,7 @@ def read_population_from_hud(retries=1, conf_threshold=None, save_failed_roi=Fal
         )
         fallback_exc = None
         try:
-            _, (cur, limit) = resources.read_resources_from_hud(
+            _, (cur, limit) = resource_reader.read_resources_from_hud(
                 ["population_limit"], force_delay=0.1, conf_threshold=conf_threshold
             )
             if cur is not None and limit is not None:

--- a/script/resources/__init__.py
+++ b/script/resources/__init__.py
@@ -1,13 +1,11 @@
 """Resource handling package for HUD detection and OCR."""
 
 import logging
-import time
 from pathlib import Path
-from typing import Iterable
+from types import SimpleNamespace
 
 import cv2
 import numpy as np
-import pytesseract
 
 from ..config_utils import load_config
 from .. import screen_utils, common
@@ -27,7 +25,29 @@ RESOURCE_ICON_ORDER = [
 ]
 
 # Submodules
-from . import cache, ocr
+from . import cache, panel, ocr, reader
+
+# Re-export cache and helper functions
+ResourceCache = cache.ResourceCache
+RESOURCE_CACHE = cache.RESOURCE_CACHE
+_LAST_READ_FROM_CACHE = cache._LAST_READ_FROM_CACHE
+_NARROW_ROIS = cache._NARROW_ROIS
+_NARROW_ROI_DEFICITS = cache._NARROW_ROI_DEFICITS
+_RESOURCE_CACHE_TTL = cache._RESOURCE_CACHE_TTL
+_RESOURCE_CACHE_MAX_AGE = cache._RESOURCE_CACHE_MAX_AGE
+_RESOURCE_DEBUG_COOLDOWN = cache._RESOURCE_DEBUG_COOLDOWN
+_LAST_REGION_BOUNDS = cache._LAST_REGION_BOUNDS
+_LAST_REGION_SPANS = cache._LAST_REGION_SPANS
+
+
+def _screen_size():
+    monitor = screen_utils.get_monitor()
+    return monitor["width"], monitor["height"]
+
+
+input_utils = SimpleNamespace(_screen_size=_screen_size)
+
+# Panel helpers
 from .panel import (
     detect_hud,
     compute_resource_rois,
@@ -40,568 +60,25 @@ from .panel import (
     _recalibrate_low_variance,
     _remove_overlaps,
 )
-from types import SimpleNamespace
 
-# Re-export cache and helper functions
-ResourceCache = cache.ResourceCache
-RESOURCE_CACHE = cache.RESOURCE_CACHE
-_LAST_READ_FROM_CACHE = cache._LAST_READ_FROM_CACHE
-_NARROW_ROIS = cache._NARROW_ROIS
-_NARROW_ROI_DEFICITS = cache._NARROW_ROI_DEFICITS
-_RESOURCE_CACHE_TTL = cache._RESOURCE_CACHE_TTL
-_RESOURCE_DEBUG_COOLDOWN = cache._RESOURCE_DEBUG_COOLDOWN
-_LAST_REGION_BOUNDS = cache._LAST_REGION_BOUNDS
-_LAST_REGION_SPANS = cache._LAST_REGION_SPANS
+# OCR helpers
+from .ocr import (
+    preprocess_roi,
+    _ocr_digits_better,
+    execute_ocr,
+    handle_ocr_failure,
+    _read_population_from_roi,
+    read_population_from_roi,
+    _extract_population,
+)
 
-# Track last OCR failure reasons
-_LAST_LOW_CONFIDENCE: set[str] = set()
-_LAST_NO_DIGITS: set[str] = set()
-
-def _screen_size():
-    monitor = screen_utils.get_monitor()
-    return monitor["width"], monitor["height"]
-
-input_utils = SimpleNamespace(_screen_size=_screen_size)
-
-# OCR functions
-preprocess_roi = ocr.preprocess_roi
-_ocr_digits_better = ocr._ocr_digits_better
-execute_ocr = ocr.execute_ocr
-handle_ocr_failure = ocr.handle_ocr_failure
-_read_population_from_roi = ocr._read_population_from_roi
-read_population_from_roi = ocr.read_population_from_roi
-_extract_population = ocr._extract_population
-
-
-def _read_resources(
-    frame,
-    required_icons,
-    icons_to_read,
-    cache_obj: ResourceCache = RESOURCE_CACHE,
-    max_cache_age: float | None = None,
-    conf_threshold: int | None = None,
-):
-    required_icons = list(required_icons)
-    icons_to_read = list(icons_to_read)
-    required_set = set(required_icons)
-
-    regions = detect_resource_regions(frame, icons_to_read, cache_obj)
-
-    if max_cache_age is None:
-        max_cache_age = cache._RESOURCE_CACHE_MAX_AGE
-    if conf_threshold is None:
-        conf_threshold = CFG.get(
-            "population_limit_ocr_conf_threshold",
-            CFG.get("ocr_conf_threshold", 60),
-        )
-
-    resource_icons = [n for n in icons_to_read if n != "population_limit"]
-    results: dict[str, int | None] = {}
-    cache_hits = set()
-    debug_images = {}
-    low_confidence = set()
-    no_digits = set()
-    for name in resource_icons:
-        res_conf_threshold = CFG.get(f"{name}_ocr_conf_threshold", conf_threshold)
-        if name not in regions:
-            if name in required_set:
-                results[name] = None
-                no_digits.add(name)
-            continue
-        x, y, w, h = regions[name]
-        deficit = cache._NARROW_ROI_DEFICITS.get(name)
-        if deficit:
-            expand_left = deficit // 2
-            expand_right = deficit - expand_left
-            orig_x = x
-            orig_w = w
-            x = max(0, orig_x - expand_left)
-            right = min(frame.shape[1], orig_x + orig_w + expand_right)
-            w = right - x
-            regions[name] = (x, y, w, h)
-            logger.debug(
-                "Expanding narrow ROI for %s by %dpx (left=%d right=%d)",
-                name,
-                deficit,
-                expand_left,
-                expand_right,
-            )
-        if w <= 0 or h <= 0:
-            logger.error(
-                "ROI for '%s' has invalid dimensions w=%d h=%d", name, w, h
-            )
-            if name in required_set:
-                raise common.ResourceReadError(
-                    f"{name} region has non-positive size"
-                )
-            continue
-        failure_count = cache_obj.resource_failure_counts.get(name, 0)
-        roi = frame[y : y + h, x : x + w]
-        gray = preprocess_roi(roi)
-        top_crop = CFG.get("ocr_top_crop", 2)
-        overrides = CFG.get("ocr_top_crop_overrides", {})
-        if name in overrides:
-            top_crop = overrides[name]
-        if top_crop > 0 and gray.shape[0] > top_crop:
-            gray = gray[top_crop:, :]
-        if name == "idle_villager":
-            data = pytesseract.image_to_data(
-                gray,
-                config="--psm 7 -c tessedit_char_whitelist=0123456789",
-                output_type=pytesseract.Output.DICT,
-            )
-            texts = [t for t in data.get("text", []) if t.strip()]
-            confidences = ocr.parse_confidences(data)
-            if texts and confidences and all(
-                c >= res_conf_threshold for c in confidences
-            ):
-                digits = "".join(filter(str.isdigit, "".join(texts)))
-            else:
-                digits = None
-            mask = gray
-            low_conf = False
-        else:
-            try:
-                digits, data, mask, low_conf = execute_ocr(
-                    gray,
-                    color=roi,
-                    conf_threshold=res_conf_threshold,
-                    roi=(x, y, w, h),
-                    resource=name,
-                )
-                logger.info(
-                    "OCR %s: digits=%s conf=%s low_conf=%s",
-                    name,
-                    digits,
-                    data.get("conf"),
-                    low_conf,
-                )
-            except TypeError:
-                digits, data, mask, low_conf = execute_ocr(
-                    gray,
-                    conf_threshold=res_conf_threshold,
-                    resource=name,
-                )
-                logger.info(
-                    "OCR %s: digits=%s conf=%s low_conf=%s",
-                    name,
-                    digits,
-                    data.get("conf"),
-                    low_conf,
-                )
-            if (
-                name == "wood_stockpile"
-                and low_conf
-                and digits
-                and name not in cache_obj.last_resource_values
-            ):
-                min_conf = CFG.get("ocr_conf_min", 0)
-                if res_conf_threshold > min_conf:
-                    try:
-                        digits_retry, data_retry, mask_retry, low_conf = execute_ocr(
-                            gray,
-                            color=roi,
-                            conf_threshold=min_conf,
-                            roi=(x, y, w, h),
-                            resource=name,
-                        )
-                        logger.info(
-                            "Retry OCR %s: digits=%s conf=%s low_conf=%s",
-                            name,
-                            digits_retry,
-                            data_retry.get("conf"),
-                            low_conf,
-                        )
-                    except TypeError:
-                        digits_retry, data_retry, mask_retry, low_conf = execute_ocr(
-                            gray,
-                            conf_threshold=min_conf,
-                            resource=name,
-                        )
-                        logger.info(
-                            "Retry OCR %s: digits=%s conf=%s low_conf=%s",
-                            name,
-                            digits_retry,
-                            data_retry.get("conf"),
-                            low_conf,
-                        )
-                    if digits_retry:
-                        digits, data, mask = digits_retry, data_retry, mask_retry
-        if not digits:
-            base_expand = CFG.get("ocr_roi_expand_px", 0)
-            step = CFG.get("ocr_roi_expand_step", 0)
-            growth = CFG.get("ocr_roi_expand_growth", 1.0)
-            expand_px = int(
-                round(
-                    base_expand
-                    + step * ((failure_count + 1) ** growth - 1)
-                )
-            )
-            if expand_px > 0:
-                x0 = max(0, x - expand_px)
-                y0 = max(0, y - expand_px)
-                x1 = min(frame.shape[1], x + w + expand_px)
-                y1 = min(frame.shape[0], y + h + expand_px)
-                logger.debug(
-                    "Expanding ROI for %s after %d failures by %dpx to x=%d y=%d w=%d h=%d",
-                    name,
-                    failure_count,
-                    expand_px,
-                    x0,
-                    y0,
-                    x1 - x0,
-                    y1 - y0,
-                )
-                roi_expanded = frame[y0:y1, x0:x1]
-                gray_expanded = preprocess_roi(roi_expanded)
-                if top_crop > 0 and gray_expanded.shape[0] > top_crop:
-                    gray_expanded = gray_expanded[top_crop:, :]
-                try:
-                    digits_exp, data_exp, mask_exp, low_conf = execute_ocr(
-                        gray_expanded,
-                        color=roi_expanded,
-                        conf_threshold=res_conf_threshold,
-                        roi=(x0, y0, x1 - x0, y1 - y0),
-                        resource=name,
-                    )
-                    logger.info(
-                        "OCR %s: digits=%s conf=%s low_conf=%s",
-                        name,
-                        digits_exp,
-                        data_exp.get("conf"),
-                        low_conf,
-                    )
-                except TypeError:
-                    digits_exp, data_exp, mask_exp, low_conf = execute_ocr(
-                        gray_expanded,
-                        conf_threshold=res_conf_threshold,
-                        resource=name,
-                    )
-                    logger.info(
-                        "OCR %s: digits=%s conf=%s low_conf=%s",
-                        name,
-                        digits_exp,
-                        data_exp.get("conf"),
-                        low_conf,
-                    )
-                if digits_exp:
-                    digits, data, mask = digits_exp, data_exp, mask_exp
-                    roi, gray = roi_expanded, gray_expanded
-                    x, y = x0, y0
-                    w, h = x1 - x0, y1 - y0
-
-        if not digits:
-            span_left, span_right = cache._LAST_REGION_SPANS.get(name, (x, x + w))
-            span_width = span_right - span_left
-            cand_widths = [min(w, span_width)]
-            cand_widths += [min(span_width, cw) for cw in (64, 56, 48)]
-            cand_widths = list(dict.fromkeys(cand_widths))
-            for cand_w in cand_widths:
-                for anchor in ("left", "center", "right"):
-                    if anchor == "left":
-                        cand_x = span_left
-                    elif anchor == "center":
-                        cand_x = span_left + (span_width - cand_w) // 2
-                    else:
-                        cand_x = span_right - cand_w
-                    cand_x = max(span_left, min(cand_x, span_right - cand_w))
-                    roi_retry = frame[y : y + h, cand_x : cand_x + cand_w]
-                    gray_retry = preprocess_roi(roi_retry)
-                    if top_crop > 0 and gray_retry.shape[0] > top_crop:
-                        gray_retry = gray_retry[top_crop:, :]
-                    try:
-                        digits_retry, data_retry, mask_retry, low_conf = execute_ocr(
-                            gray_retry,
-                            color=roi_retry,
-                            conf_threshold=res_conf_threshold,
-                            allow_fallback=False,
-                            roi=(cand_x, y, cand_w, h),
-                            resource=name,
-                        )
-                        logger.info(
-                            "OCR %s: digits=%s conf=%s low_conf=%s",
-                            name,
-                            digits_retry,
-                            data_retry.get("conf"),
-                            low_conf,
-                        )
-                    except TypeError:
-                        digits_retry, data_retry, mask_retry, low_conf = execute_ocr(
-                            gray_retry,
-                            conf_threshold=res_conf_threshold,
-                            allow_fallback=False,
-                            resource=name,
-                        )
-                        logger.info(
-                            "OCR %s: digits=%s conf=%s low_conf=%s",
-                            name,
-                            digits_retry,
-                            data_retry.get("conf"),
-                            low_conf,
-                        )
-                    if digits_retry:
-                        digits, data, mask = digits_retry, data_retry, mask_retry
-                        roi, gray = roi_retry, gray_retry
-                        x, w = cand_x, cand_w
-                        break
-                if digits:
-                    break
-        debug_images[name] = (gray, mask)
-        if CFG.get("ocr_debug"):
-            debug_dir = ROOT / "debug"
-            debug_dir.mkdir(exist_ok=True)
-            ts = int(time.time() * 1000)
-            cv2.imwrite(str(debug_dir / f"resource_{name}_roi_{ts}.png"), roi)
-            if mask is not None:
-                cv2.imwrite(str(debug_dir / f"resource_{name}_thresh_{ts}.png"), mask)
-        if not digits:
-            logger.warning(
-                "OCR failed for %s; raw boxes=%s", name, data.get("text")
-            )
-            debug_dir = ROOT / "debug"
-            debug_dir.mkdir(exist_ok=True)
-            ts = int(time.time() * 1000)
-            roi_path = debug_dir / f"resource_{name}_roi_{ts}.png"
-            cv2.imwrite(str(roi_path), roi)
-            logger.warning("Saved ROI image to %s", roi_path)
-            if mask is not None:
-                thresh_path = debug_dir / f"resource_{name}_thresh_{ts}.png"
-                cv2.imwrite(str(thresh_path), mask)
-                logger.warning("Saved threshold image to %s", thresh_path)
-            ts_cache = cache_obj.last_resource_ts.get(name)
-            use_cache = False
-            if name in cache_obj.last_resource_values and ts_cache is not None:
-                age = time.time() - ts_cache
-                if age < cache._RESOURCE_CACHE_TTL:
-                    logger.warning(
-                        "Using cached value for %s after OCR failure", name
-                    )
-                    use_cache = True
-                elif failure_count >= 1 and (
-                    max_cache_age is None or age <= max_cache_age
-                ):
-                    logger.warning(
-                        "Using cached value for %s despite expired TTL (%.2fs)",
-                        name,
-                        age,
-                    )
-                    use_cache = True
-            if use_cache:
-                results[name] = cache_obj.last_resource_values[name]
-                cache_hits.add(name)
-            else:
-                results[name] = None
-                if low_conf:
-                    low_confidence.add(name)
-                else:
-                    no_digits.add(name)
-            cache_obj.resource_failure_counts[name] = failure_count + 1
-        else:
-            value = int(digits)
-            if (
-                low_conf
-                and CFG.get("treat_low_conf_as_failure", True)
-                and (name != "wood_stockpile" or name in cache_obj.last_resource_values)
-            ):
-                fallback_key = f"{name}_low_conf_fallback"
-                if CFG.get(fallback_key, False) and name in cache_obj.last_resource_values:
-                    results[name] = cache_obj.last_resource_values[name]
-                    cache_hits.add(name)
-                    logger.warning(
-                        "Using cached value for %s due to low-confidence OCR", name
-                    )
-                else:
-                    results[name] = None
-                    logger.warning(
-                        "Discarding %s=%d due to low-confidence OCR",
-                        name,
-                        value,
-                    )
-                low_confidence.add(name)
-            else:
-                results[name] = value
-                if not low_conf:
-                    cache_obj.last_resource_values[name] = value
-                    cache_obj.last_resource_ts[name] = time.time()
-                    cache_obj.resource_failure_counts[name] = 0
-                else:
-                    low_confidence.add(name)
-            if results.get(name) is not None:
-                logger.info("Detected %s=%d", name, value)
-
-    filtered_regions = {n: regions[n] for n in resource_icons if n in regions}
-    required_for_ocr = [n for n in required_icons if n != "population_limit"]
-    handle_ocr_failure(
-        frame,
-        filtered_regions,
-        results,
-        required_for_ocr,
-        cache_obj,
-        debug_images=debug_images,
-        low_confidence=low_confidence,
-    )
-
-    cur_pop = pop_cap = None
-    if "population_limit" in icons_to_read:
-        pop_required = "population_limit" in required_set
-        pop_conf_threshold = CFG.get(
-            "population_limit_ocr_conf_threshold", conf_threshold
-        )
-        cur_pop, pop_cap = _extract_population(
-            frame,
-            regions,
-            results,
-            pop_required,
-            conf_threshold=pop_conf_threshold,
-        )
-
-    cache._LAST_READ_FROM_CACHE = cache_hits
-
-    # Record failure reasons for later inspection
-    global _LAST_LOW_CONFIDENCE, _LAST_NO_DIGITS
-    _LAST_LOW_CONFIDENCE = set(low_confidence)
-    _LAST_NO_DIGITS = set(no_digits)
-
-    logger.info("Resumo de recursos detectados: %s", results)
-
-    return results, (cur_pop, pop_cap)
-
-
-def read_resources_from_hud(
-    required_icons: Iterable[str] | None = None,
-    icons_to_read: Iterable[str] | None = None,
-    *,
-    force_delay=None,
-    max_cache_age: float | None = None,
-    conf_threshold: int | None = None,
-    cache: ResourceCache = RESOURCE_CACHE,
-):
-    if force_delay is not None:
-        time.sleep(force_delay)
-
-    frame = screen_utils._grab_frame()
-
-    if required_icons is None:
-        required_icons = list(RESOURCE_ICON_ORDER)
-    else:
-        required_icons = list(required_icons)
-
-    if icons_to_read is None:
-        icons_to_read = list(required_icons)
-    else:
-        icons_to_read = list(set(required_icons).union(icons_to_read))
-
-    return _read_resources(
-        frame,
-        required_icons,
-        icons_to_read,
-        cache,
-        max_cache_age,
-        conf_threshold,
-    )
-
-
-def gather_hud_stats(
-    force_delay=None,
-    required_icons=None,
-    optional_icons=None,
-    max_cache_age: float | None = None,
-    conf_threshold: int | None = None,
-    cache: ResourceCache = RESOURCE_CACHE,
-):
-    if force_delay is not None:
-        time.sleep(force_delay)
-
-    frame = screen_utils._grab_frame()
-
-    icon_cfg = CFG.get("hud_icons", {})
-    provided_lists = not (required_icons is None and optional_icons is None)
-    if required_icons is None:
-        required_icons = icon_cfg.get(
-            "required",
-            [
-                "wood_stockpile",
-                "food_stockpile",
-                "gold_stockpile",
-                "stone_stockpile",
-                "population_limit",
-                "idle_villager",
-            ],
-        )
-    if optional_icons is None:
-        optional_icons = icon_cfg.get("optional", [])
-
-    required_icons = list(required_icons)
-    optional_icons = list(optional_icons)
-    all_icons = list(dict.fromkeys(required_icons + optional_icons))
-
-    if not provided_lists:
-        regions = detect_resource_regions(frame, all_icons, cache)
-        required_icons = [n for n in required_icons if n in regions]
-        all_icons = list(regions.keys())
-
-    return _read_resources(
-        frame,
-        required_icons,
-        all_icons,
-        cache,
-        max_cache_age,
-        conf_threshold,
-    )
-
-
-def validate_starting_resources(
-    current: dict[str, int],
-    expected: dict[str, int] | None,
-    *,
-    tolerance: int = 10,
-    raise_on_error: bool = False,
-    frame: np.ndarray | None = None,
-    rois: dict[str, tuple[int, int, int, int]] | None = None,
-) -> None:
-    if not expected:
-        return
-    errors: list[str] = []
-    for name, exp in expected.items():
-        actual = current.get(name)
-        if actual is None:
-            if name in _LAST_LOW_CONFIDENCE:
-                msg = f"Low-confidence OCR for '{name}'"
-            else:
-                msg = f"Missing OCR reading for '{name}'"
-            if raise_on_error:
-                logger.error(msg)
-                errors.append(msg)
-            else:
-                logger.warning(msg)
-            continue
-
-        if abs(actual - exp) > tolerance:
-            roi_path = None
-            if frame is not None and rois and name in rois:
-                x, y, w, h = rois[name]
-                debug_dir = ROOT / "debug"
-                debug_dir.mkdir(exist_ok=True)
-                ts = int(time.time() * 1000)
-                roi_img = frame[y : y + h, x : x + w]
-                roi_path = debug_dir / f"resource_roi_{name}_{ts}.png"
-                cv2.imwrite(str(roi_path), roi_img)
-
-            msg = (
-                f"{name} reading {actual} deviates from expected {exp} "
-                f"(±{tolerance})"
-            )
-            if roi_path is not None:
-                msg += f"; ROI saved to {roi_path}"
-            if raise_on_error:
-                logger.error(msg)
-                errors.append(msg)
-            else:
-                logger.warning(msg)
-
-    if errors and raise_on_error:
-        raise ValueError("; ".join(errors))
-
+# Reader functions
+from .reader import (
+    _read_resources,
+    read_resources_from_hud,
+    gather_hud_stats,
+    validate_starting_resources,
+)
 
 __all__ = [
     "ResourceCache",
@@ -611,6 +88,8 @@ __all__ = [
     "_get_resource_panel_cfg",
     "locate_resource_panel",
     "detect_resource_regions",
+    "_auto_calibrate_from_icons",
+    "_fallback_rois_from_slice",
     "_apply_custom_rois",
     "_recalibrate_low_variance",
     "_remove_overlaps",

--- a/script/resources/reader.py
+++ b/script/resources/reader.py
@@ -1,0 +1,589 @@
+"""Functions for reading resource values from the HUD."""
+
+import time
+from typing import Iterable
+
+import cv2
+import numpy as np
+import pytesseract
+
+from . import CFG, ROOT, cache, common, logger, screen_utils, RESOURCE_ICON_ORDER
+from .panel import detect_resource_regions
+from . import ocr
+
+# Re-export cache utilities
+ResourceCache = cache.ResourceCache
+RESOURCE_CACHE = cache.RESOURCE_CACHE
+_LAST_READ_FROM_CACHE = cache._LAST_READ_FROM_CACHE
+_NARROW_ROIS = cache._NARROW_ROIS
+_NARROW_ROI_DEFICITS = cache._NARROW_ROI_DEFICITS
+_RESOURCE_CACHE_TTL = cache._RESOURCE_CACHE_TTL
+_RESOURCE_DEBUG_COOLDOWN = cache._RESOURCE_DEBUG_COOLDOWN
+_LAST_REGION_BOUNDS = cache._LAST_REGION_BOUNDS
+_LAST_REGION_SPANS = cache._LAST_REGION_SPANS
+
+# Track last OCR failure reasons
+_LAST_LOW_CONFIDENCE: set[str] = set()
+_LAST_NO_DIGITS: set[str] = set()
+
+# OCR helpers
+preprocess_roi = ocr.preprocess_roi
+_ocr_digits_better = ocr._ocr_digits_better
+execute_ocr = ocr.execute_ocr
+handle_ocr_failure = ocr.handle_ocr_failure
+_read_population_from_roi = ocr._read_population_from_roi
+read_population_from_roi = ocr.read_population_from_roi
+_extract_population = ocr._extract_population
+
+def _read_resources(
+    frame,
+    required_icons,
+    icons_to_read,
+    cache_obj: ResourceCache = RESOURCE_CACHE,
+    max_cache_age: float | None = None,
+    conf_threshold: int | None = None,
+):
+    required_icons = list(required_icons)
+    icons_to_read = list(icons_to_read)
+    required_set = set(required_icons)
+
+    regions = detect_resource_regions(frame, icons_to_read, cache_obj)
+
+    if max_cache_age is None:
+        max_cache_age = cache._RESOURCE_CACHE_MAX_AGE
+    if conf_threshold is None:
+        conf_threshold = CFG.get(
+            "population_limit_ocr_conf_threshold",
+            CFG.get("ocr_conf_threshold", 60),
+        )
+
+    resource_icons = [n for n in icons_to_read if n != "population_limit"]
+    results: dict[str, int | None] = {}
+    cache_hits = set()
+    debug_images = {}
+    low_confidence = set()
+    no_digits = set()
+    for name in resource_icons:
+        res_conf_threshold = CFG.get(f"{name}_ocr_conf_threshold", conf_threshold)
+        if name not in regions:
+            if name in required_set:
+                results[name] = None
+                no_digits.add(name)
+            continue
+        x, y, w, h = regions[name]
+        deficit = cache._NARROW_ROI_DEFICITS.get(name)
+        if deficit:
+            expand_left = deficit // 2
+            expand_right = deficit - expand_left
+            orig_x = x
+            orig_w = w
+            x = max(0, orig_x - expand_left)
+            right = min(frame.shape[1], orig_x + orig_w + expand_right)
+            w = right - x
+            regions[name] = (x, y, w, h)
+            logger.debug(
+                "Expanding narrow ROI for %s by %dpx (left=%d right=%d)",
+                name,
+                deficit,
+                expand_left,
+                expand_right,
+            )
+        if w <= 0 or h <= 0:
+            logger.error(
+                "ROI for '%s' has invalid dimensions w=%d h=%d", name, w, h
+            )
+            if name in required_set:
+                raise common.ResourceReadError(
+                    f"{name} region has non-positive size"
+                )
+            continue
+        failure_count = cache_obj.resource_failure_counts.get(name, 0)
+        roi = frame[y : y + h, x : x + w]
+        gray = preprocess_roi(roi)
+        top_crop = CFG.get("ocr_top_crop", 2)
+        overrides = CFG.get("ocr_top_crop_overrides", {})
+        if name in overrides:
+            top_crop = overrides[name]
+        if top_crop > 0 and gray.shape[0] > top_crop:
+            gray = gray[top_crop:, :]
+        if name == "idle_villager":
+            data = pytesseract.image_to_data(
+                gray,
+                config="--psm 7 -c tessedit_char_whitelist=0123456789",
+                output_type=pytesseract.Output.DICT,
+            )
+            texts = [t for t in data.get("text", []) if t.strip()]
+            confidences = ocr.parse_confidences(data)
+            if texts and confidences and all(
+                c >= res_conf_threshold for c in confidences
+            ):
+                digits = "".join(filter(str.isdigit, "".join(texts)))
+            else:
+                digits = None
+            mask = gray
+            low_conf = False
+        else:
+            try:
+                digits, data, mask, low_conf = execute_ocr(
+                    gray,
+                    color=roi,
+                    conf_threshold=res_conf_threshold,
+                    roi=(x, y, w, h),
+                    resource=name,
+                )
+                logger.info(
+                    "OCR %s: digits=%s conf=%s low_conf=%s",
+                    name,
+                    digits,
+                    data.get("conf"),
+                    low_conf,
+                )
+            except TypeError:
+                digits, data, mask, low_conf = execute_ocr(
+                    gray,
+                    conf_threshold=res_conf_threshold,
+                    resource=name,
+                )
+                logger.info(
+                    "OCR %s: digits=%s conf=%s low_conf=%s",
+                    name,
+                    digits,
+                    data.get("conf"),
+                    low_conf,
+                )
+            if (
+                name == "wood_stockpile"
+                and low_conf
+                and digits
+                and name not in cache_obj.last_resource_values
+            ):
+                min_conf = CFG.get("ocr_conf_min", 0)
+                if res_conf_threshold > min_conf:
+                    try:
+                        digits_retry, data_retry, mask_retry, low_conf = execute_ocr(
+                            gray,
+                            color=roi,
+                            conf_threshold=min_conf,
+                            roi=(x, y, w, h),
+                            resource=name,
+                        )
+                        logger.info(
+                            "Retry OCR %s: digits=%s conf=%s low_conf=%s",
+                            name,
+                            digits_retry,
+                            data_retry.get("conf"),
+                            low_conf,
+                        )
+                    except TypeError:
+                        digits_retry, data_retry, mask_retry, low_conf = execute_ocr(
+                            gray,
+                            conf_threshold=min_conf,
+                            resource=name,
+                        )
+                        logger.info(
+                            "Retry OCR %s: digits=%s conf=%s low_conf=%s",
+                            name,
+                            digits_retry,
+                            data_retry.get("conf"),
+                            low_conf,
+                        )
+                    if digits_retry:
+                        digits, data, mask = digits_retry, data_retry, mask_retry
+        if not digits:
+            base_expand = CFG.get("ocr_roi_expand_px", 0)
+            step = CFG.get("ocr_roi_expand_step", 0)
+            growth = CFG.get("ocr_roi_expand_growth", 1.0)
+            expand_px = int(
+                round(
+                    base_expand
+                    + step * ((failure_count + 1) ** growth - 1)
+                )
+            )
+            if expand_px > 0:
+                x0 = max(0, x - expand_px)
+                y0 = max(0, y - expand_px)
+                x1 = min(frame.shape[1], x + w + expand_px)
+                y1 = min(frame.shape[0], y + h + expand_px)
+                logger.debug(
+                    "Expanding ROI for %s after %d failures by %dpx to x=%d y=%d w=%d h=%d",
+                    name,
+                    failure_count,
+                    expand_px,
+                    x0,
+                    y0,
+                    x1 - x0,
+                    y1 - y0,
+                )
+                roi_expanded = frame[y0:y1, x0:x1]
+                gray_expanded = preprocess_roi(roi_expanded)
+                if top_crop > 0 and gray_expanded.shape[0] > top_crop:
+                    gray_expanded = gray_expanded[top_crop:, :]
+                try:
+                    digits_exp, data_exp, mask_exp, low_conf = execute_ocr(
+                        gray_expanded,
+                        color=roi_expanded,
+                        conf_threshold=res_conf_threshold,
+                        roi=(x0, y0, x1 - x0, y1 - y0),
+                        resource=name,
+                    )
+                    logger.info(
+                        "OCR %s: digits=%s conf=%s low_conf=%s",
+                        name,
+                        digits_exp,
+                        data_exp.get("conf"),
+                        low_conf,
+                    )
+                except TypeError:
+                    digits_exp, data_exp, mask_exp, low_conf = execute_ocr(
+                        gray_expanded,
+                        conf_threshold=res_conf_threshold,
+                        resource=name,
+                    )
+                    logger.info(
+                        "OCR %s: digits=%s conf=%s low_conf=%s",
+                        name,
+                        digits_exp,
+                        data_exp.get("conf"),
+                        low_conf,
+                    )
+                if digits_exp:
+                    digits, data, mask = digits_exp, data_exp, mask_exp
+                    roi, gray = roi_expanded, gray_expanded
+                    x, y = x0, y0
+                    w, h = x1 - x0, y1 - y0
+
+        if not digits:
+            span_left, span_right = cache._LAST_REGION_SPANS.get(name, (x, x + w))
+            span_width = span_right - span_left
+            cand_widths = [min(w, span_width)]
+            cand_widths += [min(span_width, cw) for cw in (64, 56, 48)]
+            cand_widths = list(dict.fromkeys(cand_widths))
+            for cand_w in cand_widths:
+                for anchor in ("left", "center", "right"):
+                    if anchor == "left":
+                        cand_x = span_left
+                    elif anchor == "center":
+                        cand_x = span_left + (span_width - cand_w) // 2
+                    else:
+                        cand_x = span_right - cand_w
+                    cand_x = max(span_left, min(cand_x, span_right - cand_w))
+                    roi_retry = frame[y : y + h, cand_x : cand_x + cand_w]
+                    gray_retry = preprocess_roi(roi_retry)
+                    if top_crop > 0 and gray_retry.shape[0] > top_crop:
+                        gray_retry = gray_retry[top_crop:, :]
+                    try:
+                        digits_retry, data_retry, mask_retry, low_conf = execute_ocr(
+                            gray_retry,
+                            color=roi_retry,
+                            conf_threshold=res_conf_threshold,
+                            allow_fallback=False,
+                            roi=(cand_x, y, cand_w, h),
+                            resource=name,
+                        )
+                        logger.info(
+                            "OCR %s: digits=%s conf=%s low_conf=%s",
+                            name,
+                            digits_retry,
+                            data_retry.get("conf"),
+                            low_conf,
+                        )
+                    except TypeError:
+                        digits_retry, data_retry, mask_retry, low_conf = execute_ocr(
+                            gray_retry,
+                            conf_threshold=res_conf_threshold,
+                            allow_fallback=False,
+                            resource=name,
+                        )
+                        logger.info(
+                            "OCR %s: digits=%s conf=%s low_conf=%s",
+                            name,
+                            digits_retry,
+                            data_retry.get("conf"),
+                            low_conf,
+                        )
+                    if digits_retry:
+                        digits, data, mask = digits_retry, data_retry, mask_retry
+                        roi, gray = roi_retry, gray_retry
+                        x, w = cand_x, cand_w
+                        break
+                if digits:
+                    break
+        debug_images[name] = (gray, mask)
+        if CFG.get("ocr_debug"):
+            debug_dir = ROOT / "debug"
+            debug_dir.mkdir(exist_ok=True)
+            ts = int(time.time() * 1000)
+            cv2.imwrite(str(debug_dir / f"resource_{name}_roi_{ts}.png"), roi)
+            if mask is not None:
+                cv2.imwrite(str(debug_dir / f"resource_{name}_thresh_{ts}.png"), mask)
+        if not digits:
+            logger.warning(
+                "OCR failed for %s; raw boxes=%s", name, data.get("text")
+            )
+            debug_dir = ROOT / "debug"
+            debug_dir.mkdir(exist_ok=True)
+            ts = int(time.time() * 1000)
+            roi_path = debug_dir / f"resource_{name}_roi_{ts}.png"
+            cv2.imwrite(str(roi_path), roi)
+            logger.warning("Saved ROI image to %s", roi_path)
+            if mask is not None:
+                thresh_path = debug_dir / f"resource_{name}_thresh_{ts}.png"
+                cv2.imwrite(str(thresh_path), mask)
+                logger.warning("Saved threshold image to %s", thresh_path)
+            ts_cache = cache_obj.last_resource_ts.get(name)
+            use_cache = False
+            if name in cache_obj.last_resource_values and ts_cache is not None:
+                age = time.time() - ts_cache
+                if age < cache._RESOURCE_CACHE_TTL:
+                    logger.warning(
+                        "Using cached value for %s after OCR failure", name
+                    )
+                    use_cache = True
+                elif failure_count >= 1 and (
+                    max_cache_age is None or age <= max_cache_age
+                ):
+                    logger.warning(
+                        "Using cached value for %s despite expired TTL (%.2fs)",
+                        name,
+                        age,
+                    )
+                    use_cache = True
+            if use_cache:
+                results[name] = cache_obj.last_resource_values[name]
+                cache_hits.add(name)
+            else:
+                results[name] = None
+                if low_conf:
+                    low_confidence.add(name)
+                else:
+                    no_digits.add(name)
+            cache_obj.resource_failure_counts[name] = failure_count + 1
+        else:
+            value = int(digits)
+            if (
+                low_conf
+                and CFG.get("treat_low_conf_as_failure", True)
+                and (name != "wood_stockpile" or name in cache_obj.last_resource_values)
+            ):
+                fallback_key = f"{name}_low_conf_fallback"
+                if CFG.get(fallback_key, False) and name in cache_obj.last_resource_values:
+                    results[name] = cache_obj.last_resource_values[name]
+                    cache_hits.add(name)
+                    logger.warning(
+                        "Using cached value for %s due to low-confidence OCR", name
+                    )
+                else:
+                    results[name] = None
+                    logger.warning(
+                        "Discarding %s=%d due to low-confidence OCR",
+                        name,
+                        value,
+                    )
+                low_confidence.add(name)
+            else:
+                results[name] = value
+                if not low_conf:
+                    cache_obj.last_resource_values[name] = value
+                    cache_obj.last_resource_ts[name] = time.time()
+                    cache_obj.resource_failure_counts[name] = 0
+                else:
+                    low_confidence.add(name)
+            if results.get(name) is not None:
+                logger.info("Detected %s=%d", name, value)
+
+    filtered_regions = {n: regions[n] for n in resource_icons if n in regions}
+    required_for_ocr = [n for n in required_icons if n != "population_limit"]
+    handle_ocr_failure(
+        frame,
+        filtered_regions,
+        results,
+        required_for_ocr,
+        cache_obj,
+        debug_images=debug_images,
+        low_confidence=low_confidence,
+    )
+
+    cur_pop = pop_cap = None
+    if "population_limit" in icons_to_read:
+        pop_required = "population_limit" in required_set
+        pop_conf_threshold = CFG.get(
+            "population_limit_ocr_conf_threshold", conf_threshold
+        )
+        cur_pop, pop_cap = _extract_population(
+            frame,
+            regions,
+            results,
+            pop_required,
+            conf_threshold=pop_conf_threshold,
+        )
+
+    cache._LAST_READ_FROM_CACHE = cache_hits
+
+    # Record failure reasons for later inspection
+    global _LAST_LOW_CONFIDENCE, _LAST_NO_DIGITS
+    _LAST_LOW_CONFIDENCE = set(low_confidence)
+    _LAST_NO_DIGITS = set(no_digits)
+
+    logger.info("Resumo de recursos detectados: %s", results)
+
+    return results, (cur_pop, pop_cap)
+
+
+def read_resources_from_hud(
+    required_icons: Iterable[str] | None = None,
+    icons_to_read: Iterable[str] | None = None,
+    *,
+    force_delay=None,
+    max_cache_age: float | None = None,
+    conf_threshold: int | None = None,
+    cache: ResourceCache = RESOURCE_CACHE,
+):
+    if force_delay is not None:
+        time.sleep(force_delay)
+
+    frame = screen_utils._grab_frame()
+
+    if required_icons is None:
+        required_icons = list(RESOURCE_ICON_ORDER)
+    else:
+        required_icons = list(required_icons)
+
+    if icons_to_read is None:
+        icons_to_read = list(required_icons)
+    else:
+        icons_to_read = list(set(required_icons).union(icons_to_read))
+
+    return _read_resources(
+        frame,
+        required_icons,
+        icons_to_read,
+        cache,
+        max_cache_age,
+        conf_threshold,
+    )
+
+
+def gather_hud_stats(
+    force_delay=None,
+    required_icons=None,
+    optional_icons=None,
+    max_cache_age: float | None = None,
+    conf_threshold: int | None = None,
+    cache: ResourceCache = RESOURCE_CACHE,
+):
+    if force_delay is not None:
+        time.sleep(force_delay)
+
+    frame = screen_utils._grab_frame()
+
+    icon_cfg = CFG.get("hud_icons", {})
+    provided_lists = not (required_icons is None and optional_icons is None)
+    if required_icons is None:
+        required_icons = icon_cfg.get(
+            "required",
+            [
+                "wood_stockpile",
+                "food_stockpile",
+                "gold_stockpile",
+                "stone_stockpile",
+                "population_limit",
+                "idle_villager",
+            ],
+        )
+    if optional_icons is None:
+        optional_icons = icon_cfg.get("optional", [])
+
+    required_icons = list(required_icons)
+    optional_icons = list(optional_icons)
+    all_icons = list(dict.fromkeys(required_icons + optional_icons))
+
+    if not provided_lists:
+        regions = detect_resource_regions(frame, all_icons, cache)
+        required_icons = [n for n in required_icons if n in regions]
+        all_icons = list(regions.keys())
+
+    return _read_resources(
+        frame,
+        required_icons,
+        all_icons,
+        cache,
+        max_cache_age,
+        conf_threshold,
+    )
+
+
+def validate_starting_resources(
+    current: dict[str, int],
+    expected: dict[str, int] | None,
+    *,
+    tolerance: int = 10,
+    raise_on_error: bool = False,
+    frame: np.ndarray | None = None,
+    rois: dict[str, tuple[int, int, int, int]] | None = None,
+) -> None:
+    if not expected:
+        return
+    errors: list[str] = []
+    for name, exp in expected.items():
+        actual = current.get(name)
+        if actual is None:
+            if name in _LAST_LOW_CONFIDENCE:
+                msg = f"Low-confidence OCR for '{name}'"
+            else:
+                msg = f"Missing OCR reading for '{name}'"
+            if raise_on_error:
+                logger.error(msg)
+                errors.append(msg)
+            else:
+                logger.warning(msg)
+            continue
+
+        if abs(actual - exp) > tolerance:
+            roi_path = None
+            if frame is not None and rois and name in rois:
+                x, y, w, h = rois[name]
+                debug_dir = ROOT / "debug"
+                debug_dir.mkdir(exist_ok=True)
+                ts = int(time.time() * 1000)
+                roi_img = frame[y : y + h, x : x + w]
+                roi_path = debug_dir / f"resource_roi_{name}_{ts}.png"
+                cv2.imwrite(str(roi_path), roi_img)
+
+            msg = (
+                f"{name} reading {actual} deviates from expected {exp} "
+                f"(±{tolerance})"
+            )
+            if roi_path is not None:
+                msg += f"; ROI saved to {roi_path}"
+            if raise_on_error:
+                logger.error(msg)
+                errors.append(msg)
+            else:
+                logger.warning(msg)
+
+    if errors and raise_on_error:
+        raise ValueError("; ".join(errors))
+
+
+
+__all__ = [
+    "ResourceCache",
+    "RESOURCE_CACHE",
+    "_LAST_READ_FROM_CACHE",
+    "_NARROW_ROIS",
+    "_NARROW_ROI_DEFICITS",
+    "_RESOURCE_CACHE_TTL",
+    "_RESOURCE_DEBUG_COOLDOWN",
+    "_LAST_REGION_BOUNDS",
+    "_LAST_REGION_SPANS",
+    "preprocess_roi",
+    "_ocr_digits_better",
+    "execute_ocr",
+    "handle_ocr_failure",
+    "_read_population_from_roi",
+    "read_population_from_roi",
+    "_read_resources",
+    "read_resources_from_hud",
+    "gather_hud_stats",
+    "validate_starting_resources",
+]

--- a/script/units/villager.py
+++ b/script/units/villager.py
@@ -3,7 +3,7 @@ import time
 
 import script.common as common
 import script.hud as hud
-import script.resources as resources
+import script.resources.reader as resources
 import script.input_utils as input_utils
 
 logger = logging.getLogger(__name__)

--- a/tests/test_build_house.py
+++ b/tests/test_build_house.py
@@ -47,7 +47,7 @@ class TestClickAndBuildHouse(TestCase):
         common.POP_CAP = 4
         expected_coords = tuple(common.CFG["areas"]["house_spot"])
         with patch(
-            "script.resources.read_resources_from_hud",
+            "script.resources.reader.read_resources_from_hud",
             return_value=({"wood_stockpile": 100}, (None, None)),
         ), \
             patch("script.input_utils._press_key_safe"), \
@@ -72,7 +72,7 @@ class TestBuildHouseResourceRetry(TestCase):
             common.ResourceReadError("fail2"),
         ]
         with patch(
-            "script.resources.read_resources_from_hud",
+            "script.resources.reader.read_resources_from_hud",
             side_effect=side_effect,
         ) as read_mock, patch("script.input_utils._press_key_safe") as press_mock, patch(
             "script.input_utils._click_norm"
@@ -92,7 +92,7 @@ class TestBuildHouseResourceRetry(TestCase):
             ({"wood_stockpile": 100}, (None, None)),
         ]
         with patch(
-            "script.resources.read_resources_from_hud",
+            "script.resources.reader.read_resources_from_hud",
             side_effect=side_effect,
         ) as read_mock, patch("script.input_utils._press_key_safe"), patch(
             "script.input_utils._click_norm"

--- a/tests/test_hud_anchor.py
+++ b/tests/test_hud_anchor.py
@@ -34,7 +34,7 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
 import script.hud as hud
-import script.resources as resources
+import script.resources.reader as resources
 import tools.campaign_bot as cb
 
 ASSET = "assets/resources.png"
@@ -73,17 +73,17 @@ class TestHudAnchor(TestCase):
             d = next(digits_iter)
             return d, {"text": [d]}, np.zeros((1, 1), dtype=np.uint8)
 
-        with patch("script.resources.locate_resource_panel", return_value={}), \
+        with patch("script.resources.reader.locate_resource_panel", return_value={}), \
              patch("script.screen_utils._grab_frame", side_effect=fake_grab_frame), \
-             patch("script.resources._ocr_digits_better", side_effect=fake_ocr), \
-             patch("script.resources.preprocess_roi", side_effect=lambda roi: np.zeros((52, 90), dtype=np.uint8)), \
+             patch("script.resources.reader._ocr_digits_better", side_effect=fake_ocr), \
+             patch("script.resources.reader.preprocess_roi", side_effect=lambda roi: np.zeros((52, 90), dtype=np.uint8)), \
              patch(
-                 "script.resources.pytesseract.image_to_data",
+                 "script.resources.reader.pytesseract.image_to_data",
                  return_value={"text": ["600"], "conf": ["90"]},
              ), \
-             patch("script.resources._read_population_from_roi", return_value=(500, 500)), \
+             patch("script.resources.reader._read_population_from_roi", return_value=(500, 500)), \
              patch("script.input_utils._screen_size", return_value=(1920, 1080)), \
-             patch("script.resources.cv2.imwrite"):
+             patch("script.resources.reader.cv2.imwrite"):
             result, _ = resources.read_resources_from_hud()
 
         expected = {
@@ -145,15 +145,15 @@ class TestHudAnchorTools(TestCase):
         with patch("tools.campaign_bot.locate_resource_panel", return_value={}), \
              patch("tools.campaign_bot._grab_frame", side_effect=fake_grab_frame), \
              patch("tools.campaign_bot._ocr_digits_better", side_effect=fake_ocr), \
-             patch("script.resources._ocr_digits_better", side_effect=fake_ocr), \
-             patch("script.resources.preprocess_roi", side_effect=lambda roi: np.zeros((52, 90), dtype=np.uint8)), \
+             patch("script.resources.reader._ocr_digits_better", side_effect=fake_ocr), \
+             patch("script.resources.reader.preprocess_roi", side_effect=lambda roi: np.zeros((52, 90), dtype=np.uint8)), \
              patch(
-                 "script.resources.pytesseract.image_to_data",
+                 "script.resources.reader.pytesseract.image_to_data",
                  return_value={"text": ["600"], "conf": ["90"]},
              ), \
-             patch("script.resources._read_population_from_roi", return_value=(500, 500)), \
+             patch("script.resources.reader._read_population_from_roi", return_value=(500, 500)), \
              patch("script.input_utils._screen_size", return_value=(1920, 1080)), \
-             patch("script.resources.cv2.imwrite"):
+             patch("script.resources.reader.cv2.imwrite"):
             result, _ = cb.read_resources_from_hud([
                 "wood_stockpile",
                 "food_stockpile",

--- a/tests/test_idle_villager_ocr.py
+++ b/tests/test_idle_villager_ocr.py
@@ -32,7 +32,7 @@ sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
 os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-import script.resources as resources
+import script.resources.reader as resources
 
 
 class TestIdleVillagerOCR(TestCase):
@@ -46,13 +46,13 @@ class TestIdleVillagerOCR(TestCase):
             return {"idle_villager": (0, 0, 50, 50)}
 
         frame = np.zeros((100, 100, 3), dtype=np.uint8)
-        with patch("script.resources.detect_resource_regions", side_effect=fake_detect), \
+        with patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
              patch("script.screen_utils._grab_frame", return_value=frame), \
              patch(
-                 "script.resources.pytesseract.image_to_data",
+                 "script.resources.reader.pytesseract.image_to_data",
                  return_value={"text": ["1", "2"], "conf": ["90", "90"]},
              ) as img2data, \
-             patch("script.resources.execute_ocr") as exec_mock:
+             patch("script.resources.reader.execute_ocr") as exec_mock:
             result, _ = resources.read_resources_from_hud(["idle_villager"])
 
         self.assertEqual(result["idle_villager"], 12)
@@ -68,13 +68,13 @@ class TestIdleVillagerOCR(TestCase):
             return {"idle_villager": (0, 0, 50, 50)}
 
         frame = np.zeros((100, 100, 3), dtype=np.uint8)
-        with patch("script.resources.detect_resource_regions", side_effect=fake_detect), \
+        with patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
              patch("script.screen_utils._grab_frame", return_value=frame), \
              patch(
-                 "script.resources.pytesseract.image_to_data",
+                 "script.resources.reader.pytesseract.image_to_data",
                  return_value={"text": ["1", "2"], "conf": [-1, "0", "95"]},
              ) as img2data, \
-             patch("script.resources.execute_ocr") as exec_mock:
+             patch("script.resources.reader.execute_ocr") as exec_mock:
             result, _ = resources.read_resources_from_hud(["idle_villager"])
 
         self.assertEqual(result["idle_villager"], 12)
@@ -90,14 +90,14 @@ class TestIdleVillagerOCR(TestCase):
             return {"idle_villager": (0, 0, 50, 50)}
 
         frame = np.zeros((100, 100, 3), dtype=np.uint8)
-        with patch("script.resources.detect_resource_regions", side_effect=fake_detect), \
+        with patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
              patch("script.screen_utils._grab_frame", return_value=frame), \
              patch(
-                 "script.resources.pytesseract.image_to_data",
+                 "script.resources.reader.pytesseract.image_to_data",
                  return_value={"text": ["1"], "conf": ["30"]},
              ), \
              patch(
-                 "script.resources.execute_ocr",
+                 "script.resources.reader.execute_ocr",
                  return_value=("", {"text": [""], "conf": []}, None, True),
              ):
             result, _ = resources.read_resources_from_hud(

--- a/tests/test_idle_villager_roi.py
+++ b/tests/test_idle_villager_roi.py
@@ -147,7 +147,7 @@ class TestIdleVillagerROI(TestCase):
             return next(counts)
 
         with patch("script.units.villager.select_idle_villager") as mock_sel, \
-            patch("script.resources.read_resources_from_hud", side_effect=fake_read):
+            patch("script.resources.reader.read_resources_from_hud", side_effect=fake_read):
             initial, selections = villager.count_idle_villagers_via_hotkey(
                 delay=0, return_selections=True
             )
@@ -170,7 +170,7 @@ class TestIdleVillagerROI(TestCase):
             return next(counts)
 
         with patch("script.units.villager.select_idle_villager"), patch(
-            "script.resources.read_resources_from_hud", side_effect=fake_read
+            "script.resources.reader.read_resources_from_hud", side_effect=fake_read
         ):
             initial, selections = villager.count_idle_villagers_via_hotkey(
                 delay=0.1, return_selections=True
@@ -193,7 +193,7 @@ class TestIdleVillagerROI(TestCase):
             return next(counts)
 
         with patch("script.units.villager.select_idle_villager") as mock_sel, patch(
-            "script.resources.read_resources_from_hud", side_effect=fake_read
+            "script.resources.reader.read_resources_from_hud", side_effect=fake_read
         ):
             initial, selections = villager.count_idle_villagers_via_hotkey(
                 delay=0, stop_threshold=2, return_selections=True

--- a/tests/test_internal_population.py
+++ b/tests/test_internal_population.py
@@ -63,7 +63,7 @@ class TestInternalPopulation(TestCase):
             return True
 
         with patch(
-            "script.resources.read_resources_from_hud",
+            "script.resources.reader.read_resources_from_hud",
             return_value=({"food_stockpile": 500}, (None, None)),
         ), \
              patch("script.buildings.town_center.build_house", side_effect=fake_build_house) as build_house_mock, \
@@ -80,7 +80,7 @@ class TestInternalPopulation(TestCase):
             "script.resources.read_population_from_roi",
             side_effect=common.PopulationReadError("primary fail"),
         ), patch(
-            "script.resources.read_resources_from_hud",
+            "script.resources.reader.read_resources_from_hud",
             side_effect=common.ResourceReadError("fallback fail"),
         ), patch("script.resources.locate_resource_panel", return_value={}):
             with self.assertRaises(common.PopulationReadError) as ctx:

--- a/tests/test_missing_resource_bar.py
+++ b/tests/test_missing_resource_bar.py
@@ -40,7 +40,7 @@ class TestMissingResourceBar(TestCase):
         common.CURRENT_POP = 3
         common.POP_CAP = 5
         with patch(
-            "script.resources.read_resources_from_hud",
+            "script.resources.reader.read_resources_from_hud",
             side_effect=common.ResourceReadError("missing"),
         ), \
              patch("script.buildings.town_center.select_idle_villager", return_value=True), \
@@ -51,7 +51,7 @@ class TestMissingResourceBar(TestCase):
     def test_build_house_handles_missing_bar(self):
         common.POP_CAP = 4
         with patch(
-            "script.resources.read_resources_from_hud",
+            "script.resources.reader.read_resources_from_hud",
             side_effect=common.ResourceReadError("missing"),
         ):
             self.assertFalse(villager.build_house())

--- a/tests/test_resource_debug_images.py
+++ b/tests/test_resource_debug_images.py
@@ -35,7 +35,7 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
-import script.resources as resources
+import script.resources.reader as resources
 
 
 class TestResourceDebugImages(TestCase):
@@ -58,7 +58,7 @@ class TestResourceDebugImages(TestCase):
 
         with patch("script.screen_utils._grab_frame", side_effect=fake_grab_frame), \
              patch(
-                 "script.resources.locate_resource_panel",
+                 "script.resources.reader.locate_resource_panel",
                  return_value={
                      "wood_stockpile": (0, 0, 50, 50),
                      "food_stockpile": (50, 0, 50, 50),
@@ -68,14 +68,14 @@ class TestResourceDebugImages(TestCase):
                      "idle_villager": (250, 0, 50, 50),
                  },
              ), \
-            patch("script.resources._ocr_digits_better", side_effect=fake_ocr), \
+            patch("script.resources.reader._ocr_digits_better", side_effect=fake_ocr), \
             patch(
-                "script.resources.pytesseract.image_to_data",
+                "script.resources.reader.pytesseract.image_to_data",
                 return_value={"text": [""], "conf": ["0"]},
             ), \
-            patch("script.resources.pytesseract.image_to_string", return_value=""), \
-            patch("script.resources._read_population_from_roi", return_value=(0, 0)), \
-            patch("script.resources.cv2.imwrite") as imwrite_mock:
+            patch("script.resources.reader.pytesseract.image_to_string", return_value=""), \
+            patch("script.resources.reader._read_population_from_roi", return_value=(0, 0)), \
+            patch("script.resources.reader.cv2.imwrite") as imwrite_mock:
             with self.assertRaises(common.ResourceReadError):
                 resources.read_resources_from_hud()
         paths = [call.args[0] for call in imwrite_mock.call_args_list]
@@ -114,7 +114,7 @@ class TestResourceDebugImages(TestCase):
         resources.RESOURCE_CACHE.resource_failure_counts.clear()
         with patch("script.screen_utils._grab_frame", side_effect=fake_grab_frame), \
              patch(
-                 "script.resources.locate_resource_panel",
+                 "script.resources.reader.locate_resource_panel",
                  return_value={
                      "wood_stockpile": (0, 0, 50, 50),
                      "food_stockpile": (50, 0, 50, 50),
@@ -124,15 +124,15 @@ class TestResourceDebugImages(TestCase):
                      "idle_villager": (250, 0, 50, 50),
                  },
              ), \
-             patch("script.resources._ocr_digits_better", side_effect=fake_ocr), \
+             patch("script.resources.reader._ocr_digits_better", side_effect=fake_ocr), \
             patch(
-                "script.resources.pytesseract.image_to_data",
+                "script.resources.reader.pytesseract.image_to_data",
                 side_effect=[{"text": [""], "conf": ["0"]}] * 20
                 + [{"text": ["0"], "conf": ["90"]}],
             ), \
-            patch("script.resources.pytesseract.image_to_string", return_value=""), \
-            patch("script.resources._read_population_from_roi", return_value=(0, 0)), \
-            patch("script.resources.cv2.imwrite") as imwrite_mock:
+            patch("script.resources.reader.pytesseract.image_to_string", return_value=""), \
+            patch("script.resources.reader._read_population_from_roi", return_value=(0, 0)), \
+            patch("script.resources.reader.cv2.imwrite") as imwrite_mock:
             with self.assertRaises(common.ResourceReadError) as ctx:
                 resources.read_resources_from_hud()
 
@@ -152,9 +152,9 @@ class TestResourceDebugImages(TestCase):
         cache = resources.ResourceCache()
 
         with tempfile.TemporaryDirectory() as tmpdir, \
-             patch("script.resources.ROOT", Path(tmpdir)), \
+             patch("script.resources.reader.ROOT", Path(tmpdir)), \
              patch("script.resources.ocr.ROOT", Path(tmpdir)), \
-             patch("script.resources._RESOURCE_DEBUG_COOLDOWN", 60):
+             patch("script.resources.reader._RESOURCE_DEBUG_COOLDOWN", 60):
 
             resources.handle_ocr_failure(frame, regions, results, [], cache_obj=cache)
             debug_dir = Path(tmpdir) / "debug"

--- a/tests/test_resource_force_delay.py
+++ b/tests/test_resource_force_delay.py
@@ -30,7 +30,7 @@ sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
 os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-import script.resources as resources
+import script.resources.reader as resources
 
 
 class TestResourceForceDelay(TestCase):
@@ -49,10 +49,10 @@ class TestResourceForceDelay(TestCase):
             calls.append(("grab", None))
             return np.zeros((1, 1, 3), dtype=np.uint8)
 
-        with patch("script.resources.time.sleep", side_effect=fake_sleep), \
-            patch("script.resources.screen_utils._grab_frame", side_effect=fake_grab), \
-            patch("script.resources.detect_resource_regions", return_value={}), \
-            patch("script.resources.handle_ocr_failure"):
+        with patch("script.resources.reader.time.sleep", side_effect=fake_sleep), \
+            patch("script.resources.reader.screen_utils._grab_frame", side_effect=fake_grab), \
+            patch("script.resources.reader.detect_resource_regions", return_value={}), \
+            patch("script.resources.reader.handle_ocr_failure"):
             resources.read_resources_from_hud([], force_delay=0.1)
 
         assert calls[0] == ("sleep", 0.1)

--- a/tests/test_resource_narrow_roi_expand.py
+++ b/tests/test_resource_narrow_roi_expand.py
@@ -61,7 +61,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback stub
     )
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-import script.resources as resources
+import script.resources.reader as resources
 
 
 class TestNarrowROIExpansion(TestCase):

--- a/tests/test_resource_ocr_failure.py
+++ b/tests/test_resource_ocr_failure.py
@@ -73,7 +73,7 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
-import script.resources as resources
+import script.resources.reader as resources
 
 
 class TestResourceOcrFailure(TestCase):
@@ -94,7 +94,7 @@ class TestResourceOcrFailure(TestCase):
         frame = np.zeros((600, 600, 3), dtype=np.uint8)
 
         with patch(
-            "script.resources.detect_resource_regions",
+            "script.resources.reader.detect_resource_regions",
             return_value={
                 "wood_stockpile": (0, 0, 50, 50),
                 "food_stockpile": (50, 0, 50, 50),
@@ -104,10 +104,10 @@ class TestResourceOcrFailure(TestCase):
                 "idle_villager": (250, 0, 50, 50),
             },
         ), patch("script.resources.ocr._ocr_digits_better", side_effect=fake_ocr), patch(
-            "script.resources.pytesseract.image_to_data",
+            "script.resources.reader.pytesseract.image_to_data",
             return_value={"text": [""], "conf": ["0"]},
         ), patch(
-            "script.resources.pytesseract.image_to_string", return_value="123"
+            "script.resources.reader.pytesseract.image_to_string", return_value="123"
         ), patch("script.resources.ocr._read_population_from_roi", return_value=(0, 0)):
             icons = resources.RESOURCE_ICON_ORDER[:-1]
             result, _ = resources._read_resources(
@@ -137,11 +137,11 @@ class TestResourceOcrFailure(TestCase):
         def fake_ocr(gray):
             return ocr_seq.pop(0)
 
-        with patch("script.resources.detect_resource_regions", side_effect=fake_detect), \
+        with patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
              patch("script.screen_utils._grab_frame", side_effect=fake_grab_frame), \
              patch("script.resources.ocr._ocr_digits_better", side_effect=fake_ocr), \
-             patch("script.resources.pytesseract.image_to_string", return_value=""), \
-             patch("script.resources.cv2.imwrite"):
+             patch("script.resources.reader.pytesseract.image_to_string", return_value=""), \
+             patch("script.resources.reader.cv2.imwrite"):
             result, _ = resources.read_resources_from_hud(["wood_stockpile"])
         self.assertEqual(result.get("wood_stockpile"), 123)
         self.assertIsNone(result.get("food_stockpile"))
@@ -159,11 +159,11 @@ class TestResourceOcrFailure(TestCase):
             data = {"text": ["123"], "conf": ["10", "20", "30"]}
             return "123", data, np.zeros((1, 1), dtype=np.uint8)
 
-        with patch("script.resources.detect_resource_regions", side_effect=fake_detect), \
+        with patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
             patch("script.screen_utils._grab_frame", side_effect=fake_grab_frame), \
             patch("script.resources.ocr._ocr_digits_better", side_effect=fake_ocr) as ocr_mock, \
-            patch("script.resources.pytesseract.image_to_string", return_value="") as img2str_mock, \
-            patch("script.resources.cv2.imwrite"):
+            patch("script.resources.reader.pytesseract.image_to_string", return_value="") as img2str_mock, \
+            patch("script.resources.reader.cv2.imwrite"):
             result, _ = resources.read_resources_from_hud(["wood_stockpile"])
 
         self.assertIsNone(result["wood_stockpile"])
@@ -183,11 +183,11 @@ class TestResourceOcrFailure(TestCase):
             data = {"text": ["123"], "conf": ["10", "20", "30"]}
             return "123", data, np.zeros((1, 1), dtype=np.uint8)
 
-        with patch("script.resources.detect_resource_regions", side_effect=fake_detect), \
+        with patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
             patch("script.screen_utils._grab_frame", side_effect=fake_grab_frame), \
             patch("script.resources.ocr._ocr_digits_better", side_effect=fake_ocr), \
-            patch("script.resources.pytesseract.image_to_string", return_value=""), \
-            patch("script.resources.cv2.imwrite"):
+            patch("script.resources.reader.pytesseract.image_to_string", return_value=""), \
+            patch("script.resources.reader.cv2.imwrite"):
             with self.assertLogs(resources.logger, level="INFO") as cm:
                 result, _ = resources.read_resources_from_hud(["wood_stockpile"])
 
@@ -217,11 +217,11 @@ class TestResourceOcrFailure(TestCase):
         def fake_ocr(gray):
             return ocr_seq.pop(0) if ocr_seq else ("", {"text": [""], "conf": [""]}, np.zeros((1, 1), dtype=np.uint8))
 
-        with patch("script.resources.detect_resource_regions", side_effect=fake_detect), \
+        with patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
             patch("script.screen_utils._grab_frame", side_effect=fake_grab_frame), \
             patch("script.resources.ocr._ocr_digits_better", side_effect=fake_ocr) as ocr_mock, \
-            patch("script.resources.pytesseract.image_to_string", return_value="") as img2str_mock, \
-            patch("script.resources.cv2.imwrite"):
+            patch("script.resources.reader.pytesseract.image_to_string", return_value="") as img2str_mock, \
+            patch("script.resources.reader.cv2.imwrite"):
             result, _ = resources.read_resources_from_hud(["wood_stockpile"])
 
         self.assertIsNone(result["wood_stockpile"])
@@ -241,11 +241,11 @@ class TestResourceOcrFailure(TestCase):
             data = {"text": ["7"], "conf": ["0"]}
             return "7", data, np.zeros((1, 1), dtype=np.uint8)
 
-        with patch("script.resources.detect_resource_regions", side_effect=fake_detect), \
+        with patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
             patch("script.screen_utils._grab_frame", side_effect=fake_grab_frame), \
             patch("script.resources.ocr._ocr_digits_better", side_effect=fake_ocr), \
-            patch("script.resources.pytesseract.image_to_string", return_value="") as img2str_mock, \
-            patch("script.resources.cv2.imwrite"):
+            patch("script.resources.reader.pytesseract.image_to_string", return_value="") as img2str_mock, \
+            patch("script.resources.reader.cv2.imwrite"):
             result, _ = resources.read_resources_from_hud(["wood_stockpile"])
         self.assertIsNone(result["wood_stockpile"])
         img2str_mock.assert_not_called()
@@ -269,11 +269,11 @@ class TestResourceOcrFailure(TestCase):
 
         frame = np.zeros((600, 600, 3), dtype=np.uint8)
 
-        with patch("script.resources.detect_resource_regions", side_effect=fake_detect), \
+        with patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
              patch("script.screen_utils._grab_frame", return_value=frame), \
              patch("script.resources.ocr._ocr_digits_better", side_effect=fake_ocr), \
-             patch("script.resources.pytesseract.image_to_string", return_value=""), \
-             patch("script.resources.cv2.imwrite"):
+             patch("script.resources.reader.pytesseract.image_to_string", return_value=""), \
+             patch("script.resources.reader.cv2.imwrite"):
             first, _ = resources.read_resources_from_hud(["wood_stockpile"])
             second, _ = resources.read_resources_from_hud(["wood_stockpile"])
 
@@ -283,7 +283,7 @@ class TestResourceOcrFailure(TestCase):
     def test_zero_roi_returns_zero(self):
         gray = np.full((20, 20), 128, dtype=np.uint8)
         with patch(
-            "script.resources.pytesseract.image_to_data",
+            "script.resources.reader.pytesseract.image_to_data",
             return_value={"text": [""], "conf": ["-1"]},
         ):
             digits, data, _ = resources._ocr_digits_better(gray)
@@ -308,7 +308,7 @@ class TestResourceOcrFailure(TestCase):
             return roi
 
         with patch(
-            "script.resources.pytesseract.image_to_data",
+            "script.resources.reader.pytesseract.image_to_data",
             return_value={"text": [""], "conf": ["-1"]},
         ), patch.dict(resources.CFG, {"ocr_zero_variance": 50}, clear=False):
             gold, _, _ = resources._ocr_digits_better(make_gold_roi())
@@ -320,9 +320,9 @@ class TestResourceOcrFailure(TestCase):
         frame = np.zeros((20, 20, 3), dtype=np.uint8)
         regions = {"wood_stockpile": (0, 0, 10, 10)}
         results = {"wood_stockpile": None}
-        with patch("script.resources.cv2.imwrite"), \
+        with patch("script.resources.reader.cv2.imwrite"), \
             patch("script.resources.ocr.logger.error") as err_mock, \
-            patch("script.resources.pytesseract.pytesseract.tesseract_cmd", "/usr/bin/true"), \
+            patch("script.resources.reader.pytesseract.pytesseract.tesseract_cmd", "/usr/bin/true"), \
             patch.object(resources.cache, "_NARROW_ROIS", {"wood_stockpile"}):
             resources.handle_ocr_failure(
                 frame, regions, results, ["wood_stockpile"]
@@ -350,8 +350,8 @@ class TestResourceOcrFailure(TestCase):
         mask = np.ones((5, 5), dtype=np.uint8)
         with tempfile.TemporaryDirectory() as tmpdir, \
              patch("script.resources.ocr._ocr_digits_better", return_value=("", {"text": [""]}, mask)), \
-             patch("script.resources.pytesseract.image_to_string", return_value=""), \
-             patch("script.resources.cv2.imwrite") as imwrite_mock, \
+             patch("script.resources.reader.pytesseract.image_to_string", return_value=""), \
+             patch("script.resources.reader.cv2.imwrite") as imwrite_mock, \
              patch("script.resources.ocr.ROOT", Path(tmpdir)):
             digits, data, mask_out, low_conf = resources.execute_ocr(gray)
         self.assertEqual(digits, "")
@@ -396,9 +396,9 @@ class TestGatherHudStatsSliding(TestCase):
             return "", {"text": [""]}, None, False
 
         with patch(
-            "script.resources.detect_resource_regions", side_effect=fake_detect
+            "script.resources.reader.detect_resource_regions", side_effect=fake_detect
         ), patch(
-            "script.resources.preprocess_roi", side_effect=lambda roi: roi[..., 0]
+            "script.resources.reader.preprocess_roi", side_effect=lambda roi: roi[..., 0]
         ), patch.dict(
             resources.cache._LAST_REGION_SPANS,
             {"wood_stockpile": (0, 120)},
@@ -408,9 +408,9 @@ class TestGatherHudStatsSliding(TestCase):
             {"wood_stockpile": (0, 120)},
             clear=True,
         ), patch(
-            "script.resources.execute_ocr", side_effect=fake_execute
+            "script.resources.reader.execute_ocr", side_effect=fake_execute
         ), patch(
-            "script.resources.pytesseract.image_to_string", return_value=""
+            "script.resources.reader.pytesseract.image_to_string", return_value=""
         ):
             resources.cache._NARROW_ROIS.clear()
             resources.cache._NARROW_ROI_DEFICITS.clear()
@@ -520,16 +520,16 @@ class TestResourceOcrRois(TestCase):
             return cur, cap
 
         with patch(
-            "script.resources.detect_resource_regions", side_effect=fake_detect
+            "script.resources.reader.detect_resource_regions", side_effect=fake_detect
         ), patch(
-            "script.resources.preprocess_roi", side_effect=fake_preprocess
+            "script.resources.reader.preprocess_roi", side_effect=fake_preprocess
         ), patch(
             "script.resources.ocr._ocr_digits_better", side_effect=fake_ocr
         ), patch(
             "script.resources.ocr._read_population_from_roi",
             side_effect=fake_pop_reader,
         ), patch(
-            "script.resources.pytesseract.pytesseract.tesseract_cmd", "/usr/bin/true"
+            "script.resources.reader.pytesseract.pytesseract.tesseract_cmd", "/usr/bin/true"
         ):
             results, pop = resources._read_resources(frame, required, required)
 

--- a/tests/test_resource_roi_validation.py
+++ b/tests/test_resource_roi_validation.py
@@ -63,29 +63,30 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
 import script.resources as resources
+import script.resources.reader as reader
 
 
 class TestResourceRoiValidation(TestCase):
     def setUp(self):
-        resources.RESOURCE_CACHE.last_resource_values.clear()
-        resources.RESOURCE_CACHE.last_resource_ts.clear()
-        resources.RESOURCE_CACHE.resource_failure_counts.clear()
-        resources._LAST_REGION_SPANS.clear()
+        reader.RESOURCE_CACHE.last_resource_values.clear()
+        reader.RESOURCE_CACHE.last_resource_ts.clear()
+        reader.RESOURCE_CACHE.resource_failure_counts.clear()
+        reader._LAST_REGION_SPANS.clear()
 
     def tearDown(self):
-        resources.RESOURCE_CACHE.last_resource_values.clear()
-        resources.RESOURCE_CACHE.last_resource_ts.clear()
-        resources.RESOURCE_CACHE.resource_failure_counts.clear()
-        resources._LAST_REGION_SPANS.clear()
+        reader.RESOURCE_CACHE.last_resource_values.clear()
+        reader.RESOURCE_CACHE.last_resource_ts.clear()
+        reader.RESOURCE_CACHE.resource_failure_counts.clear()
+        reader._LAST_REGION_SPANS.clear()
 
     def test_zero_width_roi_raises(self):
         frame = np.zeros((100, 100, 3), dtype=np.uint8)
         with patch(
-            "script.resources.detect_resource_regions",
+            "script.resources.reader.detect_resource_regions",
             return_value={"wood_stockpile": (0, 0, 0, 10)},
         ):
             with self.assertRaises(common.ResourceReadError):
-                resources._read_resources(
+                reader._read_resources(
                     frame,
                     ["wood_stockpile"],
                     ["wood_stockpile"],
@@ -99,7 +100,7 @@ class TestResourceRoiValidation(TestCase):
         calibrated = {"wood_stockpile": (50, 5, 20, 10)}
 
         def fake_auto_calibrate(_frame, _cache):
-            resources._LAST_REGION_SPANS["wood_stockpile"] = (
+            reader._LAST_REGION_SPANS["wood_stockpile"] = (
                 calibrated["wood_stockpile"][0],
                 calibrated["wood_stockpile"][0] + calibrated["wood_stockpile"][2],
             )
@@ -115,6 +116,6 @@ class TestResourceRoiValidation(TestCase):
 
         self.assertTrue(mock_calib.called)
         self.assertEqual(regions["wood_stockpile"], calibrated["wood_stockpile"])
-        span = resources._LAST_REGION_SPANS.get("wood_stockpile")
+        span = reader._LAST_REGION_SPANS.get("wood_stockpile")
         self.assertEqual(span, (50, 70))
         self.assertGreater(span[1], span[0])

--- a/tests/test_select_idle_villager.py
+++ b/tests/test_select_idle_villager.py
@@ -43,7 +43,7 @@ class TestSelectIdleVillager(TestCase):
         ])
 
         with patch("script.input_utils._press_key_safe"), \
-             patch("script.resources.read_resources_from_hud", side_effect=lambda *a, **k: next(reads)):
+             patch("script.resources.reader.read_resources_from_hud", side_effect=lambda *a, **k: next(reads)):
             self.assertTrue(villager.select_idle_villager())
 
     def test_returns_false_when_no_idle_villagers(self):
@@ -53,5 +53,5 @@ class TestSelectIdleVillager(TestCase):
         ])
 
         with patch("script.input_utils._press_key_safe"), \
-             patch("script.resources.read_resources_from_hud", side_effect=lambda *a, **k: next(reads)):
+             patch("script.resources.reader.read_resources_from_hud", side_effect=lambda *a, **k: next(reads)):
             self.assertFalse(villager.select_idle_villager())

--- a/tests/test_wood_stockpile_low_conf_retry.py
+++ b/tests/test_wood_stockpile_low_conf_retry.py
@@ -28,7 +28,7 @@ sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
 os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-import script.resources as resources
+import script.resources.reader as resources
 
 class TestWoodStockpileLowConfRetry(TestCase):
     def setUp(self):
@@ -54,11 +54,11 @@ class TestWoodStockpileLowConfRetry(TestCase):
             calls.append(conf_threshold)
             return "999", {"conf": [conf_threshold or 0]}, None, True
 
-        with patch("script.resources.detect_resource_regions", side_effect=fake_detect), \
+        with patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
              patch("script.screen_utils._grab_frame", return_value=frame), \
-             patch("script.resources.preprocess_roi", side_effect=lambda roi: roi[..., 0]), \
-             patch("script.resources.execute_ocr", side_effect=fake_execute), \
-             patch("script.resources.cv2.imwrite"), \
+             patch("script.resources.reader.preprocess_roi", side_effect=lambda roi: roi[..., 0]), \
+             patch("script.resources.reader.execute_ocr", side_effect=fake_execute), \
+             patch("script.resources.reader.cv2.imwrite"), \
              patch.dict(resources.CFG, {"treat_low_conf_as_failure": True}, clear=False):
             result, _ = resources.read_resources_from_hud(["wood_stockpile"])
 

--- a/tools/campaign_bot.py
+++ b/tools/campaign_bot.py
@@ -6,7 +6,9 @@ patch helper functions without duplicating the full implementation.
 import script.common as common
 import script.hud as hud
 import script.screen_utils as screen_utils
-import script.resources as resources
+import script.resources.reader as resources
+from script.resources import panel
+from script.resources.ocr import _read_population_from_roi as _read_population_from_roi_func
 import numpy as np
 
 # Public API expected by the tests
@@ -17,8 +19,8 @@ HUD_TEMPLATE = np.zeros((1, 1), dtype=np.uint8)
 # Default helpers (can be monkeypatched in tests)
 _grab_frame = screen_utils._grab_frame
 find_template = hud.find_template
-locate_resource_panel = resources.locate_resource_panel
-_read_population_from_roi = resources._read_population_from_roi
+locate_resource_panel = panel.locate_resource_panel
+_read_population_from_roi = _read_population_from_roi_func
 
 def wait_hud(timeout=60):
     """Delegate to :func:`script.hud.wait_hud` using patched helpers."""
@@ -45,7 +47,7 @@ def _ocr_digits_better(gray):
 def read_resources_from_hud(required_icons=None, conf_threshold=None):
     """Delegate to :func:`script.resources.read_resources_from_hud` using patched helpers."""
     common.HUD_ANCHOR = HUD_ANCHOR
-    original_locate = resources.locate_resource_panel
+    original_locate = panel.locate_resource_panel
     original_grab = screen_utils._grab_frame
     original_ocr = resources._ocr_digits_better
 
@@ -56,7 +58,7 @@ def read_resources_from_hud(required_icons=None, conf_threshold=None):
             return digits, data, None
         return res
 
-    resources.locate_resource_panel = locate_resource_panel
+    panel.locate_resource_panel = locate_resource_panel
     screen_utils._grab_frame = _grab_frame
     resources._ocr_digits_better = wrapper
     try:
@@ -65,7 +67,7 @@ def read_resources_from_hud(required_icons=None, conf_threshold=None):
             kwargs["conf_threshold"] = conf_threshold
         return resources.read_resources_from_hud(required_icons, **kwargs)
     finally:
-        resources.locate_resource_panel = original_locate
+        panel.locate_resource_panel = original_locate
         screen_utils._grab_frame = original_grab
         resources._ocr_digits_better = original_ocr
 
@@ -79,7 +81,7 @@ def gather_hud_stats(
 ):
     """Delegate to :func:`script.resources.gather_hud_stats` using patched helpers."""
     common.HUD_ANCHOR = HUD_ANCHOR
-    original_locate = resources.locate_resource_panel
+    original_locate = panel.locate_resource_panel
     original_grab = screen_utils._grab_frame
     original_ocr = resources._ocr_digits_better
     original_pop = resources._read_population_from_roi
@@ -91,7 +93,7 @@ def gather_hud_stats(
             return digits, data, None
         return res
 
-    resources.locate_resource_panel = locate_resource_panel
+    panel.locate_resource_panel = locate_resource_panel
     screen_utils._grab_frame = _grab_frame
     resources._ocr_digits_better = wrapper
     resources._read_population_from_roi = _read_population_from_roi
@@ -106,7 +108,7 @@ def gather_hud_stats(
             kwargs["conf_threshold"] = conf_threshold
         return resources.gather_hud_stats(**kwargs)
     finally:
-        resources.locate_resource_panel = original_locate
+        panel.locate_resource_panel = original_locate
         screen_utils._grab_frame = original_grab
         resources._ocr_digits_better = original_ocr
         resources._read_population_from_roi = original_pop


### PR DESCRIPTION
## Summary
- isolate HUD resource reading utilities into script/resources/reader.py
- slim down script.resources package to re-export submodules
- update imports throughout project and tests to use new reader module

## Testing
- `pytest` *(fails: 36 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b34bd6c1e083259e970aa643669c8a