### PR TITLE
Refactor OCR helpers into modular package

### DIFF
--- a/script/resources/__init__.py
+++ b/script/resources/__init__.py
@@ -64,7 +64,6 @@ from .panel import (
 # OCR helpers
 from .ocr import (
     preprocess_roi,
-    _ocr_digits_better,
     execute_ocr,
     handle_ocr_failure,
     _read_population_from_roi,

--- a/script/resources/ocr/__init__.py
+++ b/script/resources/ocr/__init__.py
@@ -1,4 +1,7 @@
 """OCR helpers for reading HUD resources."""
+
+from __future__ import annotations
+
 import logging
 import time
 
@@ -6,9 +9,9 @@ import cv2
 import numpy as np
 import pytesseract
 
-from . import CFG, ROOT
-from . import screen_utils, common
-from . import cache
+from .. import CFG, ROOT, screen_utils, common, cache
+from .preprocess import preprocess_roi
+from . import masks
 
 logger = logging.getLogger(__name__)
 
@@ -44,146 +47,6 @@ def _sanitize_digits(digits: str) -> str:
     return trimmed[:3]
 
 
-def preprocess_roi(roi):
-    """Convert ROI to a blurred grayscale image."""
-
-    gray = cv2.cvtColor(roi, cv2.COLOR_BGR2GRAY)
-    kernel = CFG.get("ocr_blur_kernel", 1)
-    if kernel and kernel > 1 and gray.shape[0] >= 30:
-        gray = cv2.medianBlur(gray, kernel)
-    return gray
-
-
-def _ocr_digits_better(gray, color=None, resource=None):
-    variance = float(np.var(gray))
-    if variance < CFG.get("ocr_zero_variance", 15.0):
-        return "0", {"zero_variance": True}, None
-
-    gray = cv2.resize(gray, None, fx=2, fy=2, interpolation=cv2.INTER_LINEAR)
-    bilateral = CFG.get("ocr_bilateral", [7, 60, 60])
-    if bilateral:
-        if isinstance(bilateral, dict):
-            d = bilateral.get("d", 7)
-            sc = bilateral.get("sigmaColor", bilateral.get("sc", 60))
-            ss = bilateral.get("sigmaSpace", bilateral.get("ss", 60))
-            gray = cv2.bilateralFilter(gray, d, sc, ss)
-        elif isinstance(bilateral, (list, tuple)) and len(bilateral) >= 3:
-            gray = cv2.bilateralFilter(gray, bilateral[0], bilateral[1], bilateral[2])
-        else:
-            gray = cv2.bilateralFilter(gray, 7, 60, 60)
-    orig = gray.copy()
-    equalize = CFG.get("ocr_equalize_hist", True)
-    if equalize:
-        if isinstance(equalize, dict):
-            clip = equalize.get("clipLimit", equalize.get("clip_limit", 2.0))
-            tile = tuple(equalize.get("tileGridSize", equalize.get("tile_grid_size", (8, 8))))
-            clahe = cv2.createCLAHE(clipLimit=clip, tileGridSize=tile)
-            gray = clahe.apply(gray)
-        else:
-            gray = cv2.equalizeHist(gray)
-
-    contrast = CFG.get("ocr_contrast_stretch")
-    if contrast:
-        if isinstance(contrast, dict):
-            alpha = contrast.get("alpha", 0)
-            beta = contrast.get("beta", 255)
-            norm_type = getattr(cv2, contrast.get("norm_type", "NORM_MINMAX"), cv2.NORM_MINMAX)
-            gray = cv2.normalize(gray, None, alpha=alpha, beta=beta, norm_type=norm_type)
-        else:
-            gray = cv2.normalize(gray, None, 0, 255, cv2.NORM_MINMAX)
-
-    kernel_size = CFG.get("ocr_kernel_size", 2)
-    kernel = np.ones((kernel_size, kernel_size), np.uint8)
-    psms = list(
-        dict.fromkeys(CFG.get("ocr_psm_list", []) + [6, 7, 8, 10, 13])
-    )
-
-    debug = CFG.get("ocr_debug")
-    debug_dir = ROOT / "debug" if debug else None
-    ts = int(time.time() * 1000) if debug else None
-
-    def _run_masks(masks, start_idx=0):
-        results = []
-        for idx, mask in enumerate(masks, start=start_idx):
-            if debug:
-                debug_dir.mkdir(exist_ok=True)
-                cv2.imwrite(str(debug_dir / f"ocr_mask_{ts}_{idx}.png"), mask)
-            for psm in psms:
-                data = pytesseract.image_to_data(
-                    mask,
-                    config=f"--psm {psm} --oem 3 -c tessedit_char_whitelist=0123456789",
-                    output_type=pytesseract.Output.DICT,
-                )
-                text = "".join(data.get("text", [])).strip()
-                digits = "".join(filter(str.isdigit, text))
-                results.append((digits, data, mask))
-        results.sort(key=lambda r: len(r[0]), reverse=True)
-        return results[0]
-
-    def _is_nearly_empty(mask, tol=0.01):
-        if mask.size == 0:
-            return True
-        ratio = cv2.countNonZero(mask) / mask.size
-        return ratio < tol or ratio > 1 - tol
-
-    thresh = cv2.adaptiveThreshold(
-        gray, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C, cv2.THRESH_BINARY, 11, 2
-    )
-    if resource == "wood_stockpile":
-        thresh = cv2.morphologyEx(thresh, cv2.MORPH_CLOSE, kernel, iterations=1)
-    if _is_nearly_empty(thresh):
-        _otsu_ret, thresh = cv2.threshold(
-            gray, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU
-        )
-    primary = _run_masks([thresh, cv2.bitwise_not(thresh)], 0)
-    if primary[0]:
-        return primary
-
-    adaptive = cv2.adaptiveThreshold(
-        gray, 255, cv2.ADAPTIVE_THRESH_MEAN_C, cv2.THRESH_BINARY, 11, 2
-    )
-    adaptive = cv2.dilate(adaptive, kernel, iterations=1)
-    if resource == "wood_stockpile":
-        adaptive = cv2.morphologyEx(adaptive, cv2.MORPH_CLOSE, kernel, iterations=1)
-    if _is_nearly_empty(adaptive):
-        _otsu_ret, adaptive = cv2.threshold(
-            gray, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU
-        )
-    digits, data, mask = _run_masks([adaptive, cv2.bitwise_not(adaptive)], 2)
-
-    if not digits:
-        if color is not None:
-            hsv = cv2.cvtColor(color, cv2.COLOR_BGR2HSV)
-        else:
-            hsv = cv2.cvtColor(cv2.cvtColor(orig, cv2.COLOR_GRAY2BGR), cv2.COLOR_BGR2HSV)
-        if resource == "wood_stockpile":
-            brown_mask = cv2.inRange(
-                hsv, np.array([10, 80, 40]), np.array([25, 255, 200])
-            )
-            digit_mask = cv2.bitwise_not(brown_mask)
-            digits, data, mask = _run_masks([digit_mask, cv2.bitwise_not(digit_mask)], 4)
-            if not digits:
-                closed = cv2.morphologyEx(digit_mask, cv2.MORPH_CLOSE, kernel, iterations=1)
-                digits, data, mask = _run_masks([closed, cv2.bitwise_not(closed)], 6)
-        else:
-            white_mask = cv2.inRange(hsv, np.array([0, 0, 200]), np.array([180, 30, 255]))
-            yellow_mask = cv2.inRange(hsv, np.array([20, 100, 180]), np.array([40, 255, 255]))
-            gray_mask = cv2.inRange(hsv, np.array([0, 0, 160]), np.array([180, 50, 220]))
-            color_mask = cv2.bitwise_or(white_mask, yellow_mask)
-            color_mask = cv2.bitwise_or(color_mask, gray_mask)
-            digits, data, mask = _run_masks([color_mask, cv2.bitwise_not(color_mask)], 4)
-            if not digits:
-                closed = cv2.morphologyEx(color_mask, cv2.MORPH_CLOSE, kernel, iterations=1)
-                digits, data, mask = _run_masks([closed, cv2.bitwise_not(closed)], 6)
-
-    if not digits:
-        variance = float(np.var(orig))
-        if variance < CFG.get("ocr_zero_variance", 15.0):
-            return "0", {"zero_variance": True}, mask
-
-    return digits, data, mask
-
-
 def execute_ocr(
     gray,
     color=None,
@@ -198,9 +61,9 @@ def execute_ocr(
         conf_threshold = CFG.get("ocr_conf_threshold", 60)
 
     try:
-        digits, data, mask = _ocr_digits_better(gray, color, resource=resource)
+        digits, data, mask = masks._ocr_digits_better(gray, color, resource=resource)
     except TypeError:
-        digits, data, mask = _ocr_digits_better(gray)
+        digits, data, mask = masks._ocr_digits_better(gray)
     low_conf = False
     best_digits = digits
     best_data = data
@@ -232,9 +95,9 @@ def execute_ocr(
             digits, data, mask = best_digits, best_data, best_mask
             break
         try:
-            digits, data, mask = _ocr_digits_better(gray, color, resource=resource)
+            digits, data, mask = masks._ocr_digits_better(gray, color, resource=resource)
         except TypeError:
-            digits, data, mask = _ocr_digits_better(gray)
+            digits, data, mask = masks._ocr_digits_better(gray)
         if digits:
             best_digits, best_data, best_mask = digits, data, mask
         if attempts == max_attempts:
@@ -578,7 +441,8 @@ def _extract_population(frame, regions, results, pop_required, conf_threshold=No
 
 __all__ = [
     "preprocess_roi",
-    "_ocr_digits_better",
+    "parse_confidences",
+    "_sanitize_digits",
     "execute_ocr",
     "handle_ocr_failure",
     "_read_population_from_roi",

--- a/script/resources/ocr/colors.py
+++ b/script/resources/ocr/colors.py
@@ -1,0 +1,36 @@
+"""Color-based heuristics for OCR masking."""
+
+import cv2
+import numpy as np
+
+
+def color_mask_sets(hsv, resource, kernel):
+    """Return base and closed masks based on resource color heuristics.
+
+    Parameters
+    ----------
+    hsv : ndarray
+        HSV image of the ROI.
+    resource : str | None
+        Name of the resource being read.
+    kernel : ndarray
+        Structuring element for morphological operations.
+    """
+
+    if resource == "wood_stockpile":
+        brown_mask = cv2.inRange(hsv, np.array([10, 80, 40]), np.array([25, 255, 200]))
+        digit_mask = cv2.bitwise_not(brown_mask)
+    else:
+        white_mask = cv2.inRange(hsv, np.array([0, 0, 200]), np.array([180, 30, 255]))
+        yellow_mask = cv2.inRange(hsv, np.array([20, 100, 180]), np.array([40, 255, 255]))
+        gray_mask = cv2.inRange(hsv, np.array([0, 0, 160]), np.array([180, 50, 220]))
+        digit_mask = cv2.bitwise_or(white_mask, yellow_mask)
+        digit_mask = cv2.bitwise_or(digit_mask, gray_mask)
+
+    base_masks = [digit_mask, cv2.bitwise_not(digit_mask)]
+    closed = cv2.morphologyEx(digit_mask, cv2.MORPH_CLOSE, kernel, iterations=1)
+    closed_masks = [closed, cv2.bitwise_not(closed)]
+    return base_masks, closed_masks
+
+
+__all__ = ["color_mask_sets"]

--- a/script/resources/ocr/masks.py
+++ b/script/resources/ocr/masks.py
@@ -1,0 +1,132 @@
+"""Masking logic for OCR digit recognition."""
+
+from __future__ import annotations
+
+import time
+
+import cv2
+import numpy as np
+import pytesseract
+
+from .. import CFG, ROOT
+from .colors import color_mask_sets
+
+
+def _run_masks(masks, psms, debug, debug_dir, ts, start_idx=0):
+    results = []
+    for idx, mask in enumerate(masks, start=start_idx):
+        if debug and debug_dir is not None:
+            debug_dir.mkdir(exist_ok=True)
+            cv2.imwrite(str(debug_dir / f"ocr_mask_{ts}_{idx}.png"), mask)
+        for psm in psms:
+            data = pytesseract.image_to_data(
+                mask,
+                config=f"--psm {psm} --oem 3 -c tessedit_char_whitelist=0123456789",
+                output_type=pytesseract.Output.DICT,
+            )
+            text = "".join(data.get("text", [])).strip()
+            digits = "".join(filter(str.isdigit, text))
+            results.append((digits, data, mask))
+    if not results:
+        return "", {"text": [], "conf": []}, None
+    results.sort(key=lambda r: len(r[0]), reverse=True)
+    return results[0]
+
+
+def _is_nearly_empty(mask, tol=0.01):
+    if mask.size == 0:
+        return True
+    ratio = cv2.countNonZero(mask) / mask.size
+    return ratio < tol or ratio > 1 - tol
+
+
+def _ocr_digits_better(gray, color=None, resource=None):
+    variance = float(np.var(gray))
+    if variance < CFG.get("ocr_zero_variance", 15.0):
+        return "0", {"zero_variance": True}, None
+
+    gray = cv2.resize(gray, None, fx=2, fy=2, interpolation=cv2.INTER_LINEAR)
+    bilateral = CFG.get("ocr_bilateral", [7, 60, 60])
+    if bilateral:
+        if isinstance(bilateral, dict):
+            d = bilateral.get("d", 7)
+            sc = bilateral.get("sigmaColor", bilateral.get("sc", 60))
+            ss = bilateral.get("sigmaSpace", bilateral.get("ss", 60))
+            gray = cv2.bilateralFilter(gray, d, sc, ss)
+        elif isinstance(bilateral, (list, tuple)) and len(bilateral) >= 3:
+            gray = cv2.bilateralFilter(gray, bilateral[0], bilateral[1], bilateral[2])
+        else:
+            gray = cv2.bilateralFilter(gray, 7, 60, 60)
+    orig = gray.copy()
+    equalize = CFG.get("ocr_equalize_hist", True)
+    if equalize:
+        if isinstance(equalize, dict):
+            clip = equalize.get("clipLimit", equalize.get("clip_limit", 2.0))
+            tile = tuple(equalize.get("tileGridSize", equalize.get("tile_grid_size", (8, 8))))
+            clahe = cv2.createCLAHE(clipLimit=clip, tileGridSize=tile)
+            gray = clahe.apply(gray)
+        else:
+            gray = cv2.equalizeHist(gray)
+
+    contrast = CFG.get("ocr_contrast_stretch")
+    if contrast:
+        if isinstance(contrast, dict):
+            alpha = contrast.get("alpha", 0)
+            beta = contrast.get("beta", 255)
+            norm_type = getattr(cv2, contrast.get("norm_type", "NORM_MINMAX"), cv2.NORM_MINMAX)
+            gray = cv2.normalize(gray, None, alpha=alpha, beta=beta, norm_type=norm_type)
+        else:
+            gray = cv2.normalize(gray, None, 0, 255, cv2.NORM_MINMAX)
+
+    kernel_size = CFG.get("ocr_kernel_size", 2)
+    kernel = np.ones((kernel_size, kernel_size), np.uint8)
+    psms = list(dict.fromkeys(CFG.get("ocr_psm_list", []) + [6, 7, 8, 10, 13]))
+
+    debug = CFG.get("ocr_debug")
+    debug_dir = ROOT / "debug" if debug else None
+    ts = int(time.time() * 1000) if debug else None
+
+    thresh = cv2.adaptiveThreshold(
+        gray, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C, cv2.THRESH_BINARY, 11, 2
+    )
+    if resource == "wood_stockpile":
+        thresh = cv2.morphologyEx(thresh, cv2.MORPH_CLOSE, kernel, iterations=1)
+    if _is_nearly_empty(thresh):
+        _otsu_ret, thresh = cv2.threshold(
+            gray, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU
+        )
+    digits, data, mask = _run_masks([thresh, cv2.bitwise_not(thresh)], psms, debug, debug_dir, ts, 0)
+    if digits:
+        return digits, data, mask
+
+    adaptive = cv2.adaptiveThreshold(
+        gray, 255, cv2.ADAPTIVE_THRESH_MEAN_C, cv2.THRESH_BINARY, 11, 2
+    )
+    adaptive = cv2.dilate(adaptive, kernel, iterations=1)
+    if resource == "wood_stockpile":
+        adaptive = cv2.morphologyEx(adaptive, cv2.MORPH_CLOSE, kernel, iterations=1)
+    if _is_nearly_empty(adaptive):
+        _otsu_ret, adaptive = cv2.threshold(
+            gray, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU
+        )
+    digits, data, mask = _run_masks([adaptive, cv2.bitwise_not(adaptive)], psms, debug, debug_dir, ts, 2)
+
+    if not digits:
+        if color is not None:
+            hsv = cv2.cvtColor(color, cv2.COLOR_BGR2HSV)
+        else:
+            hsv = cv2.cvtColor(cv2.cvtColor(orig, cv2.COLOR_GRAY2BGR), cv2.COLOR_BGR2HSV)
+        base_masks, closed_masks = color_mask_sets(hsv, resource, kernel)
+        digits, data, mask = _run_masks(base_masks, psms, debug, debug_dir, ts, 4)
+        if not digits:
+            digits, data, mask = _run_masks(closed_masks, psms, debug, debug_dir, ts, 6)
+
+    if not digits:
+        variance = float(np.var(orig))
+        if variance < CFG.get("ocr_zero_variance", 15.0):
+            return "0", {"zero_variance": True}, mask
+
+    return digits, data, mask
+
+
+__all__ = ["_ocr_digits_better", "_run_masks", "_is_nearly_empty"]

--- a/script/resources/ocr/preprocess.py
+++ b/script/resources/ocr/preprocess.py
@@ -1,0 +1,18 @@
+"""Image preprocessing utilities for OCR."""
+
+import cv2
+
+from .. import CFG
+
+
+def preprocess_roi(roi):
+    """Convert ROI to a blurred grayscale image."""
+
+    gray = cv2.cvtColor(roi, cv2.COLOR_BGR2GRAY)
+    kernel = CFG.get("ocr_blur_kernel", 1)
+    if kernel and kernel > 1 and gray.shape[0] >= 30:
+        gray = cv2.medianBlur(gray, kernel)
+    return gray
+
+
+__all__ = ["preprocess_roi"]

--- a/script/resources/reader.py
+++ b/script/resources/reader.py
@@ -10,6 +10,7 @@ import pytesseract
 from . import CFG, ROOT, cache, common, logger, screen_utils, RESOURCE_ICON_ORDER
 from .panel import detect_resource_regions
 from . import ocr
+from .ocr import masks
 
 # Re-export cache utilities
 ResourceCache = cache.ResourceCache
@@ -28,7 +29,7 @@ _LAST_NO_DIGITS: set[str] = set()
 
 # OCR helpers
 preprocess_roi = ocr.preprocess_roi
-_ocr_digits_better = ocr._ocr_digits_better
+_ocr_digits_better = masks._ocr_digits_better
 execute_ocr = ocr.execute_ocr
 handle_ocr_failure = ocr.handle_ocr_failure
 _read_population_from_roi = ocr._read_population_from_roi

--- a/tests/test_resource_helpers.py
+++ b/tests/test_resource_helpers.py
@@ -86,7 +86,7 @@ class TestPreprocessRoi(TestCase):
 class TestExecuteOcr(TestCase):
     def test_execute_ocr_fallback(self):
         gray = np.zeros((5, 5), dtype=np.uint8)
-        with patch("script.resources.ocr._ocr_digits_better", return_value=("", {}, None)), \
+        with patch("script.resources.ocr.masks._ocr_digits_better", return_value=("", {}, None)), \
              patch("script.resources.reader.pytesseract.image_to_string", return_value="456"):
             digits, data, mask, low_conf = resources.execute_ocr(
                 gray, resource="wood_stockpile"
@@ -99,7 +99,7 @@ class TestExecuteOcr(TestCase):
     def test_execute_ocr_warns_low_confidence(self):
         gray = np.zeros((5, 5), dtype=np.uint8)
         data = {"text": ["123"], "conf": ["10", "20", "30"]}
-        with patch("script.resources.ocr._ocr_digits_better", return_value=("123", data, None)), \
+        with patch("script.resources.ocr.masks._ocr_digits_better", return_value=("123", data, None)), \
              patch("script.resources.reader.pytesseract.image_to_string", return_value="") as img2str_mock:
             digits, data_out, _, low_conf = resources.execute_ocr(
                 gray, conf_threshold=60, resource="wood_stockpile"
@@ -111,7 +111,7 @@ class TestExecuteOcr(TestCase):
     def test_execute_ocr_warns_low_mean_confidence(self):
         gray = np.zeros((5, 5), dtype=np.uint8)
         data = {"text": ["12"], "conf": ["80", "20"]}
-        with patch("script.resources.ocr._ocr_digits_better", return_value=("12", data, None)), \
+        with patch("script.resources.ocr.masks._ocr_digits_better", return_value=("12", data, None)), \
              patch("script.resources.reader.pytesseract.image_to_string", return_value="") as img2str_mock, \
              patch.dict(resources.CFG, {"ocr_conf_decay": 1.0}, clear=False):
             digits, data_out, _, low_conf = resources.execute_ocr(
@@ -124,7 +124,7 @@ class TestExecuteOcr(TestCase):
     def test_execute_ocr_accepts_mixed_confidence_digits(self):
         gray = np.zeros((5, 5), dtype=np.uint8)
         data = {"text": ["789"], "conf": ["90", "10", "90"]}
-        with patch("script.resources.ocr._ocr_digits_better", return_value=("789", data, None)), \
+        with patch("script.resources.ocr.masks._ocr_digits_better", return_value=("789", data, None)), \
              patch("script.resources.reader.pytesseract.image_to_string", return_value="") as img2str_mock, \
              patch.dict(resources.CFG, {"ocr_conf_decay": 1.0}, clear=False):
             digits, data_out, _, low_conf = resources.execute_ocr(
@@ -137,7 +137,7 @@ class TestExecuteOcr(TestCase):
     def test_execute_ocr_accepts_low_conf_single_digit(self):
         gray = np.zeros((5, 5), dtype=np.uint8)
         data = {"text": ["0"], "conf": ["10"]}
-        with patch("script.resources.ocr._ocr_digits_better", return_value=("0", data, None)), \
+        with patch("script.resources.ocr.masks._ocr_digits_better", return_value=("0", data, None)), \
              patch("script.resources.reader.pytesseract.image_to_string", return_value="") as img2str_mock:
             digits, data_out, _, low_conf = resources.execute_ocr(
                 gray, conf_threshold=60, resource="wood_stockpile"
@@ -151,7 +151,7 @@ class TestExecuteOcr(TestCase):
         data1 = {"text": ["123"], "conf": ["0", "0", "0"]}
         data2 = {"text": ["789"], "conf": ["80", "90", "100"]}
         with patch(
-            "script.resources.ocr._ocr_digits_better",
+            "script.resources.ocr.masks._ocr_digits_better",
             side_effect=[("123", data1, None), ("789", data2, None)],
         ) as ocr_mock, patch("script.resources.reader.pytesseract.image_to_string") as img2str_mock:
             digits, _, _, low_conf = resources.execute_ocr(
@@ -165,7 +165,7 @@ class TestExecuteOcr(TestCase):
     def test_execute_ocr_zero_variance_shortcut(self):
         gray = np.zeros((5, 5), dtype=np.uint8)
         with patch(
-            "script.resources.ocr._ocr_digits_better",
+            "script.resources.ocr.masks._ocr_digits_better",
             return_value=("0", {"zero_variance": True}, None),
         ), patch("script.resources.reader.pytesseract.image_to_string") as img2str_mock, patch(
             "script.resources.reader.logger.warning"
@@ -187,7 +187,7 @@ class TestExecuteOcr(TestCase):
             ("12", {"text": ["12"], "conf": ["40", "40"]}, None)
             for _ in range(4)
         ]
-        with patch("script.resources.ocr._ocr_digits_better", side_effect=side_effect) as ocr_mock, \
+        with patch("script.resources.ocr.masks._ocr_digits_better", side_effect=side_effect) as ocr_mock, \
              patch("script.resources.reader.pytesseract.image_to_string", return_value="") as img2str_mock, \
              patch.dict(resources.CFG, {"ocr_conf_min": 30, "ocr_conf_decay": 0.5}, clear=False):
             digits, data_out, _, low_conf = resources.execute_ocr(
@@ -202,7 +202,7 @@ class TestExecuteOcr(TestCase):
     def test_execute_ocr_ignores_non_positive_confidences(self):
         gray = np.zeros((5, 5), dtype=np.uint8)
         data = {"text": ["12"], "conf": [-1, "0", "95"]}
-        with patch("script.resources.ocr._ocr_digits_better", return_value=("12", data, None)), \
+        with patch("script.resources.ocr.masks._ocr_digits_better", return_value=("12", data, None)), \
              patch("script.resources.reader.pytesseract.image_to_string", return_value="") as img2str_mock:
             digits, _, _, low_conf = resources.execute_ocr(
                 gray, conf_threshold=60, resource="wood_stockpile"


### PR DESCRIPTION
## Summary
- split OCR utilities into new `ocr` package with preprocessing, mask, and color modules
- expose high-level OCR API from `script.resources.ocr`
- update resource reader and tests for refactored layout

## Testing
- `pytest tests/test_resource_ocr_failure.py tests/test_resource_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_68b34f3402f08325ae7e78ebed998782