### PR TITLE
Refactor resource reader into package modules

### DIFF
--- a/script/resources/reader/__init__.py
+++ b/script/resources/reader/__init__.py
@@ -1,0 +1,64 @@
+"""Functions for reading resource values from the HUD."""
+
+import time
+from typing import Iterable
+
+import cv2
+import numpy as np
+import pytesseract
+
+from .. import CFG, ROOT, cache, common, logger, screen_utils, RESOURCE_ICON_ORDER
+from ..panel import detect_resource_regions, locate_resource_panel
+from .. import ocr
+from ..ocr import masks
+
+# Re-export OCR helpers
+preprocess_roi = ocr.preprocess_roi
+_ocr_digits_better = masks._ocr_digits_better
+execute_ocr = ocr.execute_ocr
+handle_ocr_failure = ocr.handle_ocr_failure
+_read_population_from_roi = ocr._read_population_from_roi
+read_population_from_roi = ocr.read_population_from_roi
+_extract_population = ocr._extract_population
+
+from .cache_utils import (
+    ResourceCache,
+    RESOURCE_CACHE,
+    _LAST_READ_FROM_CACHE,
+    _NARROW_ROIS,
+    _NARROW_ROI_DEFICITS,
+    _RESOURCE_CACHE_TTL,
+    _RESOURCE_CACHE_MAX_AGE,
+    _RESOURCE_DEBUG_COOLDOWN,
+    _LAST_REGION_BOUNDS,
+    _LAST_REGION_SPANS,
+)
+from .roi import prepare_roi, expand_roi_after_failure
+from .core import (
+    _read_resources,
+    read_resources_from_hud,
+    gather_hud_stats,
+    validate_starting_resources,
+)
+
+__all__ = [
+    "ResourceCache",
+    "RESOURCE_CACHE",
+    "_LAST_READ_FROM_CACHE",
+    "_NARROW_ROIS",
+    "_NARROW_ROI_DEFICITS",
+    "_RESOURCE_CACHE_TTL",
+    "_RESOURCE_DEBUG_COOLDOWN",
+    "_LAST_REGION_BOUNDS",
+    "_LAST_REGION_SPANS",
+    "preprocess_roi",
+    "_ocr_digits_better",
+    "execute_ocr",
+    "handle_ocr_failure",
+    "_read_population_from_roi",
+    "read_population_from_roi",
+    "_read_resources",
+    "read_resources_from_hud",
+    "gather_hud_stats",
+    "validate_starting_resources",
+]

--- a/script/resources/reader/cache_utils.py
+++ b/script/resources/reader/cache_utils.py
@@ -1,0 +1,33 @@
+from .. import cache
+
+ResourceCache = cache.ResourceCache
+RESOURCE_CACHE = cache.RESOURCE_CACHE
+_LAST_READ_FROM_CACHE = cache._LAST_READ_FROM_CACHE
+_NARROW_ROIS = cache._NARROW_ROIS
+_NARROW_ROI_DEFICITS = cache._NARROW_ROI_DEFICITS
+_RESOURCE_CACHE_TTL = cache._RESOURCE_CACHE_TTL
+_RESOURCE_CACHE_MAX_AGE = cache._RESOURCE_CACHE_MAX_AGE
+_RESOURCE_DEBUG_COOLDOWN = cache._RESOURCE_DEBUG_COOLDOWN
+_LAST_REGION_BOUNDS = cache._LAST_REGION_BOUNDS
+_LAST_REGION_SPANS = cache._LAST_REGION_SPANS
+
+def get_narrow_roi_deficit(name: str) -> int | None:
+    return _NARROW_ROI_DEFICITS.get(name)
+
+def get_failure_count(cache_obj: ResourceCache, name: str) -> int:
+    return cache_obj.resource_failure_counts.get(name, 0)
+
+__all__ = [
+    "ResourceCache",
+    "RESOURCE_CACHE",
+    "_LAST_READ_FROM_CACHE",
+    "_NARROW_ROIS",
+    "_NARROW_ROI_DEFICITS",
+    "_RESOURCE_CACHE_TTL",
+    "_RESOURCE_CACHE_MAX_AGE",
+    "_RESOURCE_DEBUG_COOLDOWN",
+    "_LAST_REGION_BOUNDS",
+    "_LAST_REGION_SPANS",
+    "get_narrow_roi_deficit",
+    "get_failure_count",
+]

--- a/script/resources/reader/roi.py
+++ b/script/resources/reader/roi.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from . import CFG, logger, common, preprocess_roi, execute_ocr
+from .cache_utils import get_narrow_roi_deficit, get_failure_count
+
+
+def prepare_roi(frame, regions, name: str, required_set, cache_obj):
+    x, y, w, h = regions[name]
+    deficit = get_narrow_roi_deficit(name)
+    if deficit:
+        expand_left = deficit // 2
+        expand_right = deficit - expand_left
+        orig_x = x
+        orig_w = w
+        x = max(0, orig_x - expand_left)
+        right = min(frame.shape[1], orig_x + orig_w + expand_right)
+        w = right - x
+        regions[name] = (x, y, w, h)
+        logger.debug(
+            "Expanding narrow ROI for %s by %dpx (left=%d right=%d)",
+            name,
+            deficit,
+            expand_left,
+            expand_right,
+        )
+    if w <= 0 or h <= 0:
+        logger.error("ROI for '%s' has invalid dimensions w=%d h=%d", name, w, h)
+        if name in required_set:
+            raise common.ResourceReadError(f"{name} region has non-positive size")
+        return None
+    failure_count = get_failure_count(cache_obj, name)
+    roi = frame[y : y + h, x : x + w]
+    gray = preprocess_roi(roi)
+    top_crop = CFG.get("ocr_top_crop", 2)
+    overrides = CFG.get("ocr_top_crop_overrides", {})
+    if name in overrides:
+        top_crop = overrides[name]
+    if top_crop > 0 and gray.shape[0] > top_crop:
+        gray = gray[top_crop:, :]
+    return x, y, w, h, roi, gray, top_crop, failure_count
+
+
+def expand_roi_after_failure(
+    frame,
+    name: str,
+    x: int,
+    y: int,
+    w: int,
+    h: int,
+    roi,
+    gray,
+    top_crop: int,
+    failure_count: int,
+    res_conf_threshold: int,
+):
+    base_expand = CFG.get("ocr_roi_expand_px", 0)
+    step = CFG.get("ocr_roi_expand_step", 0)
+    growth = CFG.get("ocr_roi_expand_growth", 1.0)
+    expand_px = int(round(base_expand + step * ((failure_count + 1) ** growth - 1)))
+    if expand_px <= 0:
+        return None
+    x0 = max(0, x - expand_px)
+    y0 = max(0, y - expand_px)
+    x1 = min(frame.shape[1], x + w + expand_px)
+    y1 = min(frame.shape[0], y + h + expand_px)
+    logger.debug(
+        "Expanding ROI for %s after %d failures by %dpx to x=%d y=%d w=%d h=%d",
+        name,
+        failure_count,
+        expand_px,
+        x0,
+        y0,
+        x1 - x0,
+        y1 - y0,
+    )
+    roi_expanded = frame[y0:y1, x0:x1]
+    gray_expanded = preprocess_roi(roi_expanded)
+    if top_crop > 0 and gray_expanded.shape[0] > top_crop:
+        gray_expanded = gray_expanded[top_crop:, :]
+    try:
+        digits_exp, data_exp, mask_exp, low_conf = execute_ocr(
+            gray_expanded,
+            color=roi_expanded,
+            conf_threshold=res_conf_threshold,
+            roi=(x0, y0, x1 - x0, y1 - y0),
+            resource=name,
+        )
+    except TypeError:
+        digits_exp, data_exp, mask_exp, low_conf = execute_ocr(
+            gray_expanded,
+            conf_threshold=res_conf_threshold,
+            resource=name,
+        )
+    if digits_exp:
+        return (
+            digits_exp,
+            data_exp,
+            mask_exp,
+            roi_expanded,
+            gray_expanded,
+            x0,
+            y0,
+            x1 - x0,
+            y1 - y0,
+            low_conf,
+        )
+    return None
+
+__all__ = ["prepare_roi", "expand_roi_after_failure"]


### PR DESCRIPTION
## Summary
- turn `script.resources.reader` into a package
- extract ROI logic to `roi.py`
- centralize cache helpers in `cache_utils.py`
- keep core reading flow in `core.py`

## Testing
- `pytest` *(fails: AttributeError, AssertionError, see log)*


------
https://chatgpt.com/codex/tasks/task_e_68b36d05b874832598c0360fd388fc4f