### PR TITLE
Refactor population OCR to use execute_ocr

### DIFF
--- a/tests/test_internal_population.py
+++ b/tests/test_internal_population.py
@@ -8,6 +8,22 @@ import numpy as np
 
 # Stub modules
 
+sys.modules.setdefault(
+    "cv2",
+    types.SimpleNamespace(
+        cvtColor=lambda src, code: src,
+        resize=lambda img, *a, **k: img,
+        threshold=lambda img, *a, **k: (None, img),
+        imread=lambda *a, **k: np.zeros((1, 1), dtype=np.uint8),
+        imwrite=lambda *a, **k: True,
+        IMREAD_GRAYSCALE=0,
+        COLOR_BGR2GRAY=0,
+        INTER_LINEAR=0,
+        THRESH_BINARY=0,
+        THRESH_OTSU=0,
+    ),
+)
+
 dummy_pg = types.SimpleNamespace(
     PAUSE=0,
     FAILSAFE=False,

--- a/tests/test_population_ocr_conf.py
+++ b/tests/test_population_ocr_conf.py
@@ -6,6 +6,26 @@ from unittest.mock import patch
 
 import numpy as np
 
+# Stub modules that require a GUI/display before importing the bot modules
+dummy_pg = types.SimpleNamespace(
+    PAUSE=0,
+    FAILSAFE=False,
+    size=lambda: (200, 200),
+    click=lambda *a, **k: None,
+    moveTo=lambda *a, **k: None,
+    press=lambda *a, **k: None,
+)
+
+class DummyMSS:
+    monitors = [{}, {"left": 0, "top": 0, "width": 200, "height": 200}]
+
+    def grab(self, region):
+        h, w = region["height"], region["width"]
+        return np.zeros((h, w, 4), dtype=np.uint8)
+
+sys.modules.setdefault("pyautogui", dummy_pg)
+sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
+
 # Stub OpenCV before importing resources
 sys.modules.setdefault(
     "cv2",
@@ -13,6 +33,9 @@ sys.modules.setdefault(
         cvtColor=lambda src, code: src,
         resize=lambda img, *a, **k: img,
         threshold=lambda img, *a, **k: (None, img),
+        imread=lambda *a, **k: np.zeros((1, 1), dtype=np.uint8),
+        imwrite=lambda *a, **k: True,
+        IMREAD_GRAYSCALE=0,
         COLOR_BGR2GRAY=0,
         INTER_LINEAR=0,
         THRESH_BINARY=0,
@@ -31,8 +54,13 @@ class TestPopulationOcrConfidence(TestCase):
     def test_non_positive_confidences_are_ignored(self):
         roi = np.zeros((10, 10, 3), dtype=np.uint8)
         with patch(
-            "script.resources.pytesseract.image_to_data",
-            return_value={"text": ["3/4"], "conf": ["-1", "0", "95"]},
+            "script.resources.ocr.executor.execute_ocr",
+            return_value=(
+                "34",
+                {"text": ["3", "4"], "conf": ["-1", "0", "95"]},
+                None,
+                False,
+            ),
         ):
             cur, cap = resources._read_population_from_roi(
                 roi, conf_threshold=60, save_debug=False


### PR DESCRIPTION
## Summary
- Route population ROI through `execute_ocr` to leverage existing preprocessing, masking and confidence decay
- Adjust unit tests to mock the new OCR pipeline and stub dependencies

## Testing
- `pytest tests/test_population_ocr_conf.py::TestPopulationOcrConfidence::test_non_positive_confidences_are_ignored -q`
- `pytest tests/test_population_roi.py::TestPopulationROI::test_population_roi_outside_screen_raises_error -q`
- `pytest tests/test_population_roi.py::TestPopulationROI::test_read_population_raises_when_no_digits -q`
- `pytest tests/test_population_roi.py::TestPopulationROI::test_population_roi_ignores_hud_anchor -q`
- `pytest tests/test_population_roi.py::TestPopulationROI::test_non_positive_population_roi_raises_before_ocr -q`
- `pytest tests/test_internal_population.py -q`
- `pytest tests/test_population_*.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b37758f8608325ad7efec7e316767a