### PR TITLE
Improve population ROI error reporting

### DIFF
--- a/script/hud.py
+++ b/script/hud.py
@@ -126,7 +126,8 @@ def read_population_from_hud(retries=1, conf_threshold=None, save_failed_roi=Fal
         )
     except common.PopulationReadError as primary_exc:
         logger.info(
-            "Triggering fallback to read population via resources.read_resources_from_hud"
+            "Triggering fallback to read population via resources.read_resources_from_hud after %s",
+            primary_exc,
         )
         fallback_exc = None
         try:
@@ -143,7 +144,7 @@ def read_population_from_hud(retries=1, conf_threshold=None, save_failed_roi=Fal
 
         if fallback_exc is not None:
             raise common.PopulationReadError(
-                f"{primary_exc} (fallback failed: {fallback_exc})"
+                f"{primary_exc}; fallback failed: {fallback_exc}"
             ) from fallback_exc
         raise
 

--- a/script/resources/reader/roi.py
+++ b/script/resources/reader/roi.py
@@ -145,7 +145,7 @@ def expand_population_roi_after_failure(
         cur_pop, pop_cap = _read_population_from_roi(
             roi_expanded,
             conf_threshold=res_conf_threshold,
-            save_debug=False,
+            roi_bbox=(x0, y0, x1 - x0, y1 - y0),
         )
         return cur_pop, pop_cap, roi_expanded, x0, y0, x1 - x0, y1 - y0
     except common.PopulationReadError:

--- a/tests/test_gather_hud_stats.py
+++ b/tests/test_gather_hud_stats.py
@@ -75,7 +75,7 @@ class TestGatherHudStats(TestCase):
             d = next(digits_iter)
             return d, {"text": [d]}
 
-        def fake_pop(roi, conf_threshold=None):
+        def fake_pop(roi, conf_threshold=None, roi_bbox=None):
             pop_shapes.append(roi.shape[:2])
             return 123, 200
 
@@ -133,7 +133,7 @@ class TestGatherHudStats(TestCase):
                 return "0", {"zero_variance": True}, None
             return "600", {"text": ["600"]}, None
 
-        def fake_pop(roi, conf_threshold=None):
+        def fake_pop(roi, conf_threshold=None, roi_bbox=None):
             return 123, 200
 
         with patch("tools.campaign_bot.locate_resource_panel", return_value={}), \

--- a/tests/test_population_ocr_conf.py
+++ b/tests/test_population_ocr_conf.py
@@ -63,6 +63,6 @@ class TestPopulationOcrConfidence(TestCase):
             ),
         ):
             cur, cap = resources._read_population_from_roi(
-                roi, conf_threshold=60, save_debug=False
+                roi, conf_threshold=60
             )
         self.assertEqual((cur, cap), (3, 4))

--- a/tests/test_population_roi.py
+++ b/tests/test_population_roi.py
@@ -191,7 +191,7 @@ class TestPopulationROI(TestCase):
             )
             return frame[t : t + h, l : l + w]
 
-        def fake_pop(roi, conf_threshold=None, save_debug=True):
+        def fake_pop(roi, conf_threshold=None, roi_bbox=None):
             widths.append(roi.shape[1])
             if roi.shape[1] <= 4:
                 raise common.PopulationReadError("tight")


### PR DESCRIPTION
## Summary
- include ROI coordinates in population OCR warnings and errors
- always save population ROI and mask images on OCR failure
- surface detailed population OCR failures in HUD fallback logging

## Testing
- `pytest` (fails: AssertionError and PopulationReadError in several tests)
- `pytest tests/test_population_ocr_conf.py::TestPopulationOcrConfidence::test_non_positive_confidences_are_ignored`


------
https://chatgpt.com/codex/tasks/task_e_68b37bde4f888325ab8fed76a4b9ee50