### PR TITLE
Clamp negative OCR confidences and flag zero median

### DIFF
--- a/script/resources/ocr/confidence.py
+++ b/script/resources/ocr/confidence.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 
 def parse_confidences(data):
-    """Convert OCR confidence values to floats, ignoring non-positive entries."""
+    """Convert OCR confidence values to floats, clamping negatives to ``0``.
+
+    Any values that cannot be parsed as floats are ignored. Unlike the previous
+    behaviour, non-positive confidences are retained with negative numbers being
+    converted to ``0`` so that callers can explicitly treat them as unreliable
+    rather than silently discarding them.
+    """
 
     confs = []
     for c in data.get("conf", []):
@@ -12,8 +18,9 @@ def parse_confidences(data):
             val = float(c)
         except (ValueError, TypeError):
             continue
-        if val > 0:
-            confs.append(val)
+        if val < 0:
+            val = 0.0
+        confs.append(val)
     return confs
 
 

--- a/script/resources/ocr/executor.py
+++ b/script/resources/ocr/executor.py
@@ -48,7 +48,8 @@ def execute_ocr(
             break
         low_conf = True
         if metric == 0:
-            digits, data, mask = best_digits, best_data, best_mask
+            # Median confidence of zero indicates entirely unreliable results.
+            # Keep the current digits but mark them as low confidence.
             break
         if conf_threshold <= min_conf:
             digits, data, mask = best_digits, best_data, best_mask

--- a/tests/ocr_helpers/test_execute_ocr_negative_conf.py
+++ b/tests/ocr_helpers/test_execute_ocr_negative_conf.py
@@ -1,0 +1,16 @@
+import numpy as np
+from unittest.mock import patch
+
+import script.resources as resources
+
+
+def test_negative_confidences_flagged_low_confidence():
+    gray = np.zeros((5, 5), dtype=np.uint8)
+    data = {"text": ["12"], "conf": ["-5", "0"]}
+    with patch("script.resources.ocr.masks._ocr_digits_better", return_value=("12", data, None)), \
+         patch("script.resources.ocr.executor.pytesseract.image_to_string", return_value=""):
+        digits, _, _, low_conf = resources.execute_ocr(
+            gray, conf_threshold=60, resource="wood_stockpile"
+        )
+    assert digits == "12"
+    assert low_conf

--- a/tests/ocr_helpers/test_parse_confidences.py
+++ b/tests/ocr_helpers/test_parse_confidences.py
@@ -3,9 +3,9 @@ import pytest
 from script.resources.ocr.confidence import parse_confidences
 
 
-def test_filters_invalid_and_non_positive_values():
+def test_clamps_negative_and_preserves_zero():
     data = {"conf": ["42.5", "-1", "0", "abc", "77"]}
-    assert parse_confidences(data) == [42.5, 77.0]
+    assert parse_confidences(data) == [42.5, 0.0, 0.0, 77.0]
 
 
 def test_handles_missing_conf_key():

--- a/tests/test_population_ocr_conf.py
+++ b/tests/test_population_ocr_conf.py
@@ -51,7 +51,7 @@ import script.resources as resources
 
 
 class TestPopulationOcrConfidence(TestCase):
-    def test_non_positive_confidences_are_ignored(self):
+    def test_negative_confidences_raise_error(self):
         roi = np.zeros((10, 10, 3), dtype=np.uint8)
         with patch(
             "script.resources.ocr.executor.execute_ocr",
@@ -59,10 +59,10 @@ class TestPopulationOcrConfidence(TestCase):
                 "34",
                 {"text": ["3", "4"], "conf": ["-1", "0", "95"]},
                 None,
-                False,
+                True,
             ),
         ):
-            cur, cap = resources._read_population_from_roi(
-                roi, conf_threshold=60
-            )
-        self.assertEqual((cur, cap), (3, 4))
+            with self.assertRaises(resources.common.PopulationReadError):
+                resources._read_population_from_roi(
+                    roi, conf_threshold=60
+                )

--- a/tests/test_resource_helpers.py
+++ b/tests/test_resource_helpers.py
@@ -199,7 +199,7 @@ class TestExecuteOcr(TestCase):
         img2str_mock.assert_not_called()
         ocr_mock.assert_called_once()
 
-    def test_execute_ocr_ignores_non_positive_confidences(self):
+    def test_execute_ocr_flags_non_positive_confidences(self):
         gray = np.zeros((5, 5), dtype=np.uint8)
         data = {"text": ["12"], "conf": [-1, "0", "95"]}
         with patch("script.resources.ocr.masks._ocr_digits_better", return_value=("12", data, None)), \
@@ -208,7 +208,7 @@ class TestExecuteOcr(TestCase):
                 gray, conf_threshold=60, resource="wood_stockpile"
             )
         self.assertEqual(digits, "12")
-        self.assertFalse(low_conf)
+        self.assertTrue(low_conf)
         img2str_mock.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- Clamp negative OCR confidences to 0 instead of dropping them
- Treat zero-median OCR confidence as unreliable without discarding digits
- Add tests for negative confidence handling and adjust existing cases

## Testing
- `pytest tests/ocr_helpers/test_parse_confidences.py tests/ocr_helpers/test_execute_ocr_negative_conf.py tests/test_resource_helpers.py::TestExecuteOcr::test_execute_ocr_flags_non_positive_confidences tests/test_idle_villager_ocr.py::TestIdleVillagerOCR::test_idle_villager_negative_confidence_triggers_fallback tests/test_population_ocr_conf.py::TestPopulationOcrConfidence::test_negative_confidences_raise_error -q`
- `pytest -q --maxfail=1` *(fails: assert 123 is None)*

------
https://chatgpt.com/codex/tasks/task_e_68b37e5398c483258fa35ea4aa325386