### PR TITLE
Adjust population limit ROI placement

### DIFF
--- a/config.json
+++ b/config.json
@@ -126,8 +126,8 @@
   "population_limit_roi": {
     "top_pct": 0.111,
     "height_pct": 0.025,
-    "left_pct": 0.374,
-    "width_pct": 0.029
+    "left_pct": 0.79,
+    "width_pct": 0.048
   },
   "idle_villager_roi": {
     "top_pct": 0.10,

--- a/config.sample.json
+++ b/config.sample.json
@@ -127,8 +127,8 @@
   "population_limit_roi": {
     "top_pct": 0.111,
     "height_pct": 0.025,
-    "left_pct": 0.374,
-    "width_pct": 0.029
+    "left_pct": 0.79,
+    "width_pct": 0.048
   },
   "idle_villager_roi": {
     "top_pct": 0.10,


### PR DESCRIPTION
## Summary
- move population limit ROI left of idle villager to mirror on-screen order
- update sample configuration accordingly

## Testing
- `pytest` *(fails: AttributeError, TypeError, PopulationReadError and other failures, 24 failed)*
- `python <script>` (detect_resource_regions returns population_limit and idle_villager without overlap warning)

------
https://chatgpt.com/codex/tasks/task_e_68b382fb7b2c8325a9a92f4cc28344bc