### PR TITLE
Ignore zero OCR confidences when computing metrics

### DIFF
--- a/script/resources/ocr/executor.py
+++ b/script/resources/ocr/executor.py
@@ -54,8 +54,9 @@ def execute_ocr(
     max_attempts = CFG.get("ocr_conf_max_attempts", 10)
     while digits and data.get("conf"):
         confs = parse_confidences(data)
-        metric = np.median(confs) if confs else 0
-        if confs and metric >= conf_threshold:
+        non_zero = [c for c in confs if c > 0]
+        metric = np.median(non_zero) if non_zero else 0
+        if non_zero and metric >= conf_threshold:
             low_conf = False
             break
         low_conf = True
@@ -103,8 +104,9 @@ def execute_ocr(
     # Re-evaluate confidence using the chosen metric after any decay loop
     if digits and data.get("conf"):
         confs = parse_confidences(data)
-        metric = np.median(confs) if confs else 0
-        low_conf = not (confs and metric >= conf_threshold)
+        non_zero = [c for c in confs if c > 0]
+        metric = np.median(non_zero) if non_zero else 0
+        low_conf = not (non_zero and metric >= conf_threshold)
 
     if not digits and allow_fallback:
         text = pytesseract.image_to_string(

--- a/tests/test_resource_helpers.py
+++ b/tests/test_resource_helpers.py
@@ -199,16 +199,20 @@ class TestExecuteOcr(TestCase):
         img2str_mock.assert_not_called()
         ocr_mock.assert_called_once()
 
-    def test_execute_ocr_flags_non_positive_confidences(self):
+    def test_execute_ocr_ignores_zero_confidences_when_others_high(self):
         gray = np.zeros((5, 5), dtype=np.uint8)
         data = {"text": ["12"], "conf": [-1, "0", "95"]}
-        with patch("script.resources.ocr.masks._ocr_digits_better", return_value=("12", data, None)), \
-             patch("script.resources.reader.pytesseract.image_to_string", return_value="") as img2str_mock:
+        with patch(
+            "script.resources.ocr.masks._ocr_digits_better",
+            return_value=("12", data, None),
+        ), patch(
+            "script.resources.reader.pytesseract.image_to_string", return_value=""
+        ) as img2str_mock:
             digits, _, _, low_conf = resources.execute_ocr(
                 gray, conf_threshold=60, resource="wood_stockpile"
             )
         self.assertEqual(digits, "12")
-        self.assertTrue(low_conf)
+        self.assertFalse(low_conf)
         img2str_mock.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- Skip zero confidence values when calculating OCR confidence metrics and update low-confidence check.
- Adjust resource helper test to reflect ignoring zero confidences when high-confidence digits are present.

## Testing
- `pytest tests/test_resource_helpers.py::TestExecuteOcr::test_execute_ocr_ignores_zero_confidences_when_others_high tests/ocr_helpers/test_execute_ocr_negative_conf.py::test_negative_confidences_flagged_low_confidence -q`
- `pytest` *(fails: script.common.PopulationReadError, SystemExit, AttributeError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b38ac43bb08325a21a7b73830bfbfb