### PR TITLE
Widen wood stockpile ROI and refine OCR masking

### DIFF
--- a/script/resources/panel/roi.py
+++ b/script/resources/panel/roi.py
@@ -99,6 +99,12 @@ def compute_resource_rois(
             )
 
         right = left + width
+        if current == "wood_stockpile":
+            pad = 5
+            left = max(panel_left, left - pad)
+            right = min(panel_right, right + pad)
+            width = right - left
+
         spans[current] = (left, right)
 
         regions[current] = (left, top, width, height)


### PR DESCRIPTION
## Summary
- Widen wood stockpile ROI with extra padding to capture full digits
- Strengthen wood stockpile OCR: heavier close/dilate and additional white-digit color mask

## Testing
- `python - <<'PY' ... PY` *(manual OCR; median_pos=87.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tools.campaign_bot')*


------
https://chatgpt.com/codex/tasks/task_e_68b3b8e7046083259e6a7df869fabc41