### PR TITLE
Add option to skip starting resource validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,15 @@ expected value of `0` from the optional list passed to `gather_hud_stats` to
 avoid spurious OCR readings. Explicitly provide such icons in
 `optional_icons` if they still need to be read.
 
+### Skipping starting resource validation
+
+The campaign launcher compares the resources read from the HUD with the
+expected values defined in each scenario. When OCR repeatedly misreads the
+initial numbers, set `skip_starting_resource_validation` to `true` in
+`config.json` to bypass this check. The script will still log the initial
+resource readings, allowing you to troubleshoot without blocking mission
+progress.
+
 ### Manual ROI overrides
 
 Automatic ROI detection may fail on unusual HUD layouts. Optional sections in

--- a/campaign.py
+++ b/campaign.py
@@ -85,7 +85,10 @@ def main():
                 required_icons=required,
                 optional_icons=optional,
             )
-            if non_zero:
+            skip_validation = common.CFG.get(
+                "skip_starting_resource_validation", False
+            )
+            if non_zero and not skip_validation:
                 retry_limit = common.CFG.get("resource_validation_retries", 3)
                 tolerance = 10
                 max_tolerance = 15
@@ -151,6 +154,10 @@ def main():
                             required_icons=required,
                             optional_icons=optional,
                         )
+            elif non_zero and skip_validation:
+                logger.info(
+                    "Skipping starting resource validation; initial readings will be logged."
+                )
             logger.info(
                 "Detected resources: wood=%s, food=%s, gold=%s, stone=%s",
                 res.get("wood_stockpile"),


### PR DESCRIPTION
## Summary
- allow skipping starting resource validation via `skip_starting_resource_validation`
- document how to bypass initial resource checks when OCR is unreliable

## Testing
- `pytest` *(fails: 34 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b3bc18045c832582ddf3afa8871319