### PR TITLE
Handle zero confidence in idle villager OCR

### DIFF
--- a/script/resources/reader/core.py
+++ b/script/resources/reader/core.py
@@ -82,8 +82,8 @@ def _read_resources(
                 output_type=pytesseract.Output.DICT,
             )
             texts = [t for t in data.get("text", []) if t.strip()]
-            confidences = parse_confidences(data)
-            if texts and confidences and all(
+            confidences = [c for c in parse_confidences(data) if c > 0]
+            if texts and confidences and any(
                 c >= res_conf_threshold for c in confidences
             ):
                 digits = "".join(filter(str.isdigit, "".join(texts)))


### PR DESCRIPTION
## Summary
- Ignore zero or negative confidences before thresholding idle villager OCR results
- Accept digits when any remaining confidence meets the threshold
- Add regression test ensuring zero-confidence outputs don't trigger fallback

## Testing
- `pytest tests/test_idle_villager_ocr.py`

------
https://chatgpt.com/codex/tasks/task_e_68b3c09ed7708325b7c0c65769032dbe