### PR TITLE
Sanitize OCR confidence logging

### DIFF
--- a/script/resources/reader/core.py
+++ b/script/resources/reader/core.py
@@ -104,7 +104,7 @@ def _read_resources(
                     "OCR %s: digits=%s conf=%s low_conf=%s",
                     name,
                     digits,
-                    data.get("conf"),
+                    parse_confidences(data),
                     low_conf,
                 )
             except TypeError:
@@ -117,7 +117,7 @@ def _read_resources(
                     "OCR %s: digits=%s conf=%s low_conf=%s",
                     name,
                     digits,
-                    data.get("conf"),
+                    parse_confidences(data),
                     low_conf,
                 )
             if (
@@ -140,7 +140,7 @@ def _read_resources(
                             "Retry OCR %s: digits=%s conf=%s low_conf=%s",
                             name,
                             digits_retry,
-                            data_retry.get("conf"),
+                            parse_confidences(data_retry),
                             low_conf,
                         )
                     except TypeError:
@@ -153,7 +153,7 @@ def _read_resources(
                             "Retry OCR %s: digits=%s conf=%s low_conf=%s",
                             name,
                             digits_retry,
-                            data_retry.get("conf"),
+                            parse_confidences(data_retry),
                             low_conf,
                         )
                     if digits_retry:
@@ -217,7 +217,7 @@ def _read_resources(
                             "OCR %s: digits=%s conf=%s low_conf=%s",
                             name,
                             digits_retry,
-                            data_retry.get("conf"),
+                            parse_confidences(data_retry),
                             low_conf,
                         )
                     except TypeError:
@@ -231,7 +231,7 @@ def _read_resources(
                             "OCR %s: digits=%s conf=%s low_conf=%s",
                             name,
                             digits_retry,
-                            data_retry.get("conf"),
+                            parse_confidences(data_retry),
                             low_conf,
                         )
                     if digits_retry:

--- a/tests/ocr_helpers/test_parse_confidences.py
+++ b/tests/ocr_helpers/test_parse_confidences.py
@@ -1,6 +1,12 @@
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
 import pytest
 
 from script.resources.ocr.confidence import parse_confidences
+from script.resources.reader import core
 
 
 def test_clamps_negative_and_preserves_zero():
@@ -11,3 +17,44 @@ def test_clamps_negative_and_preserves_zero():
 def test_handles_missing_conf_key():
     assert parse_confidences({}) == []
     assert parse_confidences({"conf": ["foo", None]}) == []
+
+
+def test_read_resources_logs_sanitized_confidences(caplog):
+    frame = np.zeros((10, 10, 3), dtype=np.uint8)
+    gray = np.zeros((10, 10), dtype=np.uint8)
+    data = {"text": ["12"], "conf": ["-5", "50"]}
+    cache_obj = SimpleNamespace(
+        last_resource_values={},
+        last_resource_ts={},
+        resource_failure_counts={},
+    )
+    with patch.object(core, "CFG", {}), \
+         patch.object(
+            core,
+            "detect_resource_regions",
+            return_value={"wood_stockpile": (0, 0, 10, 10)},
+        ), \
+         patch.object(
+            core,
+            "prepare_roi",
+            return_value=(0, 0, 10, 10, frame, gray, 0, 0),
+        ), \
+         patch.object(
+            core,
+            "execute_ocr",
+            return_value=("12", data, None, False),
+        ):
+        caplog.set_level(logging.INFO, logger="script.resources")
+        core._read_resources(
+            frame,
+            ["wood_stockpile"],
+            ["wood_stockpile"],
+            cache_obj=cache_obj,
+        )
+    messages = [r.getMessage() for r in caplog.records]
+    ocr_msgs = [m for m in messages if m.startswith("OCR wood_stockpile")]
+    assert ocr_msgs, "OCR log message not found"
+    msg = ocr_msgs[0]
+    assert "digits=12" in msg
+    assert "conf=[0.0, 50.0]" in msg
+    assert "low_conf=False" in msg


### PR DESCRIPTION
## Summary
- Clamp negative OCR confidences in resource reader logging by using `parse_confidences`
- Add test ensuring logger reports sanitized confidence values

## Testing
- `pytest tests/ocr_helpers/test_parse_confidences.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tools.campaign_bot')*

------
https://chatgpt.com/codex/tasks/task_e_68b3c5b6813483258645d71ee9d5276c