### PR TITLE
Validate non-empty ROI configuration lists

### DIFF
--- a/script/resources/panel/roi.py
+++ b/script/resources/panel/roi.py
@@ -21,6 +21,16 @@ def compute_resource_rois(
     detected=None,
 ):
     """Compute resource ROIs from detected icon bounds."""
+    if not pad_left:
+        raise ValueError("pad_left must contain at least one element")
+    if not pad_right:
+        raise ValueError("pad_right must contain at least one element")
+    if not icon_trims:
+        raise ValueError("icon_trims must contain at least one element")
+    if not max_widths:
+        raise ValueError("max_widths must contain at least one element")
+    if not min_widths:
+        raise ValueError("min_widths must contain at least one element")
 
     if min_requireds is None:
         min_requireds = [0] * len(RESOURCE_ICON_ORDER)

--- a/tests/test_compute_resource_rois_empty_lists.py
+++ b/tests/test_compute_resource_rois_empty_lists.py
@@ -1,0 +1,38 @@
+import json
+import subprocess
+import sys
+import pytest
+
+SCRIPT = """
+import json
+import os
+import sys
+os.environ['TESSERACT_CMD'] = '/usr/bin/true'
+import script.resources as resources
+params = json.loads(sys.argv[1])
+try:
+    resources.compute_resource_rois(0, 100, 0, 10, *params)
+except ValueError:
+    sys.exit(0)
+sys.exit(1)
+"""
+
+BASE_PARAMS = {
+    "pad_left": [1],
+    "pad_right": [1],
+    "icon_trims": [0],
+    "max_widths": [10],
+    "min_widths": [1],
+}
+ORDER = ["pad_left", "pad_right", "icon_trims", "max_widths", "min_widths"]
+
+
+@pytest.mark.parametrize("missing", ORDER)
+def test_empty_config_lists_raise_value_error(missing):
+    params = [BASE_PARAMS[key] for key in ORDER]
+    idx = ORDER.index(missing)
+    params[idx] = []
+    proc = subprocess.run(
+        [sys.executable, "-c", SCRIPT, json.dumps(params)]
+    )
+    assert proc.returncode == 0


### PR DESCRIPTION
## Summary
- ensure compute_resource_rois validates configuration lists are non-empty
- add tests for empty configuration list handling

## Testing
- `pytest tests/test_compute_resource_rois_empty_lists.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b3cc6e42648325a0966d5e5e071b8a