### PR TITLE
Allow per-resource tolerances in resource validation

### DIFF
--- a/campaign.py
+++ b/campaign.py
@@ -88,6 +88,7 @@ def main():
             skip_validation = common.CFG.get(
                 "skip_starting_resource_validation", False
             )
+            res_tolerances = common.CFG.get("resource_validation_tolerances", {})
             if non_zero and not skip_validation:
                 retry_limit = common.CFG.get("resource_validation_retries", 3)
                 tolerance = 10
@@ -108,6 +109,7 @@ def main():
                             res,
                             non_zero,
                             tolerance=tolerance,
+                            tolerances=res_tolerances,
                             raise_on_error=True,
                             frame=frame,
                             rois=rois,
@@ -136,6 +138,7 @@ def main():
                                     res,
                                     non_zero,
                                     tolerance=tolerance,
+                                    tolerances=res_tolerances,
                                     raise_on_error=False,
                                     frame=frame,
                                     rois=rois,

--- a/script/resources/reader/core.py
+++ b/script/resources/reader/core.py
@@ -407,6 +407,7 @@ def validate_starting_resources(
     expected: dict[str, int] | None,
     *,
     tolerance: int = 10,
+    tolerances: dict[str, int] | None = None,
     raise_on_error: bool = False,
     frame: np.ndarray | None = None,
     rois: dict[str, tuple[int, int, int, int]] | None = None,
@@ -428,7 +429,8 @@ def validate_starting_resources(
                 logger.warning(msg)
             continue
 
-        if abs(actual - exp) > tolerance:
+        tol = tolerance if tolerances is None else tolerances.get(name, tolerance)
+        if abs(actual - exp) > tol:
             roi_path = None
             if frame is not None and rois and name in rois:
                 x, y, w, h = rois[name]
@@ -441,7 +443,7 @@ def validate_starting_resources(
 
             msg = (
                 f"{name} reading {actual} deviates from expected {exp} "
-                f"(±{tolerance})"
+                f"(±{tol})"
             )
             if roi_path is not None:
                 msg += f"; ROI saved to {roi_path}"

--- a/tests/test_resource_helpers.py
+++ b/tests/test_resource_helpers.py
@@ -399,3 +399,16 @@ class TestValidateStartingResources(TestCase):
         self.assertIn("wood_stockpile reading 50", msg)
         self.assertIn("food_stockpile reading 30", msg)
         self.assertIn("Missing OCR reading for 'stone_stockpile'", msg)
+
+    def test_per_resource_tolerance_overrides_default(self):
+        with patch("script.resources.reader.logger.warning") as warn_mock:
+            resources.validate_starting_resources(
+                {"wood_stockpile": 50, "food_stockpile": 70},
+                {"wood_stockpile": 80, "food_stockpile": 90},
+                tolerance=10,
+                tolerances={"wood_stockpile": 40},
+                raise_on_error=False,
+            )
+            warn_mock.assert_called_once_with(
+                "food_stockpile reading 70 deviates from expected 90 (±10)"
+            )

--- a/tools/campaign_bot.py
+++ b/tools/campaign_bot.py
@@ -1,0 +1,12 @@
+"""Compatibility wrapper for tests expecting :mod:`tools.campaign_bot`.
+
+This module re-exports everything from :mod:`tools.campaign`, including
+attributes prefixed with underscores, so that tests can patch internal
+helpers as needed.
+"""
+
+from . import campaign as _campaign
+
+# Copy all attributes from tools.campaign into this module's namespace.
+globals().update({name: getattr(_campaign, name) for name in dir(_campaign)})
+


### PR DESCRIPTION
## Summary
- allow `validate_starting_resources` to accept optional per-resource tolerance overrides
- propagate tolerance overrides through `campaign.py`
- cover per-resource tolerances in tests
- expose `tools.campaign_bot` wrapper for testing

## Testing
- `pytest -q` *(fails: Module errors and assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b3cff2bdd88325bdef305468f86a32