### PR TITLE
Expand resource ROIs for 3-digit counts

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -80,10 +80,10 @@
     "resource_panel": {
         "match_threshold": 0.8,
         "scales": [0.9, 0.95, 1.0, 1.05, 1.1],
-        "roi_padding_left": [0, 0, 0, 0, 0, 0],
-        "roi_padding_right": [4, 0, 0, 0, 0, 0],
+        "roi_padding_left": [0, 3, 0, 0, 0, 3],
+        "roi_padding_right": [4, 3, 0, 0, 0, 3],
         "max_width": [120, 160, 160, 160, 160, 160],
-        "min_width": [5, 5, 5, 5, 5, 4],
+        "min_width": [5, 30, 5, 5, 5, 30],
         "min_required_width": 0,
         "idle_roi_extra_width": 24,
         "top_pct": 0.06,


### PR DESCRIPTION
## Summary
- widen `food_stockpile` and `idle_villager` ROIs with extra padding to fit three-digit values
- honor minimum widths for these resources when building ROIs and fallback slices
- test ROI computation ensures food and idle villager slots accommodate three digits

## Testing
- `pytest tests/resource_rois/test_compute_rois.py`
- `pytest` *(fails: PopulationReadError, cv2/tesseract missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b46993ff4c8325b2edf66861355a4f