### PR TITLE
Handle zero-confidence OCR results as low confidence

### DIFF
--- a/script/resources/ocr/executor.py
+++ b/script/resources/ocr/executor.py
@@ -192,6 +192,7 @@ def execute_ocr(
         digits = _sanitize_digits(digits)
         if zero_conf:
             data["zero_conf"] = True
+            low_conf = True
     return digits, data, mask, low_conf
 
 

--- a/script/resources/reader/core.py
+++ b/script/resources/reader/core.py
@@ -109,6 +109,8 @@ def _read_resources(
                 roi=(x, y, w, h),
                 resource=name,
             )
+            if data.get("zero_conf"):
+                low_conf = True
             logger.info(
                 "OCR %s: digits=%s conf=%s low_conf=%s",
                 name,
@@ -131,6 +133,8 @@ def _read_resources(
                         roi=(x, y, w, h),
                         resource=name,
                     )
+                    if data_retry.get("zero_conf"):
+                        low_conf = True
                     logger.info(
                         "Retry OCR %s: digits=%s conf=%s low_conf=%s",
                         name,
@@ -167,6 +171,8 @@ def _read_resources(
                     h,
                     low_conf,
                 ) = expansion
+                if data.get("zero_conf"):
+                    low_conf = True
         if not digits:
             span_left, span_right = cache._LAST_REGION_SPANS.get(name, (x, x + w))
             span_width = span_right - span_left
@@ -194,6 +200,8 @@ def _read_resources(
                         roi=(cand_x, y, cand_w, h),
                         resource=name,
                     )
+                    if data_retry.get("zero_conf"):
+                        low_conf = True
                     logger.info(
                         "OCR %s: digits=%s conf=%s low_conf=%s",
                         name,


### PR DESCRIPTION
## Summary
- Flag zero-confidence OCR results as low confidence in executor
- Treat zero-confidence OCR data as low confidence in resource reader
- Test that zero-confidence digits fall back to cached values

## Testing
- `pytest tests/ocr_failures/test_no_digits.py::TestNoDigits::test_zero_confidence_digits_use_cache -q`
- `pytest -q` *(fails: ResourceReadError not raised, AttributeError: module 'script.resources.ocr' has no attribute 'CFG', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b479657f688325b81d3fb1c444cf0f