### PR TITLE
Expand ROI fallback widths and test widening behavior

### DIFF
--- a/tests/test_resource_roi_validation.py
+++ b/tests/test_resource_roi_validation.py
@@ -81,9 +81,16 @@ class TestResourceRoiValidation(TestCase):
 
     def test_zero_width_roi_raises(self):
         frame = np.zeros((100, 100, 3), dtype=np.uint8)
+
+        def fake_detect(frame, icons, cache_obj):
+            return {"wood_stockpile": (0, 0, 0, 10)}
+
         with patch(
             "script.resources.reader.detect_resource_regions",
-            return_value={"wood_stockpile": (0, 0, 0, 10)},
+            side_effect=fake_detect,
+        ), patch(
+            "script.resources.reader.core.detect_resource_regions",
+            side_effect=fake_detect,
         ):
             with self.assertRaises(common.ResourceReadError):
                 reader._read_resources(
@@ -91,4 +98,53 @@ class TestResourceRoiValidation(TestCase):
                     ["wood_stockpile"],
                     ["wood_stockpile"],
                 )
+
+    def test_widen_roi_within_span(self):
+        frame = np.zeros((50, 50, 3), dtype=np.uint8)
+        attempts: list[int] = []
+
+        def fake_execute_ocr(gray, color=None, conf_threshold=None, allow_fallback=True, roi=None, resource=None):
+            attempts.append(roi[2])
+            if roi[2] == 35:
+                return "5", {"text": ["5"]}, None, False
+            return None, {"text": []}, None, False
+
+        def fake_prepare_roi(frame, regions, name, required_set, cache_obj):
+            x, y, w, h = regions[name]
+            roi = frame[y : y + h, x : x + w]
+            gray = roi
+            return x, y, w, h, roi, gray, 0, 0
+
+        def fake_detect(frame, icons, cache_obj):
+            reader.cache._LAST_REGION_SPANS = {"wood_stockpile": (0, 35)}
+            return {"wood_stockpile": (0, 0, 30, 10)}
+
+        with patch(
+            "script.resources.reader.detect_resource_regions",
+            side_effect=fake_detect,
+        ), patch(
+            "script.resources.reader.core.detect_resource_regions",
+            side_effect=fake_detect,
+        ), patch(
+            "script.resources.reader.core.preprocess_roi",
+            side_effect=lambda r: r,
+        ), patch(
+            "script.resources.reader.core.execute_ocr",
+            side_effect=fake_execute_ocr,
+        ), patch(
+            "script.resources.reader.core.prepare_roi",
+            side_effect=fake_prepare_roi,
+        ), patch(
+            "script.resources.reader.core.expand_roi_after_failure",
+            return_value=None,
+        ):
+            results, _ = reader._read_resources(
+                frame,
+                ["wood_stockpile"],
+                ["wood_stockpile"],
+            )
+
+        self.assertEqual(results["wood_stockpile"], 5)
+        self.assertIn(35, attempts)
+        self.assertEqual(max(attempts), 35)
 


### PR DESCRIPTION
## Summary
- Try an extra `cand_w + 10` width when OCR fails, bounded by the last known span
- Add regression test ensuring ROI widening uses the cached span limit

## Testing
- `pytest tests/test_resource_roi_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68b47a9aaacc8325b577c67c4a8850fd