### PR TITLE
Avoid removing diagonal strokes in population OCR

### DIFF
--- a/script/resources/ocr/masks.py
+++ b/script/resources/ocr/masks.py
@@ -134,8 +134,11 @@ def _ocr_digits_better(gray, color=None, resource=None, whitelist="0123456789"):
         )
         if digits:
             return digits, data, mask
-        pl_kernel = cv2.getStructuringElement(cv2.MORPH_CROSS, (3, 3))
-        adaptive = cv2.morphologyEx(adaptive, cv2.MORPH_OPEN, pl_kernel, iterations=1)
+        # Morphological opening with a cross-shaped kernel would remove
+        # diagonal strokes (e.g. the '/' separating current and maximum
+        # population). Skip this step to preserve such characters.
+        # pl_kernel = cv2.getStructuringElement(cv2.MORPH_CROSS, (3, 3))
+        # adaptive = cv2.morphologyEx(adaptive, cv2.MORPH_OPEN, pl_kernel, iterations=1)
     else:
         adaptive = cv2.dilate(adaptive, kernel, iterations=1)
         if resource == "wood_stockpile":


### PR DESCRIPTION
## Summary
- skip cross-kernel morphological opening in population OCR masks to preserve diagonal strokes like '/'

## Testing
- `pytest tests/test_population_ocr_conf.py tests/test_population_roi.py`
- ⚠️ `pytest tests/test_population_ocr_conf.py tests/test_population_roi_validation.py` (missing file)


------
https://chatgpt.com/codex/tasks/task_e_68b48e719fb483259af5c3d9892d90c6