### PR TITLE
Add population OCR low-confidence fallback

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -29,6 +29,7 @@
     "gold_stockpile_low_conf_fallback": false,
     "stone_stockpile_low_conf_fallback": false,
     "population_limit_low_conf_fallback": false,
+    "//population_limit_low_conf_fallback": "Set true to reuse last population or low-confidence digits after repeated low-confidence OCR.",
     "idle_villager_low_conf_fallback": false,
     "//idle_villager_low_conf_fallback": "Set true to reuse last value on low-confidence OCR.",
     "idle_villager_low_conf_streak": 5,

--- a/tests/test_gather_hud_stats.py
+++ b/tests/test_gather_hud_stats.py
@@ -75,7 +75,7 @@ class TestGatherHudStats(TestCase):
             d = next(digits_iter)
             return d, {"text": [d]}
 
-        def fake_pop(roi, conf_threshold=None, roi_bbox=None):
+        def fake_pop(roi, conf_threshold=None, roi_bbox=None, failure_count=0):
             pop_shapes.append(roi.shape[:2])
             return 123, 200
 
@@ -133,7 +133,7 @@ class TestGatherHudStats(TestCase):
                 return "0", {"zero_variance": True}, None
             return "600", {"text": ["600"]}, None
 
-        def fake_pop(roi, conf_threshold=None, roi_bbox=None):
+        def fake_pop(roi, conf_threshold=None, roi_bbox=None, failure_count=0):
             return 123, 200
 
         with patch("tools.campaign.locate_resource_panel", return_value={}), \

--- a/tests/test_population_ocr_conf.py
+++ b/tests/test_population_ocr_conf.py
@@ -83,3 +83,29 @@ class TestPopulationOcrConfidence(TestCase):
                 roi, conf_threshold=60
             )
             self.assertEqual((cur, cap), (12, 34))
+
+    def test_low_confidence_fallback_after_attempts(self):
+        roi = np.zeros((10, 10, 3), dtype=np.uint8)
+
+        with patch.dict(
+            resources.common.CFG,
+            {"population_limit_low_conf_fallback": True, "ocr_retry_limit": 3},
+            clear=False,
+        ), patch(
+            "script.resources.ocr.executor.execute_ocr",
+            return_value=(
+                "12/34",
+                {"text": ["12/34"], "conf": ["40", "40"]},
+                None,
+                True,
+            ),
+        ):
+            for fc in (0, 1):
+                with self.assertRaises(resources.common.PopulationReadError):
+                    resources._read_population_from_roi(
+                        roi, conf_threshold=60, failure_count=fc
+                    )
+            cur, cap = resources._read_population_from_roi(
+                roi, conf_threshold=60, failure_count=2
+            )
+            self.assertEqual((cur, cap), (12, 34))

--- a/tests/test_population_roi.py
+++ b/tests/test_population_roi.py
@@ -191,7 +191,7 @@ class TestPopulationROI(TestCase):
             )
             return frame[t : t + h, l : l + w]
 
-        def fake_pop(roi, conf_threshold=None, roi_bbox=None):
+        def fake_pop(roi, conf_threshold=None, roi_bbox=None, failure_count=0):
             widths.append(roi.shape[1])
             if roi.shape[1] <= 4:
                 raise common.PopulationReadError("tight")


### PR DESCRIPTION
## Summary
- allow population OCR to return low-confidence digits after repeated attempts
- cache and reuse last population after consecutive low-confidence failures
- document `population_limit_low_conf_fallback` option

## Testing
- `pytest tests/test_population_ocr_conf.py tests/test_population_limit_fallback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b48f1fc83083258da23373f1c18fa7