### PR TITLE
Improve population OCR by tuning threshold

### DIFF
--- a/script/resources/ocr/masks.py
+++ b/script/resources/ocr/masks.py
@@ -116,8 +116,9 @@ def _ocr_digits_better(gray, color=None, resource=None, whitelist="0123456789"):
     if digits and (resource != "wood_stockpile" or len(digits) > 1):
         return digits, data, mask
 
+    block_size = 21 if resource == "population_limit" else 11
     adaptive = cv2.adaptiveThreshold(
-        gray, 255, cv2.ADAPTIVE_THRESH_MEAN_C, cv2.THRESH_BINARY, 11, 2
+        gray, 255, cv2.ADAPTIVE_THRESH_MEAN_C, cv2.THRESH_BINARY, block_size, 2
     )
     if resource == "population_limit":
         _otsu_ret, otsu = cv2.threshold(


### PR DESCRIPTION
## Summary
- use larger adaptive threshold block size for population limit to keep population slash visible

## Testing
- `pytest tests/test_population_ocr_conf.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4a21dc79c83258bd18732070499bf