### PR TITLE
Ensure food ROI covers digits and broaden OCR color masks

### DIFF
--- a/script/resources/ocr/colors.py
+++ b/script/resources/ocr/colors.py
@@ -41,8 +41,13 @@ def color_mask_sets(hsv, resource, kernel):
             closed_masks.extend([closed, cv2.bitwise_not(closed)])
         return base_masks, closed_masks
     else:
-        white_mask = cv2.inRange(hsv, np.array([0, 0, 200]), np.array([180, 30, 255]))
-        yellow_mask = cv2.inRange(hsv, np.array([20, 100, 180]), np.array([40, 255, 255]))
+        # Broaden white/yellow ranges to capture greyed or anti-aliased digits
+        white_mask = cv2.inRange(
+            hsv, np.array([0, 0, 170]), np.array([180, 80, 255])
+        )
+        yellow_mask = cv2.inRange(
+            hsv, np.array([20, 70, 170]), np.array([40, 255, 255])
+        )
         gray_mask = cv2.inRange(hsv, np.array([0, 0, 160]), np.array([180, 50, 220]))
         digit_mask = cv2.bitwise_or(white_mask, yellow_mask)
         digit_mask = cv2.bitwise_or(digit_mask, gray_mask)

--- a/script/resources/panel/roi.py
+++ b/script/resources/panel/roi.py
@@ -118,7 +118,7 @@ def compute_resource_rois(
             width = right - left
         else:
             right = left + width
-        if current == "wood_stockpile":
+        if current in ("wood_stockpile", "food_stockpile"):
             pad = max(1, int(round(cur_w * 0.25)))
             left = max(panel_left, left - pad)
             right = min(panel_right, right + pad)

--- a/tests/test_food_stockpile_ocr.py
+++ b/tests/test_food_stockpile_ocr.py
@@ -1,0 +1,75 @@
+import os
+import sys
+import types
+from unittest import TestCase
+
+import cv2
+import numpy as np
+
+# Stub modules requiring a display
+
+dummy_pg = types.SimpleNamespace(
+    PAUSE=0,
+    FAILSAFE=False,
+    size=lambda: (200, 200),
+    click=lambda *a, **k: None,
+    moveTo=lambda *a, **k: None,
+    press=lambda *a, **k: None,
+)
+
+
+class DummyMSS:
+    monitors = [{}, {"left": 0, "top": 0, "width": 200, "height": 200}]
+
+    def grab(self, region):
+        h, w = region["height"], region["width"]
+        return np.zeros((h, w, 4), dtype=np.uint8)
+
+
+sys.modules.setdefault("pyautogui", dummy_pg)
+sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
+
+_OLD_TESS = os.environ.get("TESSERACT_CMD")
+os.environ["TESSERACT_CMD"] = "/usr/bin/tesseract"
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from script.resources import CFG
+from script.resources.ocr.preprocess import preprocess_roi
+from script.resources.ocr.executor import execute_ocr
+from script.resources.ocr.confidence import parse_confidences
+
+
+class TestFoodStockpileOCR(TestCase):
+    def setUp(self):
+        self._old_cmd = _OLD_TESS
+
+    def tearDown(self):
+        if self._old_cmd is None:
+            os.environ.pop("TESSERACT_CMD", None)
+        else:
+            os.environ["TESSERACT_CMD"] = self._old_cmd
+
+    def test_food_stockpile_detects_140_high_confidence(self):
+        roi = np.full((60, 150, 3), (50, 50, 50), dtype=np.uint8)
+        # Anti-aliased rendering introduces gray edges around the white digits
+        cv2.putText(
+            roi,
+            "140",
+            (10, 45),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            1.5,
+            (255, 255, 255),
+            2,
+            cv2.LINE_AA,
+        )
+        gray = preprocess_roi(roi)
+        digits, data, _mask, low_conf = execute_ocr(
+            gray, color=roi, resource="food_stockpile"
+        )
+        confs = parse_confidences(data)
+        threshold = CFG.get(
+            "food_stockpile_ocr_conf_threshold", CFG.get("ocr_conf_threshold", 60)
+        )
+        self.assertEqual(digits, "140")
+        self.assertGreaterEqual(max(confs), threshold)
+        self.assertFalse(low_conf)


### PR DESCRIPTION
## Summary
- Expand white and yellow HSV masks to capture greyed or anti-aliased digits
- Widen food ROI computation by padding like wood to avoid clipping
- Add regression test for food OCR reading "140" with adequate confidence

## Testing
- `python tools/roi_calibrator.py` (monkeypatched)
- `pytest tests/test_food_stockpile_ocr.py tests/test_wood_stockpile_ocr.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4af9475f08325a30398634813d2b9