### PR TITLE
Prioritize longer OCR digit sequences

### DIFF
--- a/script/resources/ocr/masks.py
+++ b/script/resources/ocr/masks.py
@@ -41,7 +41,7 @@ def _run_masks(masks, psms, debug, debug_dir, ts, start_idx=0, whitelist="012345
     if not scored:
         return results[0]
 
-    scored.sort(key=lambda r: (len(r[0]), -r[3]))
+    scored.sort(key=lambda r: (-len(r[0]), -r[3]))
     best = scored[0]
     return best[0], best[1], best[2]
 

--- a/tests/test_ocr_mask_confidence_sort.py
+++ b/tests/test_ocr_mask_confidence_sort.py
@@ -34,13 +34,13 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from script.resources.ocr.masks import _run_masks
 
 
-def test_high_confidence_shorter_digits_win():
+def test_longer_digits_preferred_over_shorter_even_if_confidence_lower():
     masks = [np.zeros((1, 1), dtype=np.uint8), np.zeros((1, 1), dtype=np.uint8)]
     psms = [6]
     outputs = [
-        {"text": ["1234"], "conf": ["10", "10", "10", "10"]},
-        {"text": ["99"], "conf": ["90", "90"]},
+        {"text": ["0"], "conf": ["91"]},
+        {"text": ["140"], "conf": ["90", "90", "90"]},
     ]
     with patch("script.resources.ocr.masks.pytesseract.image_to_data", side_effect=outputs):
         digits, data, mask = _run_masks(masks, psms, False, None, 0)
-    assert digits == "99"
+    assert digits == "140"


### PR DESCRIPTION
## Summary
- Rank OCR mask candidates by descending digit length before confidence
- Add tests ensuring multi-digit matches like `140` beat shorter `0` even with similar confidence

## Testing
- `pytest tests/test_ocr_mask_confidence_sort.py tests/test_food_stockpile_ocr.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4bbfc2d60832587392436dc8045ea