### PR TITLE
Allow configurable food stockpile ROI width

### DIFF
--- a/config.json
+++ b/config.json
@@ -35,6 +35,8 @@
     "population_limit_ocr_conf_threshold": 45,
     "idle_villager_ocr_conf_threshold": 40,
     "//*_ocr_conf_threshold": "Optional per-resource OCR confidence overrides.",
+    "food_stockpile_max_width": 60,
+    "//food_stockpile_max_width": "Maximum width of the food stockpile ROI.",
     "ocr_retry_limit": 3,
     "//ocr_retry_limit": "Consecutive OCR failures before using fallback value.",
     "ocr_roi_expand_base": 3,

--- a/config.sample.json
+++ b/config.sample.json
@@ -41,6 +41,8 @@
     "population_limit_ocr_conf_threshold": 45,
     "idle_villager_ocr_conf_threshold": 40,
     "//*_ocr_conf_threshold": "Optional per-resource OCR confidence overrides.",
+    "food_stockpile_max_width": 60,
+    "//food_stockpile_max_width": "Maximum width of the food stockpile ROI.",
     "ocr_retry_limit": 3,
     "//ocr_retry_limit": "Consecutive OCR failures before using fallback value.",
     "ocr_roi_expand_base": 3,

--- a/script/resources/panel/roi.py
+++ b/script/resources/panel/roi.py
@@ -109,7 +109,7 @@ def compute_resource_rois(
         available_width = right - left
         max_w = max_widths[idx] if idx < len(max_widths) else max_widths[-1]
         if current == "food_stockpile":
-            max_w = min(max_w, 60)
+            max_w = min(max_w, CFG.get("food_stockpile_max_width", max_w))
         width = min(max_w, available_width)
 
         min_req = min_requireds[idx] if idx < len(min_requireds) else min_requireds[-1]

--- a/tests/resource_rois/test_compute_rois.py
+++ b/tests/resource_rois/test_compute_rois.py
@@ -139,6 +139,27 @@ class TestComputeResourceROIs(TestCase):
         self.assertNotIn("food_stockpile", narrow)
         self.assertNotIn("idle_villager", narrow)
 
+    def test_food_roi_width_can_exceed_60_when_configured(self):
+        detected = {
+            "food_stockpile": (0, 0, 10, 10),
+            "gold_stockpile": (200, 0, 10, 10),
+        }
+        with patch.dict(resources.CFG, {"food_stockpile_max_width": 80}, clear=False):
+            regions, _spans, _narrow = resources.compute_resource_rois(
+                0,
+                300,
+                0,
+                20,
+                [0] * 6,
+                [0] * 6,
+                [0] * 6,
+                [999] * 6,
+                [0] * 6,
+                0,
+                detected=detected,
+            )
+        self.assertGreater(regions["food_stockpile"][2], 60)
+
     def test_population_roi_respects_min_width(self):
         detected = {
             "population_limit": (0, 0, 5, 5),


### PR DESCRIPTION
## Summary
- make food stockpile ROI width limit configurable
- document `food_stockpile_max_width` in configs
- extend ROI tests for wide food stockpile spans

## Testing
- `pytest tests/resource_rois/test_compute_rois.py tests/test_food_stockpile_ocr.py tests/test_wood_stockpile_ocr.py`

------
https://chatgpt.com/codex/tasks/task_e_68b4bcf70be0832590a5bf8783fbddfe