### PR TITLE
Seed idle villager cache for Hunting mission

### DIFF
--- a/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
+++ b/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
@@ -62,11 +62,16 @@ def main() -> None:
     common.TARGET_POP = info.objective_villagers
 
     # Inicialização de recursos com base no cenário
+    now = time.time()
     if info.starting_resources:
-        now = time.time()
         resources.RESOURCE_CACHE.last_resource_values.update(info.starting_resources)
         for name in info.starting_resources:
             resources.RESOURCE_CACHE.last_resource_ts[name] = now
+
+    resources.RESOURCE_CACHE.last_resource_values["idle_villager"] = (
+        info.starting_villagers
+    )
+    resources.RESOURCE_CACHE.last_resource_ts["idle_villager"] = now
 
     logger.info("Setup complete.")
     if "PYTEST_CURRENT_TEST" in os.environ:


### PR DESCRIPTION
## Summary
- Seed idle villager count in resource cache at start of Hunting mission, using `starting_villagers` from scenario info
- Extend Hunting scenario tests to verify cache seeding and prevent zero fallback before first OCR

## Testing
- `pytest tests/test_hunting_scenario.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4c1ebc0288325aab65fbf10c9ad5b