### PR TITLE
Clamp idle villager ROI before population

### DIFF
--- a/config.json
+++ b/config.json
@@ -89,7 +89,7 @@
         "max_width": [120, 160, 160, 160, 160, 160],
         "min_width": [3, 3, 3, 3, 3, 2],
         "min_required_width": 12,
-        "idle_roi_extra_width": 24,
+        "idle_roi_extra_width": 20,
         "min_pop_width": 60,
         "pop_roi_extra_width": 12,
         "top_pct": 0.06,
@@ -143,7 +143,7 @@
     "top_pct": 0.10,
     "height_pct": 0.06,
     "left_pct": 0.84,
-    "width_pct": 0.05
+    "width_pct": 0.045
   },
   "profiles": {
       "aoe1de": {

--- a/config.sample.json
+++ b/config.sample.json
@@ -95,7 +95,7 @@
         "max_width": [120, 160, 160, 160, 160, 160],
         "min_width": [5, 30, 5, 5, 5, 30],
         "min_required_width": 12,
-        "idle_roi_extra_width": 24,
+        "idle_roi_extra_width": 20,
         "min_pop_width": 60,
         "pop_roi_extra_width": 12,
         "top_pct": 0.06,
@@ -149,7 +149,7 @@
     "top_pct": 0.10,
     "height_pct": 0.06,
     "left_pct": 0.84,
-    "width_pct": 0.05
+    "width_pct": 0.045
   },
   "profiles": {
       "aoe1de": {

--- a/script/resources/panel/detection.py
+++ b/script/resources/panel/detection.py
@@ -131,6 +131,9 @@ def locate_resource_panel(frame, cache_obj: cache.ResourceCache = cache.RESOURCE
         extra = cfg.idle_roi_extra_width
         left = x + xi
         width = wi + extra
+        pop_span = spans.get("population_limit")
+        if pop_span and pop_span[0] > left:
+            width = min(width, pop_span[0] - left)
         right = left + width
         if right > x + w:
             width = (x + w) - left

--- a/tests/test_idle_villager_roi.py
+++ b/tests/test_idle_villager_roi.py
@@ -102,6 +102,70 @@ class TestIdleVillagerROI(TestCase):
         self.assertEqual(roi[2], icon_w + extra)
         self.assertGreater(roi[3], 0)
 
+    def test_idle_villager_roi_clamped_before_population(self):
+        frame = np.zeros((50, 100, 3), dtype=np.uint8)
+        panel_box = (10, 15, 80, 20)
+        xi, yi = 5, 4
+        icon_h, icon_w = 5, 5
+
+        def fake_imread(path, flags=0):
+            name = os.path.splitext(os.path.basename(path))[0]
+            if name == "idle_villager":
+                return np.ones((icon_h, icon_w), dtype=np.uint8)
+            return np.zeros((icon_h, icon_w), dtype=np.uint8)
+
+        def fake_match(img, templ, method):
+            h = img.shape[0] - templ.shape[0] + 1
+            w = img.shape[1] - templ.shape[1] + 1
+            res = np.zeros((h, w), dtype=np.float32)
+            if np.all(templ == 1):
+                res[yi, xi] = 0.95
+            return res
+
+        def fake_minmax(res):
+            max_val = float(res.max())
+            max_loc = tuple(np.unravel_index(res.argmax(), res.shape)[::-1])
+            return 0.0, max_val, (0, 0), max_loc
+
+        def fake_cvtColor(src, code):
+            return np.zeros(src.shape[:2], dtype=np.uint8)
+
+        def fake_compute(pl, pr, top, height, *args, **kwargs):
+            offset = 20
+            regions = {"population_limit": (pl + offset, top, 10, height)}
+            spans = {"population_limit": (pl + offset, pl + offset + 20)}
+            return regions, spans, {}
+
+        with patch("script.resources.find_template", return_value=(panel_box, 0.9, None)), \
+            patch("script.resources.cv2.cvtColor", side_effect=fake_cvtColor), \
+            patch("script.resources.cv2.resize", side_effect=lambda img, *a, **k: img), \
+            patch("script.resources.cv2.matchTemplate", side_effect=fake_match), \
+            patch("script.resources.cv2.minMaxLoc", side_effect=fake_minmax), \
+            patch("script.resources.cv2.imread", side_effect=fake_imread), \
+            patch("script.resources.panel.detection.compute_resource_rois", side_effect=fake_compute), \
+            patch.dict(screen_utils.ICON_TEMPLATES, {}, clear=True), \
+            patch.dict(
+                common.CFG["resource_panel"],
+                {
+                    "roi_padding_left": [0] * 6,
+                    "roi_padding_right": [0] * 6,
+                    "icon_trim_pct": [0] * 6,
+                    "scales": [1.0],
+                    "match_threshold": 0.5,
+                    "max_width": 999,
+                    "min_width": 0,
+                },
+            ), patch.dict(
+                common.CFG["profiles"]["aoe1de"]["resource_panel"],
+                {"icon_trim_pct": [0] * 6},
+            ):
+                regions = resources.locate_resource_panel(frame)
+
+        self.assertIn("idle_villager", regions)
+        roi = regions["idle_villager"]
+        pop_left = panel_box[0] + 20
+        self.assertLessEqual(roi[0] + roi[2], pop_left)
+
     def test_detect_resource_regions_uses_configured_idle_roi_when_missing(self):
         frame = np.zeros((50, 100, 3), dtype=np.uint8)
         cfg = {
@@ -128,7 +192,7 @@ class TestIdleVillagerROI(TestCase):
             "width_pct": 0.05,
             "height_pct": 0.05,
         }
-        with patch("script.resources.locate_resource_panel", return_value=detected), \
+        with patch("script.resources.panel.locate_resource_panel", return_value=detected), \
             patch.dict(resources.CFG, {"idle_villager_roi": cfg}, clear=False), \
             patch.object(common, "HUD_ANCHOR", None):
             regions = resources.detect_resource_regions(frame, ["idle_villager"])


### PR DESCRIPTION
## Summary
- Prevent `idle_roi_extra_width` from expanding into the population slot by clamping ROI width to the population region's left edge.
- Narrow default idle villager ROI settings to reflect the new behavior.
- Add regression test ensuring idle villager ROI stops before population digits.

## Testing
- `pytest tests/test_idle_villager_roi.py -q`
- `pytest tests/test_idle_villager_ocr.py -q`
- `pytest tests/resource_rois/test_compute_rois.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4c612f28c83259c492849b0f983b5