### PR TITLE
Handle resource validation failures individually

### DIFF
--- a/campaign.py
+++ b/campaign.py
@@ -115,7 +115,7 @@ def main():
                             rois=rois,
                         )
                         break
-                    except ValueError as e:
+                    except resources.ResourceValidationError as e:
                         logger.warning(
                             "Starting resource validation attempt %d failed: %s",
                             attempt,
@@ -148,7 +148,7 @@ def main():
                                 raise
                         attempt += 1
                         tolerance = min(max_tolerance, tolerance + 5)
-                        for k in non_zero:
+                        for k in e.failing_keys:
                             resources._NARROW_ROI_DEFICITS[k] = (
                                 resources._NARROW_ROI_DEFICITS.get(k, 0) + 2
                             )

--- a/script/resources/__init__.py
+++ b/script/resources/__init__.py
@@ -77,6 +77,7 @@ from .reader import (
     read_resources_from_hud,
     gather_hud_stats,
     validate_starting_resources,
+    ResourceValidationError,
 )
 
 __all__ = [
@@ -100,4 +101,5 @@ __all__ = [
     "read_resources_from_hud",
     "gather_hud_stats",
     "validate_starting_resources",
+    "ResourceValidationError",
 ]

--- a/script/resources/reader/__init__.py
+++ b/script/resources/reader/__init__.py
@@ -40,6 +40,7 @@ from .core import (
     read_resources_from_hud,
     gather_hud_stats,
     validate_starting_resources,
+    ResourceValidationError,
 )
 
 __all__ = [
@@ -62,4 +63,5 @@ __all__ = [
     "read_resources_from_hud",
     "gather_hud_stats",
     "validate_starting_resources",
+    "ResourceValidationError",
 ]


### PR DESCRIPTION
## Summary
- Track resource validation failures with a new `ResourceValidationError`
- Narrow ROIs only for failing resources during campaign retries
- Add tests ensuring only bad readings trigger ROI narrowing

## Testing
- `pytest tests/test_campaign_resource_validation.py -q`
- `pytest -q` *(fails: TesseractNotFoundError and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b4cfcc5c0083258effb0d88fcb94dc