### PR TITLE
Fallback to PATH when configured Tesseract path is invalid

### DIFF
--- a/script/common.py
+++ b/script/common.py
@@ -18,7 +18,7 @@ CFG = load_config()
 logger = logging.getLogger(__name__)
 
 tesseract_cmd = os.environ.get("TESSERACT_CMD") or CFG.get("tesseract_path")
-path_lookup = shutil.which("tesseract") if not tesseract_cmd else None
+path_lookup = shutil.which("tesseract")
 if tesseract_cmd:
     tesseract_path = Path(tesseract_cmd)
     if tesseract_path.is_file() and os.access(tesseract_path, os.X_OK):

--- a/tests/test_tesseract_path_fallback.py
+++ b/tests/test_tesseract_path_fallback.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import types
+import importlib
+
+
+def test_tesseract_path_fallback(monkeypatch, tmp_path):
+    fake_dir = tmp_path / "bin"
+    fake_dir.mkdir()
+    fake_tesseract = fake_dir / "tesseract"
+    fake_tesseract.write_text("#!/bin/sh\nexit 0\n")
+    fake_tesseract.chmod(0o755)
+
+    monkeypatch.setenv("PATH", f"{fake_dir}{os.pathsep}" + os.environ.get("PATH", ""))
+    monkeypatch.setenv("TESSERACT_CMD", "/invalid/path/tesseract")
+
+    fake_pytesseract = types.SimpleNamespace(pytesseract=types.SimpleNamespace(tesseract_cmd=""))
+    monkeypatch.setitem(sys.modules, "pytesseract", fake_pytesseract)
+    sys.modules.pop("script.common", None)
+    common = importlib.import_module("script.common")
+    assert common.pytesseract.pytesseract.tesseract_cmd == str(fake_tesseract)
+    monkeypatch.delitem(sys.modules, "script.common", raising=False)
+


### PR DESCRIPTION
## Summary
- Always check for `tesseract` on `PATH`
- When configured `tesseract_path` is invalid, fall back to `PATH`
- Test fallback when the configured path is wrong

## Testing
- `TESSERACT_CMD=/usr/bin/true pytest` *(fails: 50 failed, 129 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68b4d2d12738832587870609cfdd051a