### PR TITLE
Raise error if HUD template missing

### DIFF
--- a/script/hud.py
+++ b/script/hud.py
@@ -29,11 +29,13 @@ def wait_hud(timeout=60):
     t0 = time.time()
     tmpl = screen_utils.HUD_TEMPLATE
     asset = "assets/resources.png"
+    if tmpl is None:
+        raise RuntimeError(
+            f"HUD template '{asset}' not loaded; ensure {asset} exists"
+        )
     last_score = -1.0
     while time.time() - t0 < timeout:
         frame = screen_utils._grab_frame()
-        if tmpl is None:
-            break
         box, score, heat = find_template(
             frame, tmpl, threshold=CFG["threshold"], scales=CFG["scales"]
         )

--- a/tests/test_hud_anchor.py
+++ b/tests/test_hud_anchor.py
@@ -46,6 +46,14 @@ class TestHudAnchor(TestCase):
         resources.RESOURCE_CACHE.last_resource_ts.clear()
         resources.RESOURCE_CACHE.resource_failure_counts.clear()
 
+    def test_wait_hud_raises_without_template(self):
+        with patch.object(hud.screen_utils, "HUD_TEMPLATE", None), \
+             patch("script.screen_utils._grab_frame") as grab_mock:
+            with self.assertRaises(RuntimeError) as ctx:
+                hud.wait_hud(timeout=1)
+        grab_mock.assert_not_called()
+        self.assertIn(ASSET, str(ctx.exception))
+
     def test_wait_hud_sets_asset(self):
         common.HUD_ANCHOR = None
         fake_frame = np.zeros((100, 100, 3), dtype=np.uint8)


### PR DESCRIPTION
## Summary
- fail fast in `hud.wait_hud` when the HUD template image is missing
- adjust HUD detection loop to assume template exists
- add regression test for missing HUD template

## Testing
- `pytest` (fails: tests/test_resource_debug_images.py::TestResourceDebugImages::test_debug_images_written_when_all_none_and_debug_off ... tests/test_wood_stockpile_ocr.py::TestWoodStockpileOCR::test_wood_stockpile_high_confidence)`

------
https://chatgpt.com/codex/tasks/task_e_68b4d448f5848325b4f2249bef40a1dc