### PR TITLE
Handle specific read errors

### DIFF
--- a/campaign.py
+++ b/campaign.py
@@ -61,7 +61,7 @@ def main():
                 )
                 raise SystemExit(
                     "HUD not detected after two attempts; exiting script."
-                )
+                ) from e2
 
         info = parse_scenario_info(args.scenario)
         common.CURRENT_POP = info.starting_villagers
@@ -172,9 +172,9 @@ def main():
             logger.info(
                 "Detected idle villagers: %s", res.get("idle_villager")
             )
-        except Exception as e:
+        except (common.ResourceReadError, common.PopulationReadError) as e:
             logger.error("Failed to detect resources or population: %s", e)
-            raise SystemExit("Failed to detect resources or population")
+            raise SystemExit("Failed to detect resources or population") from e
 
         logger.info("Setup complete.")
         module_name = _scenario_to_module(args.scenario)
@@ -182,7 +182,7 @@ def main():
             mission = importlib.import_module(module_name)
         except ModuleNotFoundError as e:
             logger.error("Failed to import mission module '%s': %s", module_name, e)
-            raise SystemExit(f"Mission module '{module_name}' not found")
+            raise SystemExit(f"Mission module '{module_name}' not found") from e
         func = getattr(mission, "run_mission", None) or getattr(mission, "main", None)
         if func is None:
             logger.error(

--- a/script/units/villager.py
+++ b/script/units/villager.py
@@ -73,7 +73,7 @@ def build_house():
         try:
             hud.wait_hud()
             res_vals, _ = resources.read_resources_from_hud(["wood_stockpile"])
-        except Exception as exc:
+        except common.ResourceReadError as exc:
             logger.error(
                 "Failed to refresh HUD or read resources while building house: %s",
                 exc,
@@ -116,7 +116,7 @@ def build_house():
 
         try:
             cur, limit = hud.read_population_from_hud()
-        except Exception as exc:  # pragma: no cover - falha de OCR
+        except (common.ResourceReadError, common.PopulationReadError) as exc:  # pragma: no cover - falha de OCR
             logger.warning("Failed to read population: %s", exc)
             limit = common.POP_CAP
 

--- a/tests/test_campaign_resource_read_error_surface.py
+++ b/tests/test_campaign_resource_read_error_surface.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import types
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+# Setup dummy dependencies
+
+dummy_pg = types.SimpleNamespace(
+    PAUSE=0,
+    FAILSAFE=False,
+    size=lambda: (200, 200),
+    click=lambda *a, **k: None,
+    moveTo=lambda *a, **k: None,
+    press=lambda *a, **k: None,
+)
+
+class DummyMSS:
+    monitors = [{}, {"left": 0, "top": 0, "width": 200, "height": 200}]
+
+    def grab(self, region):
+        import numpy as np
+        h, w = region["height"], region["width"]
+        return np.zeros((h, w, 4), dtype=np.uint8)
+
+sys.modules.setdefault("pyautogui", dummy_pg)
+sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
+os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import campaign
+
+
+class TestResourceReadErrorSurface(TestCase):
+    def test_resource_read_error_surfaces_message(self):
+        info = types.SimpleNamespace(
+            starting_resources={},
+            starting_villagers=3,
+            objective_villagers=5,
+        )
+        err_msg = "boom"
+        logger_mock = MagicMock()
+        dummy_module = types.SimpleNamespace(run_mission=lambda *a, **k: None)
+
+        with patch("campaign.parse_scenario_info", return_value=info), \
+            patch(
+                "campaign.argparse.ArgumentParser.parse_args",
+                return_value=types.SimpleNamespace(scenario="dummy"),
+            ), \
+            patch("campaign.screen_utils.init_sct"), \
+            patch("campaign.screen_utils.teardown_sct"), \
+            patch("campaign.hud.wait_hud", return_value=({}, "asset")), \
+            patch(
+                "campaign.resources.gather_hud_stats",
+                side_effect=campaign.common.ResourceReadError(err_msg),
+            ), \
+            patch("campaign.logging.getLogger", return_value=logger_mock), \
+            patch("importlib.import_module", return_value=dummy_module):
+            with self.assertRaises(SystemExit) as ctx:
+                campaign.main()
+
+        self.assertIsInstance(ctx.exception.__cause__, campaign.common.ResourceReadError)
+        self.assertEqual(str(ctx.exception.__cause__), err_msg)
+        self.assertTrue(
+            any(
+                err_msg in " ".join(map(str, call.args))
+                for call in logger_mock.error.call_args_list
+            )
+        )


### PR DESCRIPTION
## Summary
- Replace broad exception catches with ResourceReadError/PopulationReadError
- Attach original exceptions when aborting with SystemExit
- Add regression test ensuring resource read failures expose underlying messages

## Testing
- `pytest tests/test_campaign_resource_read_error_surface.py -q`
- `pytest -q` *(fails: TesseractNotFoundError and multiple assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d8321494832585a0f88b71880e01