### PR TITLE
Reduce idle villager ROI width

### DIFF
--- a/config.json
+++ b/config.json
@@ -89,7 +89,7 @@
         "max_width": [120, 160, 160, 160, 160, 160],
         "min_width": [3, 3, 3, 3, 3, 2],
         "min_required_width": 12,
-        "idle_roi_extra_width": 20,
+        "idle_roi_extra_width": 12,
         "min_pop_width": 60,
         "pop_roi_extra_width": 12,
         "top_pct": 0.06,
@@ -143,7 +143,7 @@
     "top_pct": 0.10,
     "height_pct": 0.06,
     "left_pct": 0.84,
-    "width_pct": 0.045
+    "width_pct": 0.04
   },
   "profiles": {
       "aoe1de": {

--- a/config.sample.json
+++ b/config.sample.json
@@ -95,7 +95,7 @@
         "max_width": [120, 160, 160, 160, 160, 160],
         "min_width": [5, 30, 5, 5, 5, 30],
         "min_required_width": 12,
-        "idle_roi_extra_width": 20,
+        "idle_roi_extra_width": 12,
         "min_pop_width": 60,
         "pop_roi_extra_width": 12,
         "top_pct": 0.06,
@@ -149,7 +149,7 @@
     "top_pct": 0.10,
     "height_pct": 0.06,
     "left_pct": 0.84,
-    "width_pct": 0.045
+    "width_pct": 0.04
   },
   "profiles": {
       "aoe1de": {

--- a/tests/test_idle_villager_roi.py
+++ b/tests/test_idle_villager_roi.py
@@ -170,7 +170,7 @@ class TestIdleVillagerROI(TestCase):
         cfg = {
             "left_pct": 0.5,
             "top_pct": 0.25,
-            "width_pct": 0.05,
+            "width_pct": 0.04,
             "height_pct": 0.05,
         }
         expected = (100, 50, 40, 20)
@@ -188,7 +188,7 @@ class TestIdleVillagerROI(TestCase):
         cfg = {
             "left_pct": 0.5,
             "top_pct": 0.25,
-            "width_pct": 0.05,
+            "width_pct": 0.04,
             "height_pct": 0.05,
         }
         with patch("script.resources.panel.locate_resource_panel", return_value=detected), \


### PR DESCRIPTION
## Summary
- tighten idle villager region by shrinking `idle_roi_extra_width`
- narrow default `idle_villager_roi.width_pct`
- adjust idle villager ROI tests for new width

## Testing
- `pytest tests/test_idle_villager_roi.py tests/test_resource_panel_cfg.py tests/test_select_idle_villager.py`

------
https://chatgpt.com/codex/tasks/task_e_68b50eafe8c083259b0c76cf7d6f56b9