### PR TITLE
Increase idle villager OCR threshold

### DIFF
--- a/config.json
+++ b/config.json
@@ -33,7 +33,7 @@
     "gold_stockpile_ocr_conf_threshold": 45,
     "stone_stockpile_ocr_conf_threshold": 45,
     "population_limit_ocr_conf_threshold": 40,
-    "idle_villager_ocr_conf_threshold": 40,
+    "idle_villager_ocr_conf_threshold": 55,
     "//*_ocr_conf_threshold": "Optional per-resource OCR confidence overrides.",
     "food_stockpile_max_width": 60,
     "//food_stockpile_max_width": "Maximum width of the food stockpile ROI.",

--- a/config.sample.json
+++ b/config.sample.json
@@ -39,7 +39,7 @@
     "gold_stockpile_ocr_conf_threshold": 45,
     "stone_stockpile_ocr_conf_threshold": 45,
     "population_limit_ocr_conf_threshold": 45,
-    "idle_villager_ocr_conf_threshold": 40,
+    "idle_villager_ocr_conf_threshold": 55,
     "//*_ocr_conf_threshold": "Optional per-resource OCR confidence overrides.",
     "food_stockpile_max_width": 60,
     "//food_stockpile_max_width": "Maximum width of the food stockpile ROI.",

--- a/tests/test_idle_villager_ocr.py
+++ b/tests/test_idle_villager_ocr.py
@@ -101,12 +101,13 @@ class TestIdleVillagerOCR(TestCase):
             return {"idle_villager": (0, 0, 50, 50)}
 
         frame = np.zeros((100, 100, 3), dtype=np.uint8)
+        low_conf = str(resources.CFG["idle_villager_ocr_conf_threshold"] - 1)
         with patch(
             "script.resources.reader.core.detect_resource_regions",
             side_effect=fake_detect,
         ), patch("script.screen_utils._grab_frame", return_value=frame), patch(
             "script.resources.reader.pytesseract.image_to_data",
-            return_value={"text": ["1"], "conf": ["30"]},
+            return_value={"text": ["1"], "conf": [low_conf]},
         ), patch(
             "script.resources.reader.core.execute_ocr",
             return_value=("", {"text": [""], "conf": []}, None, True),


### PR DESCRIPTION
## Summary
- raise idle villager OCR confidence threshold to 55
- update sample config and tests to use dynamic low-confidence threshold

## Testing
- `pytest tests/test_idle_villager_ocr.py tests/test_idle_villager_roi.py tests/test_select_idle_villager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b50fda5c248325a74190d3b7fd9974