### PR TITLE
Clamp idle villager ROI before population counter

### DIFF
--- a/script/resources/panel/detection.py
+++ b/script/resources/panel/detection.py
@@ -132,8 +132,8 @@ def locate_resource_panel(frame, cache_obj: cache.ResourceCache = cache.RESOURCE
         left = x + xi
         width = wi + extra
         pop_span = spans.get("population_limit")
-        if pop_span and pop_span[0] > left:
-            width = min(width, pop_span[0] - left)
+        if pop_span and pop_span[0] > left and left + width > pop_span[0]:
+            width = max(0, min(width, pop_span[0] - left))
         right = left + width
         if right > x + w:
             width = (x + w) - left

--- a/tests/test_idle_villager_roi.py
+++ b/tests/test_idle_villager_roi.py
@@ -165,6 +165,73 @@ class TestIdleVillagerROI(TestCase):
         pop_left = panel_box[0] + 20
         self.assertLessEqual(roi[0] + roi[2], pop_left)
 
+    def test_idle_villager_roi_shrinks_near_population(self):
+        frame = np.zeros((50, 100, 3), dtype=np.uint8)
+        panel_box = (10, 15, 80, 20)
+        xi, yi = 5, 4
+        icon_h, icon_w = 5, 5
+
+        def fake_imread(path, flags=0):
+            name = os.path.splitext(os.path.basename(path))[0]
+            if name == "idle_villager":
+                return np.ones((icon_h, icon_w), dtype=np.uint8)
+            return np.zeros((icon_h, icon_w), dtype=np.uint8)
+
+        def fake_match(img, templ, method):
+            h = img.shape[0] - templ.shape[0] + 1
+            w = img.shape[1] - templ.shape[1] + 1
+            res = np.zeros((h, w), dtype=np.float32)
+            if np.all(templ == 1):
+                res[yi, xi] = 0.95
+            return res
+
+        def fake_minmax(res):
+            max_val = float(res.max())
+            max_loc = tuple(np.unravel_index(res.argmax(), res.shape)[::-1])
+            return 0.0, max_val, (0, 0), max_loc
+
+        def fake_cvtColor(src, code):
+            return np.zeros(src.shape[:2], dtype=np.uint8)
+
+        def fake_compute(pl, pr, top, height, *args, **kwargs):
+            offset = 25
+            regions = {"population_limit": (pl + offset, top, 10, height)}
+            spans = {"population_limit": (pl + offset, pl + offset + 20)}
+            return regions, spans, {}
+
+        with patch("script.resources.find_template", return_value=(panel_box, 0.9, None)), \
+            patch("script.resources.cv2.cvtColor", side_effect=fake_cvtColor), \
+            patch("script.resources.cv2.resize", side_effect=lambda img, *a, **k: img), \
+            patch("script.resources.cv2.matchTemplate", side_effect=fake_match), \
+            patch("script.resources.cv2.minMaxLoc", side_effect=fake_minmax), \
+            patch("script.resources.cv2.imread", side_effect=fake_imread), \
+            patch("script.resources.panel.detection.compute_resource_rois", side_effect=fake_compute), \
+            patch.dict(screen_utils.ICON_TEMPLATES, {}, clear=True), \
+            patch.dict(
+                common.CFG["resource_panel"],
+                {
+                    "roi_padding_left": [0] * 6,
+                    "roi_padding_right": [0] * 6,
+                    "icon_trim_pct": [0] * 6,
+                    "scales": [1.0],
+                    "match_threshold": 0.5,
+                    "max_width": 999,
+                    "min_width": 0,
+                    "idle_roi_extra_width": 20,
+                },
+            ), patch.dict(
+                common.CFG["profiles"]["aoe1de"]["resource_panel"],
+                {"icon_trim_pct": [0] * 6},
+            ):
+                regions = resources.locate_resource_panel(frame)
+
+        self.assertIn("idle_villager", regions)
+        roi = regions["idle_villager"]
+        pop_left = panel_box[0] + 25
+        self.assertLessEqual(roi[0] + roi[2], pop_left)
+        expected_width = pop_left - (panel_box[0] + xi)
+        self.assertEqual(roi[2], expected_width)
+
     def test_detect_resource_regions_uses_configured_idle_roi_when_missing(self):
         frame = np.zeros((50, 100, 3), dtype=np.uint8)
         cfg = {


### PR DESCRIPTION
## Summary
- Prevent idle-villager ROI from overlapping the population counter by clamping its width
- Add regression test ensuring idle-villager ROI stops at population region

## Testing
- `pytest tests/test_idle_villager_roi.py -q`
- `pytest -q` *(fails: Invalid Tesseract OCR path; Tesseract not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5165a3a4c8325bec88e664223de5e