### PR TITLE
Clamp idle villager ROI to digit span

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,6 @@ between two icons. Three configuration options define the valid horizontal
 * `roi_padding_right` – pixels subtracted from the left edge of the next icon.
 * `icon_trim_pct` – fraction of the icon slot to skip when estimating ROIs
   from the HUD anchor.
-* `idle_roi_extra_width` – extra pixels appended to the idle villager span to
-  capture digits.
 * `min_pop_width` – minimum width reserved for the population readout when
   the icon cannot be detected.
 * `pop_roi_extra_width` – extra pixels appended to the right of the population
@@ -136,10 +134,6 @@ With icon positions `0, 30, 60, 90, 120, 150`, icon width `5` and paddings
 | gold           | 65         | 90             | 67              | 88              |
 | stone          | 95         | 120            | 97              | 118             |
 | population     | 125        | 150            | 127            | 148             |
-| idle villager* | –          | –              | (ROI extends past icon by `idle_roi_extra_width`) |            |
-
-`*` Idle villager is the last icon; its ROI extends beyond the icon by
-`idle_roi_extra_width` pixels.
 
 #### Calibrating per-icon offsets
 

--- a/config.json
+++ b/config.json
@@ -89,7 +89,7 @@
         "max_width": [120, 160, 160, 160, 160, 160],
         "min_width": [3, 3, 3, 3, 3, 2],
         "min_required_width": 12,
-        "idle_roi_extra_width": 12,
+          "idle_roi_extra_width": 0,
         "min_pop_width": 60,
         "pop_roi_extra_width": 12,
         "top_pct": 0.06,

--- a/config.sample.json
+++ b/config.sample.json
@@ -95,7 +95,7 @@
         "max_width": [120, 160, 160, 160, 160, 160],
         "min_width": [5, 30, 5, 5, 5, 30],
         "min_required_width": 12,
-        "idle_roi_extra_width": 12,
+          "idle_roi_extra_width": 0,
         "min_pop_width": 60,
         "pop_roi_extra_width": 12,
         "top_pct": 0.06,

--- a/script/resources/panel/calibration.py
+++ b/script/resources/panel/calibration.py
@@ -73,13 +73,19 @@ def _auto_calibrate_from_icons(frame, cache_obj: cache.ResourceCache = cache.RES
 
     if "idle_villager" in detected_rel:
         xi, yi, wi, hi = detected_rel["idle_villager"]
-        extra = cfg.idle_roi_extra_width
-        left = panel_left + xi
-        width = wi + extra
-        right = left + width
+        span = spans.get("idle_villager")
+        if span:
+            left, right = span
+        else:
+            left = panel_left + xi + wi
+            right = left
+        pop_span = spans.get("population_limit")
+        if pop_span and pop_span[0] > left and right > pop_span[0]:
+            right = pop_span[0]
         if right > panel_right:
-            width = panel_right - left
-        regions["idle_villager"] = (panel_left + xi, panel_top + yi, width, hi)
+            right = panel_right
+        width = max(0, right - left)
+        regions["idle_villager"] = (left, panel_top + yi, width, hi)
 
     if cache._LAST_REGION_BOUNDS != regions:
         cache._LAST_REGION_BOUNDS = regions.copy()

--- a/script/resources/panel/detection.py
+++ b/script/resources/panel/detection.py
@@ -128,15 +128,18 @@ def locate_resource_panel(frame, cache_obj: cache.ResourceCache = cache.RESOURCE
 
     if "idle_villager" in detected:
         xi, yi, wi, hi = detected["idle_villager"]
-        extra = cfg.idle_roi_extra_width
-        left = x + xi
-        width = wi + extra
+        span = spans.get("idle_villager")
+        if span:
+            left, right = span
+        else:
+            left = x + xi + wi
+            right = left
         pop_span = spans.get("population_limit")
-        if pop_span and pop_span[0] > left and left + width > pop_span[0]:
-            width = max(0, min(width, pop_span[0] - left))
-        right = left + width
+        if pop_span and pop_span[0] > left and right > pop_span[0]:
+            right = pop_span[0]
         if right > x + w:
-            width = (x + w) - left
+            right = x + w
+        width = max(0, right - left)
         regions["idle_villager"] = (left, y + yi, width, hi)
         logger.debug(
             "ROI for 'idle_villager': icon=(%d,%d) width=%d", left, y + yi, width


### PR DESCRIPTION
## Summary
- clamp idle villager ROI to detected digit span and prevent overlap with population value
- apply the same ROI cropping in calibration
- drop idle villager extra width from configs and docs
- adjust tests for the new idle ROI

## Testing
- `pytest`
- `pytest tests/test_idle_villager_roi.py tests/test_resource_panel_cfg.py tests/test_population_limit_fallback.py`


------
https://chatgpt.com/codex/tasks/task_e_68b51b466b548325aa71d23174aed321