### PR TITLE
Refactor idle villager ROI handling

### DIFF
--- a/script/resources/panel/detection.py
+++ b/script/resources/panel/detection.py
@@ -127,22 +127,26 @@ def locate_resource_panel(frame, cache_obj: cache.ResourceCache = cache.RESOURCE
     cache._LAST_REGION_SPANS = spans.copy()
 
     if "idle_villager" in detected:
-        xi, yi, wi, hi = detected["idle_villager"]
+        xi, _yi, wi, _hi = detected["idle_villager"]
         span = spans.get("idle_villager")
         if span:
             left, right = span
         else:
             left = x + xi + wi
-            right = left
+            right = left + cfg.idle_roi_extra_width
         pop_span = spans.get("population_limit")
         if pop_span and pop_span[0] > left and right > pop_span[0]:
             right = pop_span[0]
         if right > x + w:
             right = x + w
         width = max(0, right - left)
-        regions["idle_villager"] = (left, y + yi, width, hi)
+        regions["idle_villager"] = (left, top, width, height)
         logger.debug(
-            "ROI for 'idle_villager': icon=(%d,%d) width=%d", left, y + yi, width
+            "ROI for 'idle_villager': left=%d top=%d width=%d height=%d",
+            left,
+            top,
+            width,
+            height,
         )
 
     if cache._LAST_REGION_BOUNDS != regions:

--- a/tests/test_idle_villager_roi.py
+++ b/tests/test_idle_villager_roi.py
@@ -101,7 +101,10 @@ class TestIdleVillagerROI(TestCase):
 
         self.assertIn("idle_villager", regions)
         roi = regions["idle_villager"]
-        expected = (panel_box[0] + xi + icon_w, panel_box[1] + yi, 10, icon_h)
+        cfg_obj = resources.panel._get_resource_panel_cfg()
+        top = panel_box[1] + int(cfg_obj.top_pct * panel_box[3])
+        height = int(cfg_obj.height_pct * panel_box[3])
+        expected = (panel_box[0] + xi + icon_w, top, 10, height)
         self.assertEqual(roi, expected)
         self.assertEqual(roi[2], 10)
         self.assertGreater(roi[3], 0)


### PR DESCRIPTION
## Summary
- reuse panel top/height when computing idle villager ROI
- extend idle ROI width when no digit span exists
- adjust tests for new idle villager ROI bounds

## Testing
- `pytest tests/test_idle_villager_roi.py -q`
- `pytest -q --maxfail=1` *(fails: tests/ocr_failures/test_debug_outputs.py::test_discard_low_confidence_logged)*


------
https://chatgpt.com/codex/tasks/task_e_68b520e4a9c0832591d62dfd77b93e1a