### PR TITLE
test: verify idle villager ROI bounds

### DIFF
--- a/tests/test_idle_villager_roi.py
+++ b/tests/test_idle_villager_roi.py
@@ -173,8 +173,14 @@ class TestIdleVillagerROI(TestCase):
 
         self.assertIn("idle_villager", regions)
         roi = regions["idle_villager"]
+        cfg_obj = resources.panel._get_resource_panel_cfg()
+        top = panel_box[1] + int(cfg_obj.top_pct * panel_box[3])
+        height = int(cfg_obj.height_pct * panel_box[3])
+        self.assertEqual(roi[1], top)
+        self.assertEqual(roi[3], height)
         pop_left = panel_box[0] + 20
-        self.assertLessEqual(roi[0] + roi[2], pop_left)
+        expected_width = pop_left - (panel_box[0] + xi + icon_w)
+        self.assertEqual(roi[2], expected_width)
 
     def test_idle_villager_roi_shrinks_near_population(self):
         frame = np.zeros((50, 100, 3), dtype=np.uint8)
@@ -240,10 +246,84 @@ class TestIdleVillagerROI(TestCase):
 
         self.assertIn("idle_villager", regions)
         roi = regions["idle_villager"]
+        cfg_obj = resources.panel._get_resource_panel_cfg()
+        top = panel_box[1] + int(cfg_obj.top_pct * panel_box[3])
+        height = int(cfg_obj.height_pct * panel_box[3])
+        self.assertEqual(roi[1], top)
+        self.assertEqual(roi[3], height)
         pop_left = panel_box[0] + 25
-        self.assertLessEqual(roi[0] + roi[2], pop_left)
         expected_width = pop_left - (panel_box[0] + xi + icon_w)
         self.assertEqual(roi[2], expected_width)
+
+    def test_idle_villager_roi_uses_extra_width_when_no_span(self):
+        frame = np.zeros((50, 100, 3), dtype=np.uint8)
+        panel_box = (10, 15, 80, 20)
+        xi, yi = 5, 4
+        icon_h, icon_w = 5, 5
+
+        def fake_imread(path, flags=0):
+            name = os.path.splitext(os.path.basename(path))[0]
+            if name == "idle_villager":
+                return np.ones((icon_h, icon_w), dtype=np.uint8)
+            return np.zeros((icon_h, icon_w), dtype=np.uint8)
+
+        def fake_match(img, templ, method):
+            h = img.shape[0] - templ.shape[0] + 1
+            w = img.shape[1] - templ.shape[1] + 1
+            res = np.zeros((h, w), dtype=np.float32)
+            if np.all(templ == 1):
+                res[yi, xi] = 0.95
+            return res
+
+        def fake_minmax(res):
+            max_val = float(res.max())
+            max_loc = tuple(np.unravel_index(res.argmax(), res.shape)[::-1])
+            return 0.0, max_val, (0, 0), max_loc
+
+        def fake_cvtColor(src, code):
+            return np.zeros(src.shape[:2], dtype=np.uint8)
+
+        def fake_compute(pl, pr, top, height, *args, **kwargs):
+            offset = 60
+            pop_span = (pl + offset, pl + offset + 20)
+            regions = {"population_limit": (pl + offset, top, 10, height)}
+            spans = {"population_limit": pop_span}
+            return regions, spans, {}
+
+        with patch("script.resources.find_template", return_value=(panel_box, 0.9, None)), \
+            patch("script.resources.cv2.cvtColor", side_effect=fake_cvtColor), \
+            patch("script.resources.cv2.resize", side_effect=lambda img, *a, **k: img), \
+            patch("script.resources.cv2.matchTemplate", side_effect=fake_match), \
+            patch("script.resources.cv2.minMaxLoc", side_effect=fake_minmax), \
+            patch("script.resources.cv2.imread", side_effect=fake_imread), \
+            patch("script.resources.panel.detection.compute_resource_rois", side_effect=fake_compute), \
+            patch.dict(screen_utils.ICON_TEMPLATES, {}, clear=True), \
+            patch.dict(
+                common.CFG["resource_panel"],
+                {
+                    "roi_padding_left": [0] * 6,
+                    "roi_padding_right": [0] * 6,
+                    "icon_trim_pct": [0] * 6,
+                    "scales": [1.0],
+                    "match_threshold": 0.5,
+                    "max_width": 999,
+                    "min_width": 0,
+                    "idle_roi_extra_width": 15,
+                },
+            ), patch.dict(
+                common.CFG["profiles"]["aoe1de"]["resource_panel"],
+                {"icon_trim_pct": [0] * 6},
+            ):
+                regions = resources.locate_resource_panel(frame)
+                cfg_obj = resources.panel._get_resource_panel_cfg()
+
+        self.assertIn("idle_villager", regions)
+        roi = regions["idle_villager"]
+        top = panel_box[1] + int(cfg_obj.top_pct * panel_box[3])
+        height = int(cfg_obj.height_pct * panel_box[3])
+        self.assertEqual(roi[1], top)
+        self.assertEqual(roi[3], height)
+        self.assertEqual(roi[2], cfg_obj.idle_roi_extra_width)
 
     def test_detect_resource_regions_uses_configured_idle_roi_when_missing(self):
         frame = np.zeros((50, 100, 3), dtype=np.uint8)


### PR DESCRIPTION
## Summary
- ensure idle villager ROI height and top match panel geometry
- assert width clamps at population limit
- cover width expansion when idle ROI digit span is missing

## Testing
- `pytest tests/test_idle_villager_roi.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5223233d08325b858af100b656e9f