### PR TITLE
Handle idle villager ROI within compute_resource_rois

### DIFF
--- a/script/resources/panel/detection.py
+++ b/script/resources/panel/detection.py
@@ -118,6 +118,7 @@ def locate_resource_panel(frame, cache_obj: cache.ResourceCache = cache.RESOURCE
         cfg.max_widths,
         cfg.min_widths,
         cfg.min_pop_width,
+        cfg.idle_roi_extra_width,
         cfg.min_requireds,
         detected,
     )
@@ -125,29 +126,6 @@ def locate_resource_panel(frame, cache_obj: cache.ResourceCache = cache.RESOURCE
     cache._NARROW_ROIS = set(narrow.keys())
     cache._NARROW_ROI_DEFICITS = narrow.copy()
     cache._LAST_REGION_SPANS = spans.copy()
-
-    if "idle_villager" in detected:
-        xi, _yi, wi, _hi = detected["idle_villager"]
-        span = spans.get("idle_villager")
-        if span:
-            left, right = span
-        else:
-            left = x + xi + wi
-            right = left + cfg.idle_roi_extra_width
-        pop_span = spans.get("population_limit")
-        if pop_span and pop_span[0] > left and right > pop_span[0]:
-            right = pop_span[0]
-        if right > x + w:
-            right = x + w
-        width = max(0, right - left)
-        regions["idle_villager"] = (left, top, width, height)
-        logger.debug(
-            "ROI for 'idle_villager': left=%d top=%d width=%d height=%d",
-            left,
-            top,
-            width,
-            height,
-        )
 
     if cache._LAST_REGION_BOUNDS != regions:
         cache._LAST_REGION_BOUNDS = regions.copy()

--- a/script/resources/panel/roi.py
+++ b/script/resources/panel/roi.py
@@ -20,6 +20,7 @@ def compute_resource_rois(
     max_widths,
     min_widths,
     min_pop_width,
+    idle_extra_width,
     min_requireds=None,
     detected=None,
 ):
@@ -155,6 +156,22 @@ def compute_resource_rois(
             right,
             width,
         )
+    if (
+        "idle_villager" in detected
+        and "idle_villager" not in regions
+        and idle_extra_width > 0
+    ):
+        xi, _yi, wi, _hi = detected["idle_villager"]
+        left = panel_left + xi + wi
+        right = left + idle_extra_width
+        pop_span = spans.get("population_limit")
+        if pop_span and pop_span[0] > left and right > pop_span[0]:
+            right = pop_span[0]
+        if right > panel_right:
+            right = panel_right
+        width = max(0, right - left)
+        regions["idle_villager"] = (left, top, width, height)
+        spans["idle_villager"] = (left, right)
 
     return regions, spans, narrow
 
@@ -204,6 +221,7 @@ def _fallback_rois_from_slice(
         max_widths,
         min_widths,
         cfg.min_pop_width,
+        cfg.idle_roi_extra_width,
         detected=detected,
     )
 

--- a/tests/resource_rois/test_compute_rois.py
+++ b/tests/resource_rois/test_compute_rois.py
@@ -25,6 +25,7 @@ class TestComputeResourceROIs(TestCase):
             [999] * 6,
             [20] * 6,
             0,
+            0,
             detected=detected,
         )
         roi = regions["wood_stockpile"]
@@ -52,6 +53,7 @@ class TestComputeResourceROIs(TestCase):
             [0] * 6,
             [999] * 6,
             [0] * 6,
+            0,
             0,
             detected=detected,
         )
@@ -132,6 +134,7 @@ class TestComputeResourceROIs(TestCase):
             [999] * 6,
             [30] * 6,
             0,
+            0,
             detected=detected,
         )
         self.assertGreaterEqual(regions["food_stockpile"][2], 30)
@@ -156,6 +159,7 @@ class TestComputeResourceROIs(TestCase):
                 [999] * 6,
                 [0] * 6,
                 0,
+                0,
                 detected=detected,
             )
         self.assertGreater(regions["food_stockpile"][2], 60)
@@ -177,6 +181,7 @@ class TestComputeResourceROIs(TestCase):
             [999] * 6,
             [0] * 6,
             min_pop_width,
+            0,
             [0] * 6,
             detected=detected,
         )

--- a/tests/test_compute_resource_rois_empty_lists.py
+++ b/tests/test_compute_resource_rois_empty_lists.py
@@ -24,13 +24,14 @@ BASE_PARAMS = {
     "max_widths": [10],
     "min_widths": [1],
     "min_pop_width": 0,
+    "idle_extra_width": 0,
 }
 ORDER = ["pad_left", "pad_right", "icon_trims", "max_widths", "min_widths"]
 
 
 @pytest.mark.parametrize("missing", ORDER)
 def test_empty_config_lists_raise_value_error(missing):
-    params = [BASE_PARAMS[key] for key in ORDER] + [BASE_PARAMS["min_pop_width"]]
+    params = [BASE_PARAMS[key] for key in ORDER] + [BASE_PARAMS["min_pop_width"], BASE_PARAMS["idle_extra_width"]]
     idx = ORDER.index(missing)
     params[idx] = []
     proc = subprocess.run(

--- a/tests/test_idle_villager_roi.py
+++ b/tests/test_idle_villager_roi.py
@@ -72,7 +72,8 @@ class TestIdleVillagerROI(TestCase):
         def fake_compute(pl, pr, top, height, *args, **kwargs):
             left = pl + xi + icon_w
             span = (left, left + 10)
-            return {}, {"idle_villager": span}, {}
+            regions = {"idle_villager": (left, top, 10, height)}
+            return regions, {"idle_villager": span}, {}
 
         with patch("script.resources.find_template", return_value=(panel_box, 0.9, None)), \
             patch("script.resources.cv2.cvtColor", side_effect=fake_cvtColor), \
@@ -141,9 +142,15 @@ class TestIdleVillagerROI(TestCase):
             offset = 20
             pop_span = (pl + offset, pl + offset + 20)
             idle_left = pl + xi + icon_w
-            idle_span = (idle_left, pop_span[0] + 10)
-            regions = {"population_limit": (pl + offset, top, 10, height)}
-            spans = {"population_limit": pop_span, "idle_villager": idle_span}
+            idle_width = pop_span[0] - idle_left
+            regions = {
+                "population_limit": (pl + offset, top, 10, height),
+                "idle_villager": (idle_left, top, idle_width, height),
+            }
+            spans = {
+                "population_limit": pop_span,
+                "idle_villager": (idle_left, idle_left + idle_width),
+            }
             return regions, spans, {}
 
         with patch("script.resources.find_template", return_value=(panel_box, 0.9, None)), \
@@ -214,9 +221,15 @@ class TestIdleVillagerROI(TestCase):
             offset = 25
             pop_span = (pl + offset, pl + offset + 20)
             idle_left = pl + xi + icon_w
-            idle_span = (idle_left, pop_span[0] + 10)
-            regions = {"population_limit": (pl + offset, top, 10, height)}
-            spans = {"population_limit": pop_span, "idle_villager": idle_span}
+            idle_width = pop_span[0] - idle_left
+            regions = {
+                "population_limit": (pl + offset, top, 10, height),
+                "idle_villager": (idle_left, top, idle_width, height),
+            }
+            spans = {
+                "population_limit": pop_span,
+                "idle_villager": (idle_left, idle_left + idle_width),
+            }
             return regions, spans, {}
 
         with patch("script.resources.find_template", return_value=(panel_box, 0.9, None)), \
@@ -261,69 +274,28 @@ class TestIdleVillagerROI(TestCase):
         xi, yi = 5, 4
         icon_h, icon_w = 5, 5
 
-        def fake_imread(path, flags=0):
-            name = os.path.splitext(os.path.basename(path))[0]
-            if name == "idle_villager":
-                return np.ones((icon_h, icon_w), dtype=np.uint8)
-            return np.zeros((icon_h, icon_w), dtype=np.uint8)
-
-        def fake_match(img, templ, method):
-            h = img.shape[0] - templ.shape[0] + 1
-            w = img.shape[1] - templ.shape[1] + 1
-            res = np.zeros((h, w), dtype=np.float32)
-            if np.all(templ == 1):
-                res[yi, xi] = 0.95
-            return res
-
-        def fake_minmax(res):
-            max_val = float(res.max())
-            max_loc = tuple(np.unravel_index(res.argmax(), res.shape)[::-1])
-            return 0.0, max_val, (0, 0), max_loc
-
-        def fake_cvtColor(src, code):
-            return np.zeros(src.shape[:2], dtype=np.uint8)
-
-        def fake_compute(pl, pr, top, height, *args, **kwargs):
-            offset = 60
-            pop_span = (pl + offset, pl + offset + 20)
-            regions = {"population_limit": (pl + offset, top, 10, height)}
-            spans = {"population_limit": pop_span}
-            return regions, spans, {}
-
-        with patch("script.resources.find_template", return_value=(panel_box, 0.9, None)), \
-            patch("script.resources.cv2.cvtColor", side_effect=fake_cvtColor), \
-            patch("script.resources.cv2.resize", side_effect=lambda img, *a, **k: img), \
-            patch("script.resources.cv2.matchTemplate", side_effect=fake_match), \
-            patch("script.resources.cv2.minMaxLoc", side_effect=fake_minmax), \
-            patch("script.resources.cv2.imread", side_effect=fake_imread), \
-            patch("script.resources.panel.detection.compute_resource_rois", side_effect=fake_compute), \
-            patch.dict(screen_utils.ICON_TEMPLATES, {}, clear=True), \
-            patch.dict(
-                common.CFG["resource_panel"],
-                {
-                    "roi_padding_left": [0] * 6,
-                    "roi_padding_right": [0] * 6,
-                    "icon_trim_pct": [0] * 6,
-                    "scales": [1.0],
-                    "match_threshold": 0.5,
-                    "max_width": 999,
-                    "min_width": 0,
-                    "idle_roi_extra_width": 15,
-                },
-            ), patch.dict(
-                common.CFG["profiles"]["aoe1de"]["resource_panel"],
-                {"icon_trim_pct": [0] * 6},
-            ):
-                regions = resources.locate_resource_panel(frame)
-                cfg_obj = resources.panel._get_resource_panel_cfg()
+        detected = {
+            "population_limit": (0, 0, 10, 10),
+            "idle_villager": (xi, yi, icon_w, icon_h),
+        }
+        regions, _spans, _narrow = resources.compute_resource_rois(
+            0,
+            70,
+            0,
+            10,
+            [0, 0, 0, 0, 0, 100],
+            [0] * 6,
+            [0] * 6,
+            [999] * 6,
+            [0] * 6,
+            0,
+            15,
+            detected=detected,
+        )
 
         self.assertIn("idle_villager", regions)
         roi = regions["idle_villager"]
-        top = panel_box[1] + int(cfg_obj.top_pct * panel_box[3])
-        height = int(cfg_obj.height_pct * panel_box[3])
-        self.assertEqual(roi[1], top)
-        self.assertEqual(roi[3], height)
-        self.assertEqual(roi[2], cfg_obj.idle_roi_extra_width)
+        self.assertEqual(roi[2], 15)
 
     def test_detect_resource_regions_uses_configured_idle_roi_when_missing(self):
         frame = np.zeros((50, 100, 3), dtype=np.uint8)

--- a/tests/test_resource_min_required_width.py
+++ b/tests/test_resource_min_required_width.py
@@ -70,6 +70,7 @@ class TestResourceMinRequiredWidth(TestCase):
             [20] * 6,
             [0] * 6,
             0,
+            0,
             [50] * 6,
             detected=detected,
         )


### PR DESCRIPTION
## Summary
- compute idle villager ROI inside `compute_resource_rois` using `idle_roi_extra_width`
- remove detection-level idle villager ROI handling
- adjust tests for new unified ROI logic and function signature

## Testing
- `pytest tests/test_idle_villager_roi.py -q`
- `pytest tests/resource_rois/test_compute_rois.py -q`
- `pytest tests/test_resource_min_required_width.py -q`
- `pytest tests/test_compute_resource_rois_empty_lists.py -q`
- `pytest -q` *(fails: multiple errors including missing Tesseract and resource bounds assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68b6450b67748325b456e19a7ae62bb6