### PR TITLE
Prevent population ROI overlap with idle villager

### DIFF
--- a/script/resources/panel/roi.py
+++ b/script/resources/panel/roi.py
@@ -93,10 +93,13 @@ def compute_resource_rois(
 
         left = cur_right + pad_l
         right = next_left - pad_r
+        if current == "population_limit" and next_name == "idle_villager":
+            right -= 4  # safety margin to avoid idle villager icon
 
         # Clamp ROI boundaries to the panel limits after applying padding
         left = max(panel_left, left)
         right = min(panel_right, right)
+        orig_right = right
 
         if right <= left:
             logger.warning(
@@ -132,8 +135,7 @@ def compute_resource_rois(
 
         if current == "population_limit" and width < min_pop_width:
             width = min_pop_width
-            right = min(panel_right, left + width)
-            left = max(panel_left, right - width)
+            right = min(orig_right, left + width)
             width = right - left
         else:
             right = left + width

--- a/tests/resource_rois/test_compute_rois.py
+++ b/tests/resource_rois/test_compute_rois.py
@@ -167,12 +167,12 @@ class TestComputeResourceROIs(TestCase):
     def test_population_roi_respects_min_width(self):
         detected = {
             "population_limit": (0, 0, 5, 5),
-            "idle_villager": (20, 0, 5, 5),
+            "idle_villager": (200, 0, 5, 5),
         }
         min_pop_width = 50
         regions, _spans, _narrow = resources.compute_resource_rois(
             0,
-            200,
+            300,
             0,
             10,
             [2] * 6,
@@ -186,6 +186,34 @@ class TestComputeResourceROIs(TestCase):
             detected=detected,
         )
         self.assertGreaterEqual(regions["population_limit"][2], min_pop_width)
+
+    def test_population_roi_excludes_nearby_idle_villager(self):
+        detected = {
+            "population_limit": (0, 0, 5, 5),
+            "idle_villager": (15, 0, 5, 5),
+        }
+        min_pop_width = 10
+        regions, _spans, _narrow = resources.compute_resource_rois(
+            0,
+            40,
+            0,
+            10,
+            [2] * 6,
+            [2] * 6,
+            [0] * 6,
+            [999] * 6,
+            [0] * 6,
+            min_pop_width,
+            0,
+            [0] * 6,
+            detected=detected,
+        )
+        roi = regions["population_limit"]
+        left, _, width, _ = roi
+        right = left + width
+        idle_left = detected["idle_villager"][0]
+        self.assertLessEqual(right, idle_left - 4)
+        self.assertLess(width, min_pop_width)
 
     def test_idle_roi_generated_when_span_non_positive(self):
         detected = {


### PR DESCRIPTION
## Summary
- avoid including idle-villager icon when computing the population_limit ROI by applying a safety margin and clamping width
- ensure ROI width expansion remains left-aligned
- regression test for population ROI near idle villager

## Testing
- `pytest tests/resource_rois/test_compute_rois.py::TestComputeResourceROIs::test_population_roi_excludes_nearby_idle_villager -q`
- `pytest tests/resource_rois/test_compute_rois.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b651dba35483259b490d1eb2e24d49