### PR TITLE
Add population OCR preprocessing for slash patterns

### DIFF
--- a/script/resources/ocr/executor.py
+++ b/script/resources/ocr/executor.py
@@ -419,6 +419,7 @@ def _read_population_from_roi(roi, conf_threshold=None, roi_bbox=None, failure_c
         conf_threshold=conf_threshold,
         allow_fallback=False,
         whitelist="0123456789/",
+        resource="population_limit",
     )
     raw_text = "".join(filter(None, data.get("text", [])))
     parts = [p for p in raw_text.split("/") if p]

--- a/script/resources/ocr/masks.py
+++ b/script/resources/ocr/masks.py
@@ -127,6 +127,8 @@ def _ocr_digits_better(gray, color=None, resource=None, whitelist="0123456789"):
         gray, 255, cv2.ADAPTIVE_THRESH_MEAN_C, cv2.THRESH_BINARY, block_size, 2
     )
     if resource == "population_limit":
+        pop_kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (1, 3))
+        adaptive = cv2.morphologyEx(adaptive, cv2.MORPH_CLOSE, pop_kernel, iterations=1)
         _otsu_ret, otsu = cv2.threshold(
             gray, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU
         )


### PR DESCRIPTION
## Summary
- Reinforce population digits with vertical morphological closing after adaptive thresholding
- Propagate population context to OCR execution
- Test population OCR to ensure fractions like `3/4` parse correctly

## Testing
- `pytest tests/test_population_ocr_conf.py -q`
- `pytest tests/test_population_limit_fallback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b656d3ff288325846ca87b94953a22