### PR TITLE
Make wood stockpile dilation configurable

### DIFF
--- a/config.json
+++ b/config.json
@@ -69,6 +69,8 @@
   "ocr_contrast_stretch": true,
   "ocr_psm_list": [7, 6, 11, 13],
   "ocr_zero_variance": 15,
+  "ocr_ws_dilate_var": 1500,
+  "//ocr_ws_dilate_var": "Variance threshold for wood stockpile dilation; <=0 disables.",
   "tesseract_path": "C:\\Program Files\\Tesseract-OCR\\tesseract.exe",
   "resource_cache_ttl": 1.5,
   "resource_cache_max_age": null,

--- a/config.sample.json
+++ b/config.sample.json
@@ -75,6 +75,8 @@
   "//ocr_contrast_stretch": "Rescale intensities before thresholding; true for min-max or object with {alpha,beta}.",
   "ocr_psm_list": [7, 6, 11, 13],
   "ocr_zero_variance": 15,
+  "ocr_ws_dilate_var": 1500,
+  "//ocr_ws_dilate_var": "Variance threshold for wood stockpile dilation; <=0 disables.",
   "tesseract_path": "C:\\Program Files\\Tesseract-OCR\\tesseract.exe",
   "resource_cache_ttl": 1.5,
   "resource_cache_max_age": null,


### PR DESCRIPTION
## Summary
- add `ocr_ws_dilate_var` option to control wood stockpile dilation
- conditionally skip wood stockpile dilation when variance exceeds threshold
- document new option in configuration files

## Testing
- `pytest` *(fails: configuration issues, missing resources and tesseract path)*
- `TESSERACT_CMD=/usr/bin/tesseract python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68b65a22158883259d3fb09b0f5530a3