### PR TITLE
Add optional color-mask validation for wood stockpile OCR

### DIFF
--- a/config.json
+++ b/config.json
@@ -29,6 +29,8 @@
     "idle_villager_low_conf_streak": 5,
     "//*_low_conf_fallback": "Use cached value when OCR confidence is low.",
     "wood_stockpile_ocr_conf_threshold": 45,
+    "wood_stockpile_color_pass": false,
+    "//wood_stockpile_color_pass": "Validate wood stockpile with a second color-mask OCR pass.",
     "food_stockpile_ocr_conf_threshold": 40,
     "gold_stockpile_ocr_conf_threshold": 45,
     "stone_stockpile_ocr_conf_threshold": 45,

--- a/config.sample.json
+++ b/config.sample.json
@@ -35,6 +35,8 @@
     "idle_villager_low_conf_streak": 5,
     "//*_low_conf_fallback": "Use cached value when OCR confidence is low.",
     "wood_stockpile_ocr_conf_threshold": 45,
+    "wood_stockpile_color_pass": false,
+    "//wood_stockpile_color_pass": "Validate wood stockpile with a second color-mask OCR pass.",
     "food_stockpile_ocr_conf_threshold": 45,
     "gold_stockpile_ocr_conf_threshold": 45,
     "stone_stockpile_ocr_conf_threshold": 45,

--- a/script/resources/ocr/masks.py
+++ b/script/resources/ocr/masks.py
@@ -122,6 +122,32 @@ def _ocr_digits_better(gray, color=None, resource=None, whitelist="0123456789"):
         confs = parse_confidences(data)
         threshold = CFG.get("ocr_conf_threshold", 60)
         if confs and max(confs) >= threshold:
+            if (
+                resource == "wood_stockpile"
+                and CFG.get("wood_stockpile_color_pass")
+                and color is not None
+            ):
+                hsv_ws = cv2.cvtColor(color, cv2.COLOR_BGR2HSV)
+                white = cv2.inRange(
+                    hsv_ws, np.array([0, 0, 200]), np.array([180, 50, 255])
+                )
+                ws_kernel = cv2.getStructuringElement(cv2.MORPH_CROSS, (3, 3))
+                white = cv2.morphologyEx(white, cv2.MORPH_CLOSE, ws_kernel, iterations=1)
+                if ws_should_dilate:
+                    white = cv2.dilate(white, ws_kernel, iterations=1)
+                alt_digits, alt_data, alt_mask = _run_masks(
+                    [white, cv2.bitwise_not(white)],
+                    psms,
+                    debug,
+                    debug_dir,
+                    ts,
+                    4,
+                    whitelist=whitelist,
+                )
+                if alt_digits and alt_digits != digits:
+                    alt_confs = parse_confidences(alt_data)
+                    if alt_confs and max(alt_confs) >= threshold:
+                        return alt_digits, alt_data, alt_mask
             return digits, data, mask
 
     block_size = 21 if resource == "population_limit" else 11


### PR DESCRIPTION
## Summary
- allow a second color-based OCR pass for wood stockpile readings when `wood_stockpile_color_pass` is enabled
- prefer the color mask result when it differs from the first pass and has sufficient confidence
- expose `wood_stockpile_color_pass` in configuration files

## Testing
- `pytest -q tests/test_wood_stockpile_ocr.py::TestWoodStockpileOCR::test_wood_stockpile_detects_80`
- `python - <<'PY'
import os, sys, types, numpy as np, cv2
# Stubs
dummy_pg = types.SimpleNamespace(PAUSE=0, FAILSAFE=False, size=lambda: (200,200), click=lambda *a,**k: None, moveTo=lambda *a,**k: None, press=lambda *a,**k: None)
class DummyMSS:
    monitors=[{}, {"left":0,"top":0,"width":200,"height":200}]
    def grab(self, region):
        h,w=region['height'], region['width']
        import numpy as np
        return np.zeros((h,w,4), dtype=np.uint8)
sys.modules.setdefault('pyautogui', dummy_pg)
sys.modules.setdefault('mss', types.SimpleNamespace(mss=lambda: DummyMSS()))
import script.common as common
import script.resources as resources
from script.resources.ocr.preprocess import preprocess_roi
from script.resources.ocr.executor import execute_ocr
from unittest.mock import patch
roi = np.full((60, 120, 3), (19,69,139), dtype=np.uint8)
cv2.putText(roi, '80', (5,50), cv2.FONT_HERSHEY_SIMPLEX, 2, (255,255,255), 3)
gray = preprocess_roi(roi)
with patch.dict(resources.CFG, {'wood_stockpile_color_pass': True}, clear=False):
    digits, data, _mask, _low_conf = execute_ocr(gray, color=roi, resource='wood_stockpile')
print('digits', digits)
PY
- `pytest -q` *(fails: many tests require additional stubs and environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b65be137c08325b0df490f86f410d9