### PR TITLE
Handle zero-confidence OCR digits

### DIFF
--- a/script/resources/reader/core.py
+++ b/script/resources/reader/core.py
@@ -154,6 +154,12 @@ def _ocr_resource(
             )
             if digits_retry:
                 digits, data, mask = digits_retry, data_retry, mask_retry
+    treat_low_conf_as_failure = (
+        CFG.get("treat_low_conf_as_failure", True)
+        and not CFG.get("allow_low_conf_digits", False)
+    )
+    if low_conf and treat_low_conf_as_failure:
+        digits = None
     return digits, data, mask, low_conf
 
 


### PR DESCRIPTION
## Summary
- Flag OCR results as low confidence when any digit has zero confidence
- Drop digits in `_ocr_resource` when low confidence is treated as failure
- Add regression test ensuring zero-confidence digits are rejected for wood stockpile

## Testing
- `pytest tests/test_wood_stockpile_ocr.py`
- `pytest` *(fails: 46 failed, 147 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b661363de48325b8497a0ee12ace64