### PR TITLE
Add overlays and debug saving for resource validation deviations

### DIFF
--- a/tests/test_starting_resource_debug.py
+++ b/tests/test_starting_resource_debug.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import types
+import numpy as np
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+
+dummy_pg = types.SimpleNamespace(
+    PAUSE=0,
+    FAILSAFE=False,
+    size=lambda: (200, 200),
+    click=lambda *a, **k: None,
+    moveTo=lambda *a, **k: None,
+    press=lambda *a, **k: None,
+)
+
+
+class DummyMSS:
+    monitors = [{}, {"left": 0, "top": 0, "width": 200, "height": 200}]
+
+    def grab(self, region):
+        h, w = region["height"], region["width"]
+        return np.zeros((h, w, 4), dtype=np.uint8)
+
+
+sys.modules.setdefault("pyautogui", dummy_pg)
+sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
+
+os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from script.resources.reader.core import validate_starting_resources, _LAST_LOW_CONFIDENCE
+
+
+def test_debug_files_written_on_deviation(tmp_path):
+    frame = np.zeros((20, 20, 3), dtype=np.uint8)
+    rois = {"wood_stockpile": (0, 0, 10, 10)}
+    current = {"wood_stockpile": 0}
+    expected = {"wood_stockpile": 50}
+
+    _LAST_LOW_CONFIDENCE.clear()
+
+    with patch("script.resources.reader.core.ROOT", Path(tmp_path)):
+        validate_starting_resources(current, expected, frame=frame, rois=rois)
+
+    debug_dir = Path(tmp_path) / "debug"
+    files = {p.name for p in debug_dir.iterdir()}
+    assert any(re.match(r"resource_roi_wood_stockpile_\d+\.png", n) for n in files)
+    assert any(re.match(r"resource_gray_wood_stockpile_\d+\.png", n) for n in files)
+    assert any(re.match(r"resource_thresh_wood_stockpile_\d+\.png", n) for n in files)


### PR DESCRIPTION
## Summary
- Save ROI, grayscale, and threshold debug images with resource name and timestamp overlays
- Always capture debug artifacts when resource values deviate beyond tolerance
- Add regression test asserting debug files are produced on deviation

## Testing
- `pytest tests/test_starting_resource_debug.py -q`
- `pytest tests/test_resource_debug_images.py -q` *(fails: PopulationReadError: Failed to read population from HUD)*

------
https://chatgpt.com/codex/tasks/task_e_68b669810aa48325b13d40a3ac30678a