### PR TITLE
Parse starting idle villager information

### DIFF
--- a/campaign.py
+++ b/campaign.py
@@ -67,6 +67,9 @@ def main():
         common.CURRENT_POP = info.starting_villagers
         common.POP_CAP = 4  # 1 Town Center
         common.TARGET_POP = info.objective_villagers
+        idle_start = getattr(info, "starting_idle_villagers", info.starting_villagers)
+        resources.RESOURCE_CACHE.last_resource_values["idle_villager"] = idle_start
+        resources.RESOURCE_CACHE.last_resource_ts["idle_villager"] = time.time()
         try:
             icon_cfg = common.CFG.get("hud_icons", {})
             if info.starting_resources is None:

--- a/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
+++ b/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
@@ -73,6 +73,10 @@ def main() -> None:
     resources.RESOURCE_CACHE.last_resource_values.update(res_vals)
     for name in res_vals:
         resources.RESOURCE_CACHE.last_resource_ts[name] = now
+    resources.RESOURCE_CACHE.last_resource_values["idle_villager"] = (
+        info.starting_idle_villagers
+    )
+    resources.RESOURCE_CACHE.last_resource_ts["idle_villager"] = now
 
     # Atualize população e limites
     common.CURRENT_POP = cur_pop if cur_pop is not None else info.starting_villagers
@@ -102,8 +106,8 @@ def run_mission(info) -> None:
     food_spot = common.CFG.get("areas", {}).get("food_spot")
 
     logger.info("Assigning starting villagers to hunt")
-    # Allocate the starting villagers to gather food.
-    for idx in range(info.starting_villagers):
+    # Allocate only the idle starting villagers to gather food.
+    for idx in range(info.starting_idle_villagers):
         if villager.select_idle_villager():
             if food_spot:
                 input_utils._click_norm(*food_spot, button="right")

--- a/campaigns/Ascent_of_Egypt/Egypt_2_Foraging.py
+++ b/campaigns/Ascent_of_Egypt/Egypt_2_Foraging.py
@@ -57,12 +57,16 @@ def main() -> None:
     common.POP_CAP = 4  # População suportada pelo Town Center inicial
     common.TARGET_POP = info.objective_villagers
 
-    # Inicialização de recursos com base no cenário
+    # Inicialização de recursos e contagem de aldeões ociosos com base no cenário
+    now = time.time()
     if info.starting_resources:
-        now = time.time()
         resources.RESOURCE_CACHE.last_resource_values.update(info.starting_resources)
         for name in info.starting_resources:
             resources.RESOURCE_CACHE.last_resource_ts[name] = now
+    resources.RESOURCE_CACHE.last_resource_values["idle_villager"] = (
+        info.starting_idle_villagers
+    )
+    resources.RESOURCE_CACHE.last_resource_ts["idle_villager"] = now
 
     logger.info("Setup complete.")
 

--- a/script/config_utils.py
+++ b/script/config_utils.py
@@ -136,6 +136,7 @@ def load_config(path: str | Path | None = None) -> dict[str, Any]:
 @dataclass
 class ScenarioInfo:
     starting_villagers: int = 0
+    starting_idle_villagers: int = 0
     population_limit: int = 0
     objective_villagers: int = 0
     # Expected starting resources keyed by resource name used in OCR routines
@@ -162,6 +163,10 @@ def parse_scenario_info(path: str | Path) -> ScenarioInfo:
                     m = re.search(r"(\d+)\s+villagers", line, re.IGNORECASE)
                     if m:
                         info.starting_villagers = int(m.group(1))
+                elif lower.startswith("starting idle villagers"):
+                    m = re.search(r"(\d+)", line)
+                    if m:
+                        info.starting_idle_villagers = int(m.group(1))
                 elif lower.startswith("starting resources"):
                     res = {}
                     for name in ("wood", "food", "gold", "stone"):

--- a/tests/test_campaign_resource_read_error_surface.py
+++ b/tests/test_campaign_resource_read_error_surface.py
@@ -36,6 +36,7 @@ class TestResourceReadErrorSurface(TestCase):
         info = types.SimpleNamespace(
             starting_resources={},
             starting_villagers=3,
+            starting_idle_villagers=0,
             objective_villagers=5,
         )
         err_msg = "boom"

--- a/tests/test_campaign_resource_validation.py
+++ b/tests/test_campaign_resource_validation.py
@@ -44,6 +44,7 @@ class TestCampaignResourceValidation(TestCase):
                 "stone_stockpile": 0,
             },
             starting_villagers=3,
+            starting_idle_villagers=0,
             objective_villagers=5,
         )
 

--- a/tests/test_campaign_starting_resources_none.py
+++ b/tests/test_campaign_starting_resources_none.py
@@ -40,6 +40,7 @@ class TestCampaignNoStartingResources(TestCase):
         info = types.SimpleNamespace(
             starting_resources=None,
             starting_villagers=3,
+            starting_idle_villagers=0,
             objective_villagers=5,
         )
 

--- a/tests/test_foraging_scenario.py
+++ b/tests/test_foraging_scenario.py
@@ -55,6 +55,7 @@ class TestForagingScenario(TestCase):
     def test_main_initialises_counters(self):
         info = config_utils.ScenarioInfo(
             starting_villagers=3,
+            starting_idle_villagers=3,
             population_limit=50,
             starting_resources={
                 "wood_stockpile": 200,
@@ -80,10 +81,10 @@ class TestForagingScenario(TestCase):
             self.assertEqual(common.CURRENT_POP, info.starting_villagers)
             self.assertEqual(common.POP_CAP, 4)
             self.assertEqual(common.TARGET_POP, info.objective_villagers)
-            self.assertEqual(
-                resources.RESOURCE_CACHE.last_resource_values, info.starting_resources
-            )
-            for name in info.starting_resources:
+            expected = dict(info.starting_resources)
+            expected["idle_villager"] = info.starting_idle_villagers
+            self.assertEqual(resources.RESOURCE_CACHE.last_resource_values, expected)
+            for name in expected:
                 self.assertIn(name, resources.RESOURCE_CACHE.last_resource_ts)
 
             wait_mock.assert_called_once()

--- a/tests/test_gather_hud_stats.py
+++ b/tests/test_gather_hud_stats.py
@@ -227,6 +227,7 @@ class TestGatherHudStats(TestCase):
                 "stone_stockpile": 0,
             },
             starting_villagers=3,
+            starting_idle_villagers=0,
             objective_villagers=5,
         )
 

--- a/tests/test_hunting_scenario.py
+++ b/tests/test_hunting_scenario.py
@@ -53,6 +53,7 @@ class TestHuntingScenario(TestCase):
     def test_main_initialises_counters(self):
         info = config_utils.ScenarioInfo(
             starting_villagers=3,
+            starting_idle_villagers=3,
             population_limit=50,
             starting_resources={
                 "wood_stockpile": 80,
@@ -75,7 +76,7 @@ class TestHuntingScenario(TestCase):
             self.assertEqual(common.POP_CAP, 4)
             self.assertEqual(common.TARGET_POP, info.objective_villagers)
             expected_cache = dict(info.starting_resources)
-            expected_cache["idle_villager"] = info.starting_villagers
+            expected_cache["idle_villager"] = info.starting_idle_villagers
             self.assertEqual(
                 resources.reader.RESOURCE_CACHE.last_resource_values, expected_cache
             )
@@ -88,6 +89,7 @@ class TestHuntingScenario(TestCase):
     def test_idle_villager_cache_seeded(self):
         info = config_utils.ScenarioInfo(
             starting_villagers=3,
+            starting_idle_villagers=3,
             population_limit=50,
             starting_resources=None,
             objective_villagers=8,
@@ -109,7 +111,7 @@ class TestHuntingScenario(TestCase):
                 resources.reader.RESOURCE_CACHE.last_resource_values.get(
                     "idle_villager"
                 ),
-                info.starting_villagers,
+                info.starting_idle_villagers,
             )
             self.assertIn(
                 "idle_villager", resources.reader.RESOURCE_CACHE.last_resource_ts

--- a/tests/test_internal_population.py
+++ b/tests/test_internal_population.py
@@ -59,6 +59,7 @@ class TestInternalPopulation(TestCase):
     def test_parse_scenario_info(self):
         info = config_utils.parse_scenario_info("campaigns/Ascent_of_Egypt/Egypt_1_Hunting.txt")
         self.assertEqual(info.starting_villagers, 3)
+        self.assertEqual(info.starting_idle_villagers, 3)
         self.assertEqual(info.population_limit, 50)
         self.assertEqual(info.objective_villagers, 7)
         self.assertEqual(


### PR DESCRIPTION
## Summary
- parse `Starting Idle Villagers` lines in scenario text
- seed idle villager cache using parsed value in campaign runner and Egypt scenarios
- adjust hunting mission to only assign parsed idle villagers
- update tests for new ScenarioInfo field

## Testing
- `pytest` *(fails: ResourceValidationError, PopulationReadError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b66fc0d6e08325ab8265e254afa843