### PR TITLE
Seed Foraging scenario from HUD readings

### DIFF
--- a/campaigns/Ascent_of_Egypt/Egypt_2_Foraging.py
+++ b/campaigns/Ascent_of_Egypt/Egypt_2_Foraging.py
@@ -52,21 +52,32 @@ def main() -> None:
     scenario_txt = Path(__file__).with_suffix(".txt")
     info = parse_scenario_info(scenario_txt)
 
-    # Configuração inicial de população
-    common.CURRENT_POP = info.starting_villagers
-    common.POP_CAP = 4  # População suportada pelo Town Center inicial
-    common.TARGET_POP = info.objective_villagers
+    # Leia o HUD para obter os valores atuais de recursos e população
+    res_vals, (cur_pop, pop_cap) = resources.gather_hud_stats()
 
-    # Inicialização de recursos e contagem de aldeões ociosos com base no cenário
+    # Validação dos recursos iniciais
+    try:
+        resources.validate_starting_resources(
+            res_vals, info.starting_resources, raise_on_error=True
+        )
+    except resources.ResourceValidationError as exc:
+        logger.error("Erro na validação dos recursos iniciais: %s", exc)
+        raise
+
+    # Atualize os caches com os valores confirmados
     now = time.time()
-    if info.starting_resources:
-        resources.RESOURCE_CACHE.last_resource_values.update(info.starting_resources)
-        for name in info.starting_resources:
-            resources.RESOURCE_CACHE.last_resource_ts[name] = now
+    resources.RESOURCE_CACHE.last_resource_values.update(res_vals)
+    for name in res_vals:
+        resources.RESOURCE_CACHE.last_resource_ts[name] = now
     resources.RESOURCE_CACHE.last_resource_values["idle_villager"] = (
         info.starting_idle_villagers
     )
     resources.RESOURCE_CACHE.last_resource_ts["idle_villager"] = now
+
+    # Atualize população e limites
+    common.CURRENT_POP = cur_pop if cur_pop is not None else info.starting_villagers
+    common.POP_CAP = pop_cap if pop_cap is not None else 4
+    common.TARGET_POP = info.objective_villagers
 
     logger.info("Setup complete.")
 


### PR DESCRIPTION
## Summary
- Read HUD resources and population in Foraging mission and validate against scenario data
- Seed resource cache and population counters with confirmed HUD values
- Adjust Foraging scenario test to patch HUD gathering and verify cache initialisation

## Testing
- `pytest -q tests/test_foraging_scenario.py::TestForagingScenario::test_main_initialises_counters -q`


------
https://chatgpt.com/codex/tasks/task_e_68b673c832fc8325a776a7973add8438