### PR TITLE
Validate population readings in Egypt missions

### DIFF
--- a/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
+++ b/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
@@ -62,6 +62,16 @@ def main() -> None:
     # Leia o HUD para obter os valores atuais de recursos e população
     res_vals, (cur_pop, pop_cap) = resources.gather_hud_stats()
 
+    if cur_pop != info.starting_villagers or pop_cap != info.population_limit:
+        logger.error(
+            "HUD population (%s/%s) does not match expected %s/%s; aborting scenario.",
+            cur_pop,
+            pop_cap,
+            info.starting_villagers,
+            info.population_limit,
+        )
+        return
+
     # Validação dos recursos iniciais
     try:
         resources.validate_starting_resources(
@@ -89,8 +99,8 @@ def main() -> None:
     resources.RESOURCE_CACHE.last_resource_ts["idle_villager"] = now
 
     # Atualize população e limites
-    common.CURRENT_POP = cur_pop if cur_pop is not None else info.starting_villagers
-    common.POP_CAP = pop_cap if pop_cap is not None else 4
+    common.CURRENT_POP = cur_pop
+    common.POP_CAP = pop_cap
     common.TARGET_POP = info.objective_villagers
 
     logger.info("Setup complete.")

--- a/campaigns/Ascent_of_Egypt/Egypt_2_Foraging.py
+++ b/campaigns/Ascent_of_Egypt/Egypt_2_Foraging.py
@@ -58,6 +58,16 @@ def main() -> None:
     # Leia o HUD para obter os valores atuais de recursos e população
     res_vals, (cur_pop, pop_cap) = resources.gather_hud_stats()
 
+    if cur_pop != info.starting_villagers or pop_cap != info.population_limit:
+        logger.error(
+            "HUD population (%s/%s) does not match expected %s/%s; aborting scenario.",
+            cur_pop,
+            pop_cap,
+            info.starting_villagers,
+            info.population_limit,
+        )
+        return
+
     # Validação dos recursos iniciais
     try:
         resources.validate_starting_resources(
@@ -85,8 +95,8 @@ def main() -> None:
     resources.RESOURCE_CACHE.last_resource_ts["idle_villager"] = now
 
     # Atualize população e limites
-    common.CURRENT_POP = cur_pop if cur_pop is not None else info.starting_villagers
-    common.POP_CAP = pop_cap if pop_cap is not None else 4
+    common.CURRENT_POP = cur_pop
+    common.POP_CAP = pop_cap
     common.TARGET_POP = info.objective_villagers
 
     logger.info("Setup complete.")

--- a/tests/test_hunting_scenario.py
+++ b/tests/test_hunting_scenario.py
@@ -71,7 +71,7 @@ class TestHuntingScenario(TestCase):
         info = config_utils.ScenarioInfo(
             starting_villagers=3,
             starting_idle_villagers=3,
-            population_limit=50,
+            population_limit=4,
             starting_resources={
                 "wood_stockpile": 80,
                 "food_stockpile": 140,
@@ -89,7 +89,7 @@ class TestHuntingScenario(TestCase):
              patch("script.config_utils.parse_scenario_info", return_value=info) as parse_mock, \
              patch(
                  "script.resources.reader.gather_hud_stats",
-                 return_value=(gathered, (info.starting_villagers, 4)),
+                 return_value=(gathered, (info.starting_villagers, info.population_limit)),
              ) as gather_mock, \
              patch.object(resources.reader, "RESOURCE_CACHE", resources.ResourceCache()):
             runpy.run_path(
@@ -98,7 +98,7 @@ class TestHuntingScenario(TestCase):
             )
 
             self.assertEqual(common.CURRENT_POP, info.starting_villagers)
-            self.assertEqual(common.POP_CAP, 4)
+            self.assertEqual(common.POP_CAP, info.population_limit)
             self.assertEqual(common.TARGET_POP, info.objective_villagers)
             self.assertEqual(
                 resources.reader.RESOURCE_CACHE.last_resource_values, gathered
@@ -114,7 +114,7 @@ class TestHuntingScenario(TestCase):
         info = config_utils.ScenarioInfo(
             starting_villagers=3,
             starting_idle_villagers=3,
-            population_limit=50,
+            population_limit=4,
             starting_resources=None,
             objective_villagers=7,
             starting_buildings={},
@@ -141,7 +141,7 @@ class TestHuntingScenario(TestCase):
         info = config_utils.ScenarioInfo(
             starting_villagers=3,
             starting_idle_villagers=3,
-            population_limit=50,
+            population_limit=4,
             starting_resources=None,
             objective_villagers=8,
             starting_buildings={"Town Center": 1},
@@ -155,7 +155,7 @@ class TestHuntingScenario(TestCase):
             "script.resources.reader.gather_hud_stats",
             return_value=(
                 {"idle_villager": info.starting_idle_villagers},
-                (info.starting_villagers, 4),
+                (info.starting_villagers, info.population_limit),
             ),
         ) as gather_mock, patch.object(
             resources.reader, "RESOURCE_CACHE", resources.ResourceCache()
@@ -183,7 +183,7 @@ class TestHuntingScenario(TestCase):
         info = config_utils.ScenarioInfo(
             starting_villagers=3,
             starting_idle_villagers=3,
-            population_limit=50,
+            population_limit=4,
             starting_resources={
                 "wood_stockpile": 80,
                 "food_stockpile": 140,
@@ -205,7 +205,7 @@ class TestHuntingScenario(TestCase):
 
         with patch.object(module.hud, "wait_hud", return_value=((0, 0, 0, 0), "asset")), \
             patch.object(module, "parse_scenario_info", return_value=info), \
-            patch.object(module.resources, "gather_hud_stats", return_value=(gathered, (info.starting_villagers, 4))) as gather_mock, \
+            patch.object(module.resources, "gather_hud_stats", return_value=(gathered, (info.starting_villagers, info.population_limit))) as gather_mock, \
             patch.object(module, "run_mission") as run_mock, \
             patch.object(module.resources, "RESOURCE_CACHE", resources.ResourceCache()), \
             self.assertLogs(module.logger, level="ERROR") as log_ctx:
@@ -217,3 +217,77 @@ class TestHuntingScenario(TestCase):
         self.assertTrue(
             any("idle villager" in m.lower() for m in log_ctx.output)
         )
+
+    def test_aborts_on_population_mismatch(self):
+        info = config_utils.ScenarioInfo(
+            starting_villagers=3,
+            starting_idle_villagers=3,
+            population_limit=4,
+            starting_resources={
+                "wood_stockpile": 80,
+                "food_stockpile": 140,
+                "gold_stockpile": 0,
+                "stone_stockpile": 0,
+            },
+            objective_villagers=7,
+            starting_buildings={"Town Center": 1},
+        )
+
+        gathered = dict(info.starting_resources)
+        gathered["idle_villager"] = info.starting_idle_villagers
+
+        import importlib
+
+        module = importlib.import_module(
+            "campaigns.Ascent_of_Egypt.Egypt_1_Hunting"
+        )
+
+        with patch.object(module.hud, "wait_hud", return_value=((0, 0, 0, 0), "asset")), \
+            patch.object(module, "parse_scenario_info", return_value=info), \
+            patch.object(module.resources, "gather_hud_stats", return_value=(gathered, (info.starting_villagers - 1, info.population_limit))) as gather_mock, \
+            patch.object(module, "run_mission") as run_mock, \
+            patch.object(module.resources, "RESOURCE_CACHE", resources.ResourceCache()), \
+            self.assertLogs(module.logger, level="ERROR") as log_ctx:
+            module.main()
+
+        run_mock.assert_not_called()
+        gather_mock.assert_called_once()
+        self.assertEqual(module.resources.RESOURCE_CACHE.last_resource_values, {})
+        self.assertTrue(any("population" in m.lower() for m in log_ctx.output))
+
+    def test_aborts_on_pop_cap_mismatch(self):
+        info = config_utils.ScenarioInfo(
+            starting_villagers=3,
+            starting_idle_villagers=3,
+            population_limit=4,
+            starting_resources={
+                "wood_stockpile": 80,
+                "food_stockpile": 140,
+                "gold_stockpile": 0,
+                "stone_stockpile": 0,
+            },
+            objective_villagers=7,
+            starting_buildings={"Town Center": 1},
+        )
+
+        gathered = dict(info.starting_resources)
+        gathered["idle_villager"] = info.starting_idle_villagers
+
+        import importlib
+
+        module = importlib.import_module(
+            "campaigns.Ascent_of_Egypt.Egypt_1_Hunting"
+        )
+
+        with patch.object(module.hud, "wait_hud", return_value=((0, 0, 0, 0), "asset")), \
+            patch.object(module, "parse_scenario_info", return_value=info), \
+            patch.object(module.resources, "gather_hud_stats", return_value=(gathered, (info.starting_villagers, info.population_limit - 1))) as gather_mock, \
+            patch.object(module, "run_mission") as run_mock, \
+            patch.object(module.resources, "RESOURCE_CACHE", resources.ResourceCache()), \
+            self.assertLogs(module.logger, level="ERROR") as log_ctx:
+            module.main()
+
+        run_mock.assert_not_called()
+        gather_mock.assert_called_once()
+        self.assertEqual(module.resources.RESOURCE_CACHE.last_resource_values, {})
+        self.assertTrue(any("population" in m.lower() for m in log_ctx.output))


### PR DESCRIPTION
## Summary
- ensure Egypt Hunting and Foraging scenarios abort if HUD population or pop-cap doesn't match expected
- seed population counters using HUD values after successful validation
- test for mismatched population and pop-cap scenarios

## Testing
- `pytest tests/test_hunting_scenario.py tests/test_foraging_scenario.py`


------
https://chatgpt.com/codex/tasks/task_e_68b678dfa9d88325bb8a9c4bc17d33eb