### PR TITLE
Lower population ROI width and warn about overlap

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -149,8 +149,9 @@
     "top_pct": 0.111,
     "height_pct": 0.027,
     "left_pct": 0.374,
-    "width_pct": 0.05
+    "width_pct": 0.03
   },
+  "//population_limit_roi": "Remove this block to use automatic HUD detection; oversized ROIs can overlap the idle-villager icon and break OCR.",
   "idle_villager_roi": {
     "top_pct": 0.10,
     "height_pct": 0.06,


### PR DESCRIPTION
## Summary
- Reduce `population_limit_roi.width_pct` to 0.03 for tighter bounds
- Add comment noting oversized population ROIs can overlap the idle villager icon and break OCR

## Testing
- `pytest tests/test_population_roi_bounds.py -q`
- `pytest -q` *(fails: tesseract not installed; multiple tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68b74ea478a48325bda679c12ec8e4a2