### PR TITLE
Align population ROI with detected span and adjust fallback

### DIFF
--- a/config.json
+++ b/config.json
@@ -143,7 +143,7 @@
     "top_pct": 0.111,
     "height_pct": 0.027,
     "left_pct": 0.374,
-    "width_pct": 0.05
+    "width_pct": 0.045
   },
   "idle_villager_roi": {
     "top_pct": 0.10,

--- a/script/resources/panel/roi.py
+++ b/script/resources/panel/roi.py
@@ -115,6 +115,8 @@ def compute_resource_rois(
         max_w = max_widths[idx] if idx < len(max_widths) else max_widths[-1]
         if current == "food_stockpile":
             max_w = min(max_w, CFG.get("food_stockpile_max_width", max_w))
+        if current == "population_limit" and next_bounds is not None:
+            max_w = available_width
         width = min(max_w, available_width)
 
         min_req = min_requireds[idx] if idx < len(min_requireds) else min_requireds[-1]

--- a/script/resources/reader/roi.py
+++ b/script/resources/reader/roi.py
@@ -45,6 +45,9 @@ def prepare_roi(
         if name == "idle_villager":
             expand_left = 0
             expand_right = deficit
+        elif name == "population_limit":
+            expand_left = deficit
+            expand_right = 0
         else:
             expand_left = deficit // 2
             expand_right = deficit - expand_left


### PR DESCRIPTION
## Summary
- ensure detected population span width respected by panel ROI calculations
- keep idle villager region clear when expanding population ROI during reading
- narrow fallback population ROI defaults

## Testing
- `pytest -q` *(fails: OpenCV template matching assertion)*


------
https://chatgpt.com/codex/tasks/task_e_68b75aa493bc8325acc1fb8463ecf3b9