### PR TITLE
feat: allow zero-confidence OCR digits when configured

### DIFF
--- a/config.json
+++ b/config.json
@@ -17,6 +17,8 @@
   "//ocr_conf_max_attempts": "Full OCR retries before only lowering the confidence threshold.",
   "allow_low_conf_population": true,
   "//allow_low_conf_population": "Accept population digits even when confidence is below the threshold; logs a warning instead of raising.",
+  "allow_zero_confidence_digits": true,
+  "//allow_zero_confidence_digits": "Treat all-zero OCR confidences as unknown instead of failure.",
     "treat_low_conf_as_failure": true,
     "//treat_low_conf_as_failure": "Return None when OCR confidence is below threshold.",
     "wood_stockpile_low_conf_fallback": true,

--- a/config.sample.json
+++ b/config.sample.json
@@ -21,6 +21,8 @@
   "//allow_low_conf_digits": "Accept OCR digits even when confidence is below the threshold.",
   "allow_low_conf_population": false,
   "//allow_low_conf_population": "Accept population digits even when confidence is below the threshold; logs a warning instead of raising.",
+  "allow_zero_confidence_digits": true,
+  "//allow_zero_confidence_digits": "Treat all-zero OCR confidences as unknown instead of failure.",
   "treat_low_conf_as_failure": true,
     "//treat_low_conf_as_failure": "Return None when OCR confidence is below threshold.",
     "wood_stockpile_low_conf_fallback": true,

--- a/script/resources/reader/core.py
+++ b/script/resources/reader/core.py
@@ -116,7 +116,7 @@ def _ocr_resource(
         roi=roi_bbox,
         resource=name,
     )
-    if data.get("zero_conf"):
+    if data.get("zero_conf") and not CFG.get("allow_zero_confidence_digits"):
         low_conf = True
     logger.info(
         "OCR %s: digits=%s conf=%s low_conf=%s",
@@ -140,7 +140,7 @@ def _ocr_resource(
                 roi=roi_bbox,
                 resource=name,
             )
-            if data_retry.get("zero_conf"):
+            if data_retry.get("zero_conf") and not CFG.get("allow_zero_confidence_digits"):
                 low_conf = True
             logger.info(
                 "Retry OCR %s: digits=%s conf=%s low_conf=%s",
@@ -209,7 +209,7 @@ def _retry_ocr(
                 h,
                 low_conf,
             ) = expansion
-            if data.get("zero_conf"):
+            if data.get("zero_conf") and not CFG.get("allow_zero_confidence_digits"):
                 low_conf = True
     if not digits:
         span_left, span_right = cache._LAST_REGION_SPANS.get(name, (x, x + w))
@@ -238,7 +238,7 @@ def _retry_ocr(
                     roi=(cand_x, y, cand_w, h),
                     resource=name,
                 )
-                if data_retry.get("zero_conf"):
+                if data_retry.get("zero_conf") and not CFG.get("allow_zero_confidence_digits"):
                     low_conf = True
                 logger.info(
                     "OCR %s: digits=%s conf=%s low_conf=%s",
@@ -271,7 +271,7 @@ def _retry_ocr(
                         roi=(cand_x, y, expanded_w, h),
                         resource=name,
                     )
-                    if data_retry.get("zero_conf"):
+                    if data_retry.get("zero_conf") and not CFG.get("allow_zero_confidence_digits"):
                         low_conf = True
                     logger.info(
                         "OCR %s: digits=%s conf=%s low_conf=%s",

--- a/tests/ocr_failures/test_low_confidence.py
+++ b/tests/ocr_failures/test_low_confidence.py
@@ -99,7 +99,7 @@ class TestResourceLowConfidence(TestCase):
             return "123", data, np.zeros((1, 1), dtype=np.uint8)
 
         resources.RESOURCE_CACHE.last_resource_values["wood_stockpile"] = 0
-        with patch.dict(resources.CFG, {"wood_stockpile_low_conf_fallback": False}, clear=False), \
+        with patch.dict(resources.CFG, {"wood_stockpile_low_conf_fallback": False, "allow_zero_confidence_digits": False}, clear=False), \
             patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
             patch("script.screen_utils._grab_frame", side_effect=fake_grab_frame), \
             patch("script.resources.ocr.masks._ocr_digits_better", side_effect=fake_ocr) as ocr_mock, \

--- a/tests/ocr_failures/test_no_digits.py
+++ b/tests/ocr_failures/test_no_digits.py
@@ -123,7 +123,7 @@ class TestNoDigits(TestCase):
         frame = np.zeros((600, 600, 3), dtype=np.uint8)
 
         resources.RESOURCE_CACHE.last_resource_values["wood_stockpile"] = 456
-        with patch.dict(resources.CFG, {"wood_stockpile_low_conf_fallback": True}, clear=False), \
+        with patch.dict(resources.CFG, {"wood_stockpile_low_conf_fallback": True, "allow_zero_confidence_digits": False}, clear=False), \
             patch(
                 "script.resources.reader.detect_resource_regions",
                 return_value={"wood_stockpile": (0, 0, 50, 50)},

--- a/tests/ocr_helpers/test_parse_confidences.py
+++ b/tests/ocr_helpers/test_parse_confidences.py
@@ -9,14 +9,14 @@ from script.resources.ocr.confidence import parse_confidences
 from script.resources.reader import core
 
 
-def test_clamps_negative_and_preserves_zero():
+def test_clamps_negative_and_excludes_zero():
     data = {"conf": ["42.5", "-1", "0", "abc", "77"]}
-    assert parse_confidences(data) == [42.5, 0.0, 0.0, 77.0]
+    assert parse_confidences(data) == [42.5, 77.0]
 
 
 def test_handles_missing_conf_key():
-    assert parse_confidences({}) == []
-    assert parse_confidences({"conf": ["foo", None]}) == []
+    assert parse_confidences({}) is None
+    assert parse_confidences({"conf": ["foo", None]}) is None
 
 
 def test_read_resources_logs_sanitized_confidences(caplog):
@@ -56,5 +56,5 @@ def test_read_resources_logs_sanitized_confidences(caplog):
     assert ocr_msgs, "OCR log message not found"
     msg = ocr_msgs[0]
     assert "digits=12" in msg
-    assert "conf=[0.0, 50.0]" in msg
+    assert "conf=[50.0]" in msg
     assert "low_conf=False" in msg

--- a/tests/test_resource_helpers.py
+++ b/tests/test_resource_helpers.py
@@ -154,7 +154,7 @@ class TestExecuteOcr(TestCase):
         with patch(
             "script.resources.ocr.masks._ocr_digits_better",
             side_effect=[("123", data1, None), ("789", data2, None)],
-        ) as ocr_mock, patch("script.resources.reader.pytesseract.image_to_string") as img2str_mock:
+        ) as ocr_mock, patch("script.resources.reader.pytesseract.image_to_string") as img2str_mock, patch.dict(resources.CFG, {"allow_zero_confidence_digits": False}, clear=False):
             digits, _, _, low_conf = resources.execute_ocr(
                 gray, conf_threshold=60, resource="wood_stockpile"
             )

--- a/tests/test_wood_stockpile_ocr.py
+++ b/tests/test_wood_stockpile_ocr.py
@@ -97,7 +97,7 @@ class TestWoodStockpileOCR(TestCase):
         with patch(
             "script.resources.ocr.executor.masks._ocr_digits_better",
             side_effect=fake_ocr_digits_better,
-        ), patch.dict(CFG, {"treat_low_conf_as_failure": True}, clear=False):
+        ), patch.dict(CFG, {"treat_low_conf_as_failure": True, "allow_zero_confidence_digits": False}, clear=False):
             digits, data, _mask, low_conf = _ocr_resource(
                 "wood_stockpile",
                 roi,
@@ -107,7 +107,7 @@ class TestWoodStockpileOCR(TestCase):
                 cache_obj,
             )
         self.assertTrue(low_conf)
-        self.assertEqual(parse_confidences(data), [91.0, 0.0])
+        self.assertEqual(parse_confidences(data), [91.0])
         self.assertIsNone(digits)
 
     def test_wood_stockpile_roi_expansion_captures_80(self):


### PR DESCRIPTION
## Summary
- ignore zero Tesseract confidences and return `None` when all confidences are non-positive
- handle `None` confidences in OCR executor so digits can pass when allowed
- gate zero-confidence handling behind new `allow_zero_confidence_digits` config flag

## Testing
- `pytest` *(fails: test_resource_roi_validation.py::TestResourceRoiValidation::test_zero_width_roi_raises, tests/test_resource_rois.py::TestResourceROIs::test_food_stockpile_roi_bounds, tests/test_resource_rois.py::TestResourceROIs::test_gold_stockpile_roi_bounds, tests/test_resource_rois.py::TestResourceROIs::test_population_limit_roi_bounds, tests/test_resource_rois.py::TestResourceROIs::test_roi_limited_by_max_width, tests/test_resource_rois.py::TestResourceROIs::test_rois_clamp_with_min_width, tests/test_resource_rois.py::TestResourceROIs::test_rois_trimmed_icon_bounds, tests/test_resource_rois.py::TestResourceROIs::test_rois_trimmed_icon_bounds_pixels, tests/test_resource_rois.py::TestResourceROIs::test_rois_use_available_width_with_close_icons, tests/test_resource_rois.py::TestResourceROIs::test_stone_stockpile_roi_bounds, tests/test_resource_rois.py::TestResourceROIs::test_synthetic_frame_rois_between_icons, tests/test_starting_resource_debug.py::test_debug_files_written_on_deviation, tests/test_stone_roi_config.py::TestStoneROIConfig::test_stone_roi_scales_1080p, tests/test_stone_roi_config.py::TestStoneROIConfig::test_stone_roi_scales_1440p, tests/test_wood_stockpile_ocr.py::TestWoodStockpileOCR::test_wood_stockpile_detects_300, tests/test_wood_stockpile_ocr.py::TestWoodStockpileOCR::test_wood_stockpile_detects_80, tests/test_wood_stockpile_ocr.py::TestWoodStockpileOCR::test_wood_stockpile_high_confidence, tests/test_wood_stockpile_ocr.py::TestWoodStockpileOCR::test_wood_stockpile_roi_expansion_captures_80, tests/test_wood_stockpile_ocr.py::TestWoodStockpileOCR::test_wood_stockpile_zero_conf_rejected)*

------
https://chatgpt.com/codex/tasks/task_e_68b76c7547b4832592df2dce6ae6a7df