### PR TITLE
Align OCR confidences with text entries

### DIFF
--- a/script/resources/ocr/executor.py
+++ b/script/resources/ocr/executor.py
@@ -65,7 +65,11 @@ def execute_ocr(
                     low_conf = True
             break
         texts = data.get("text", [])
-        digit_confs = [c for t, c in zip(texts, confs) if any(ch.isdigit() for ch in t)]
+        digit_confs = [
+            c
+            for t, c in zip(texts, confs)
+            if c > 0 and any(ch.isdigit() for ch in t)
+        ]
         metric = np.median(digit_confs) if digit_confs else 0
         if digit_confs and metric >= conf_threshold:
             low_conf = False
@@ -120,7 +124,11 @@ def execute_ocr(
                     low_conf = True
         else:
             texts = data.get("text", [])
-            digit_confs = [c for t, c in zip(texts, confs) if any(ch.isdigit() for ch in t)]
+            digit_confs = [
+                c
+                for t, c in zip(texts, confs)
+                if c > 0 and any(ch.isdigit() for ch in t)
+            ]
             metric = np.median(digit_confs) if digit_confs else 0
             if digit_confs and metric >= conf_threshold:
                 low_conf = False

--- a/tests/ocr_helpers/test_execute_ocr_negative_conf.py
+++ b/tests/ocr_helpers/test_execute_ocr_negative_conf.py
@@ -14,3 +14,18 @@ def test_negative_confidences_flagged_low_confidence():
         )
     assert digits == "12"
     assert low_conf
+
+
+def test_negative_conf_preceding_digits_not_low_confidence():
+    gray = np.zeros((5, 5), dtype=np.uint8)
+    data = {"text": ["foo", "12"], "conf": ["-5", "80"]}
+    with patch(
+        "script.resources.ocr.masks._ocr_digits_better", return_value=("12", data, None)
+    ), patch(
+        "script.resources.ocr.executor.pytesseract.image_to_string", return_value=""
+    ):
+        digits, _, _, low_conf = resources.execute_ocr(
+            gray, conf_threshold=60, resource="wood_stockpile"
+        )
+    assert digits == "12"
+    assert not low_conf

--- a/tests/ocr_helpers/test_parse_confidences.py
+++ b/tests/ocr_helpers/test_parse_confidences.py
@@ -9,20 +9,24 @@ from script.resources.ocr.confidence import parse_confidences
 from script.resources.reader import core
 
 
-def test_clamps_negative_and_excludes_zero():
-    data = {"conf": ["42.5", "-1", "0", "abc", "77"]}
-    assert parse_confidences(data) == [42.5, 77.0]
+def test_alignment_and_placeholder_values():
+    data = {
+        "text": list("abcde"),
+        "conf": ["42.5", "-1", "0", "abc", "77"],
+    }
+    assert parse_confidences(data) == [42.5, 0.0, 0.0, 0.0, 77.0]
 
 
 def test_handles_missing_conf_key():
     assert parse_confidences({}) is None
-    assert parse_confidences({"conf": ["foo", None]}) is None
+    data = {"text": ["x", "y"], "conf": ["foo", None]}
+    assert parse_confidences(data) == [0.0, 0.0]
 
 
 def test_read_resources_logs_sanitized_confidences(caplog):
     frame = np.zeros((10, 10, 3), dtype=np.uint8)
     gray = np.zeros((10, 10), dtype=np.uint8)
-    data = {"text": ["12"], "conf": ["-5", "50"]}
+    data = {"text": ["foo", "12"], "conf": ["-5", "50"]}
     cache_obj = SimpleNamespace(
         last_resource_values={},
         last_resource_ts={},
@@ -56,5 +60,5 @@ def test_read_resources_logs_sanitized_confidences(caplog):
     assert ocr_msgs, "OCR log message not found"
     msg = ocr_msgs[0]
     assert "digits=12" in msg
-    assert "conf=[50.0]" in msg
+    assert "conf=[0.0, 50.0]" in msg
     assert "low_conf=False" in msg

--- a/tests/test_resource_helpers.py
+++ b/tests/test_resource_helpers.py
@@ -111,7 +111,7 @@ class TestExecuteOcr(TestCase):
 
     def test_execute_ocr_warns_low_mean_confidence(self):
         gray = np.zeros((5, 5), dtype=np.uint8)
-        data = {"text": ["12"], "conf": ["80", "20"]}
+        data = {"text": ["1", "2"], "conf": ["80", "20"]}
         with patch("script.resources.ocr.masks._ocr_digits_better", return_value=("12", data, None)), \
              patch("script.resources.reader.pytesseract.image_to_string", return_value="") as img2str_mock, \
              patch.dict(resources.CFG, {"ocr_conf_decay": 1.0}, clear=False):
@@ -202,7 +202,7 @@ class TestExecuteOcr(TestCase):
 
     def test_execute_ocr_ignores_zero_confidences_when_others_high(self):
         gray = np.zeros((5, 5), dtype=np.uint8)
-        data = {"text": ["12"], "conf": [-1, "0", "95"]}
+        data = {"text": ["foo", "", "12"], "conf": [-1, "0", "95"]}
         with patch(
             "script.resources.ocr.masks._ocr_digits_better",
             return_value=("12", data, None),

--- a/tests/test_wood_stockpile_ocr.py
+++ b/tests/test_wood_stockpile_ocr.py
@@ -116,7 +116,7 @@ class TestWoodStockpileOCR(TestCase):
                 cache_obj,
             )
         self.assertTrue(low_conf)
-        self.assertIsNone(parse_confidences(data))
+        self.assertEqual(parse_confidences(data), [0.0, 0.0])
         self.assertIsNone(digits)
 
     def test_wood_stockpile_roi_expansion_captures_80(self):


### PR DESCRIPTION
## Summary
- Keep OCR confidence lists aligned with their text entries and fill invalid or non-positive values with zero
- Ensure OCR executor filters only non-positive confidences so digit–confidence pairs stay in sync
- Add regression tests for negative confidence entries preceding digits and update existing expectations

## Testing
- `pytest tests/ocr_helpers/test_parse_confidences.py tests/ocr_helpers/test_execute_ocr_negative_conf.py`
- `pytest tests/test_resource_helpers.py`
- `pytest tests/test_food_stockpile_ocr.py`
- `pytest tests/test_wood_stockpile_ocr.py`
- `pytest` *(fails: compute_resource_rois_empty_lists, food_stockpile_detects_140_high_confidence, gather_hud_stats, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b77dc75024832596f3d389c45a1292