### PR TITLE
Handle ambiguous population OCR without slash

### DIFF
--- a/script/resources/ocr/executor.py
+++ b/script/resources/ocr/executor.py
@@ -511,6 +511,17 @@ def _read_population_from_roi(roi, conf_threshold=None, roi_bbox=None, failure_c
         err.low_conf_digits = (cur, cap)
         raise err
 
+    if "/" not in raw_text:
+        if low_conf and raw_text.isdigit() and len(raw_text) == 2 and raw_text[0] == raw_text[1]:
+            cur = int(raw_text[0])
+            cap = int(raw_text[1])
+            err_msg = (
+                f"Ambiguous population OCR: text='{raw_text}', confs={confidences}"
+            )
+            err = common.PopulationReadError(err_msg)
+            err.low_conf = True
+            err.low_conf_digits = (cur, cap)
+            raise err
     if "/" not in raw_text and raw_text.isdigit():
         if len(raw_text) == 2:
             cur = int(raw_text[0])

--- a/tests/test_population_ocr_conf.py
+++ b/tests/test_population_ocr_conf.py
@@ -97,6 +97,21 @@ class TestPopulationOcrConfidence(TestCase):
             )
             self.assertEqual((cur, cap), (12, 34))
 
+    def test_ambiguous_double_digits_raise_error(self):
+        roi = np.zeros((10, 10, 3), dtype=np.uint8)
+        with patch.dict(resources.common.CFG, {"allow_low_conf_population": True}, clear=False), \
+            patch(
+                "script.resources.ocr.executor.execute_ocr",
+                return_value=(
+                    "77",
+                    {"text": ["7", "7"], "conf": ["40", "40"]},
+                    None,
+                    True,
+                ),
+            ):
+            with self.assertRaises(resources.common.PopulationReadError):
+                resources._read_population_from_roi(roi, conf_threshold=60)
+
     def test_low_confidence_fallback_after_attempts(self):
         roi = np.zeros((10, 10, 3), dtype=np.uint8)
 
@@ -112,7 +127,7 @@ class TestPopulationOcrConfidence(TestCase):
             "script.resources.ocr.executor.execute_ocr",
             return_value=(
                 "12/34",
-                {"text": ["12/34"], "conf": ["40", "40"]},
+                {"text": ["12/34", ""], "conf": ["40", "40"]},
                 None,
                 True,
             ),
@@ -142,7 +157,7 @@ class TestPopulationOcrConfidence(TestCase):
             "script.resources.ocr.executor.execute_ocr",
             return_value=(
                 "12/34",
-                {"text": ["12/34"], "conf": ["40", "40"]},
+                {"text": ["12/34", ""], "conf": ["40", "40"]},
                 None,
                 True,
             ),


### PR DESCRIPTION
## Summary
- Detect low-confidence population results missing a slash and raise an error when both digits match
- Cover ambiguous double-digit readings like "77" with a dedicated test
- Adjust fallback test to include blank text entry so both confidences appear

## Testing
- `pytest tests/test_population_ocr_conf.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b785590f48832595710b06ffc08b1a