### PR TITLE
Default allow_low_conf_population to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Configuration options in `config.json` allow adjusting how resource numbers are 
   `low_conf=True` so callers can decide whether to accept or retry the value.
 * `allow_low_conf_population` – when `true`, population digits are returned even
   when OCR confidence falls below the threshold. A warning is logged instead of
-  raising an immediate `PopulationReadError` (default `false`).
+  raising an immediate `PopulationReadError`. Enable this only if population OCR
+  is reliable (default `false`).
 
 ## Capturing `assets/resources.png`
 

--- a/config.sample.json
+++ b/config.sample.json
@@ -20,7 +20,7 @@
   "allow_low_conf_digits": false,
   "//allow_low_conf_digits": "Accept OCR digits even when confidence is below the threshold.",
   "allow_low_conf_population": false,
-  "//allow_low_conf_population": "Accept population digits even when confidence is below the threshold; logs a warning instead of raising.",
+  "//allow_low_conf_population": "Accept population digits even when confidence is below the threshold; enable only if population OCR is reliable; logs a warning instead of raising.",
   "allow_zero_confidence_digits": true,
   "//allow_zero_confidence_digits": "Treat all-zero OCR confidences as unknown instead of failure.",
   "treat_low_conf_as_failure": true,

--- a/script/config_utils.py
+++ b/script/config_utils.py
@@ -121,10 +121,21 @@ def load_config(path: str | Path | None = None) -> dict[str, Any]:
         ) from exc
 
     # Merge profile overrides with base settings
+    allow_low_conf_pop = cfg.setdefault("allow_low_conf_population", False)
+    if allow_low_conf_pop:
+        logger.warning(
+            "'allow_low_conf_population' enabled in base config; ensure population OCR is reliable"
+        )
+
     profiles = cfg.get("profiles", {})
     base_cfg = {k: v for k, v in cfg.items() if k != "profiles"}
     for name, override in profiles.items():
         profiles[name] = _deep_merge(base_cfg, override)
+        if profiles[name].get("allow_low_conf_population") and not allow_low_conf_pop:
+            logger.warning(
+                "'allow_low_conf_population' enabled for profile '%s'; ensure population OCR is reliable",
+                name,
+            )
     cfg["profiles"] = profiles
 
     validate_config(cfg)

--- a/tests/test_load_config_errors.py
+++ b/tests/test_load_config_errors.py
@@ -78,8 +78,13 @@ class TestLoadConfigErrors(TestCase):
     def test_allow_low_conf_population_enabled(self):
         tmp_path = self._write_config({"allow_low_conf_population": True})
         try:
-            cfg = config_utils.load_config(tmp_path)
+            with self.assertLogs(config_utils.logger, level="WARNING") as cm:
+                cfg = config_utils.load_config(tmp_path)
             self.assertTrue(cfg["allow_low_conf_population"])
+            self.assertTrue(
+                any("allow_low_conf_population" in msg for msg in cm.output),
+                "Expected warning log when allow_low_conf_population is true",
+            )
         finally:
             os.remove(tmp_path)
 


### PR DESCRIPTION
## Summary
- clarify that `allow_low_conf_population` should only be enabled when population OCR is reliable and set its default to `false`
- log a warning when `allow_low_conf_population` is enabled
- test logging for `allow_low_conf_population`

## Testing
- `pytest` *(fails: FAILED tests/test_resource_helpers.py::TestCacheDiscrepancy::test_mismatched_cache_ignored_and_validation_succeeds - AssertionError: ... & 63 more)*

------
https://chatgpt.com/codex/tasks/task_e_68b788ae06848325862362d0d8988d27