### PR TITLE
Add population validation helper and test

### DIFF
--- a/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
+++ b/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
@@ -62,15 +62,17 @@ def main() -> None:
     # Leia o HUD para obter os valores atuais de recursos e população
     res_vals, (cur_pop, pop_cap) = resources.gather_hud_stats()
 
-    if cur_pop != info.starting_villagers or pop_cap != info.population_limit:
-        logger.error(
-            "HUD population (%s/%s) does not match expected %s/%s; aborting scenario.",
-            cur_pop,
-            pop_cap,
-            info.starting_villagers,
-            info.population_limit,
-        )
+    pop_check = resources.validate_population(
+        res_vals,
+        cur_pop,
+        pop_cap,
+        expected_cur=info.starting_villagers,
+        expected_cap=info.population_limit,
+        retry_fn=resources.gather_hud_stats,
+    )
+    if pop_check is None:
         return
+    res_vals, (cur_pop, pop_cap) = pop_check
 
     # Validação dos recursos iniciais
     try:

--- a/script/resources/reader/__init__.py
+++ b/script/resources/reader/__init__.py
@@ -40,6 +40,7 @@ from .core import (
     read_resources_from_hud,
     gather_hud_stats,
     validate_starting_resources,
+    validate_population,
     ResourceValidationError,
 )
 
@@ -63,5 +64,6 @@ __all__ = [
     "read_resources_from_hud",
     "gather_hud_stats",
     "validate_starting_resources",
+    "validate_population",
     "ResourceValidationError",
 ]


### PR DESCRIPTION
## Summary
- add reusable population validation helper to resource reader
- check population cap in Egypt_1_Hunting scenario using new helper
- cover cap mismatch logic with unit test

## Testing
- `pytest tests/test_campaign_resource_validation.py -q`
- `pytest -q` *(fails: OpenCV errors in broader suite)*

------
https://chatgpt.com/codex/tasks/task_e_68b78b9c7db48325943d1a0de6e14f04