### PR TITLE
Allow low-confidence duplicate population digits

### DIFF
--- a/script/resources/ocr/executor.py
+++ b/script/resources/ocr/executor.py
@@ -542,6 +542,14 @@ def _read_population_from_roi(roi, conf_threshold=None, roi_bbox=None, failure_c
             cur = int(raw_text[0])
             cap = int(raw_text[1])
             _validate_population(cur, cap)
+            if allow_low_conf:
+                logger.warning(
+                    "Returning low-confidence population %d/%d; conf=%s",
+                    cur,
+                    cap,
+                    confidences,
+                )
+                return cur, cap, True
             err_msg = (
                 f"Ambiguous population OCR: text='{raw_text}', confs={confidences}"
             )

--- a/tests/test_population_roi.py
+++ b/tests/test_population_roi.py
@@ -333,10 +333,10 @@ class TestPopulationROI(TestCase):
         _, kwargs = ocr_mock.call_args
         self.assertEqual(kwargs.get("whitelist"), "0123456789/")
 
-    def test_low_confidence_duplicate_digits_raise_error(self):
+    def test_low_confidence_duplicate_digits_raises_error_when_disallowed(self):
         roi = np.zeros((10, 10, 3), dtype=np.uint8)
         gray = np.zeros((10, 10), dtype=np.uint8)
-        with patch.dict(common.CFG, {"allow_low_conf_population": True}, clear=False), patch(
+        with patch.dict(common.CFG, {"allow_low_conf_population": False}, clear=False), patch(
             "script.resources.ocr.executor.preprocess_roi", return_value=gray
         ), patch(
             "script.resources.ocr.executor.execute_ocr",
@@ -351,6 +351,27 @@ class TestPopulationROI(TestCase):
                 resources._read_population_from_roi(roi, conf_threshold=60)
             err = ctx.exception
             self.assertTrue(getattr(err, "low_conf", False))
+
+    def test_low_confidence_duplicate_digits_returns_value_when_allowed(self):
+        roi = np.zeros((10, 10, 3), dtype=np.uint8)
+        gray = np.zeros((10, 10), dtype=np.uint8)
+        with patch.dict(common.CFG, {"allow_low_conf_population": True}, clear=False), patch(
+            "script.resources.ocr.executor.preprocess_roi", return_value=gray
+        ), patch(
+            "script.resources.ocr.executor.execute_ocr",
+            return_value=(
+                "77",
+                {"text": ["7", "7"], "conf": ["40", "40"]},
+                None,
+                True,
+            ),
+        ):
+            cur, cap, low_conf = resources._read_population_from_roi(
+                roi, conf_threshold=60
+            )
+
+        self.assertTrue(low_conf)
+        self.assertEqual((cur, cap), (7, 7))
 
     def test_allow_low_conf_population_returns_digits(self):
         roi = np.zeros((10, 10, 3), dtype=np.uint8)


### PR DESCRIPTION
## Summary
- Return low-confidence population values for OCR outputs like `77` when `allow_low_conf_population` is enabled instead of raising `PopulationReadError`
- Add tests covering duplicate-digit handling with configuration enabled/disabled

## Testing
- `pytest tests/test_population_roi.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b79a5231648325abdf2a0c2c7defa5