### PR TITLE
Expand population ROI for slash handling

### DIFF
--- a/script/resources/panel/roi.py
+++ b/script/resources/panel/roi.py
@@ -136,9 +136,10 @@ def compute_resource_rois(
                 min_w,
             )
 
-        if current == "population_limit" and width < min_pop_width:
-            width = min_pop_width
-            right = min(orig_right, left + width)
+        if current == "population_limit":
+            width = max(width, min_pop_width)
+            extra = CFG.get("pop_roi_extra_width", 0)
+            right = min(panel_right, next_left, left + width + extra)
             width = right - left
         else:
             right = left + width


### PR DESCRIPTION
## Summary
- extend population span with configurable padding to reserve space for slash and large values
- grow population ROI symmetrically after OCR failures with minimum width
- add regression test for ROI expansion when slash is initially missing

## Testing
- `pytest tests/test_population_roi_bounds.py tests/test_population_limit_fallback.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b79b15cf188325999c36804f1c033f