### PR TITLE
Handle wood stockpile low confidence without cache

### DIFF
--- a/script/resources/reader/core.py
+++ b/script/resources/reader/core.py
@@ -311,6 +311,13 @@ def _handle_cache_and_fallback(
     low_conf_flag = False
     no_digit_flag = False
 
+    if (
+        name == "wood_stockpile"
+        and low_conf
+        and name not in cache_obj.last_resource_values
+    ):
+        return None, cache_hit, True, not bool(digits)
+
     if not digits:
         logger.warning(
             "OCR failed for %s; raw boxes=%s", name, data.get("text")
@@ -452,20 +459,6 @@ def _handle_cache_and_fallback(
             value = None
             no_digit_flag = False
         low_conf_flag = True
-        return value, cache_hit, low_conf_flag, no_digit_flag
-
-    if (
-        name == "wood_stockpile"
-        and low_conf
-        and name not in cache_obj.last_resource_values
-    ):
-        logger.warning(
-            "Discarding %s=%d due to low-confidence OCR", name, value
-        )
-        value = None
-        low_conf_flag = True
-        no_digit_flag = False
-        cache_obj.resource_failure_counts[name] = failure_count + 1
         return value, cache_hit, low_conf_flag, no_digit_flag
 
     if not low_conf:


### PR DESCRIPTION
## Summary
- Guard `_handle_cache_and_fallback` to return `None` for low-confidence wood stockpile reads without cached values
- Avoid updating cache statistics unless a valid reading is produced
- Add test ensuring low-confidence readings without cache do not fallback to invalid values

## Testing
- `pytest tests/ocr_failures/test_low_confidence.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7a05edf448325bccbd1f772c6f273