### PR TITLE
Skip blank OCR boxes when computing confidences

### DIFF
--- a/script/resources/reader/core.py
+++ b/script/resources/reader/core.py
@@ -86,15 +86,18 @@ def _ocr_resource(
             config="--psm 7 -c tessedit_char_whitelist=0123456789",
             output_type=pytesseract.Output.DICT,
         )
-        texts = [t for t in data.get("text", []) if t.strip()]
-        raw_digits = "".join(filter(str.isdigit, "".join(texts))) if texts else None
         confidences = parse_confidences(data)
+        texts = data.get("text", [])
+        raw_digits = "".join(filter(str.isdigit, "".join(texts))) if texts else None
         digits = None
         low_conf = False
         if raw_digits:
-            if confidences and any(c >= res_conf_threshold for c in confidences):
+            digit_confs = [
+                c for t, c in zip(texts, confidences or []) if any(ch.isdigit() for ch in t)
+            ]
+            if digit_confs and any(c >= res_conf_threshold for c in digit_confs):
                 digits = raw_digits
-            elif confidences and any(c > 0 for c in confidences):
+            elif digit_confs and any(c > 0 for c in digit_confs):
                 digits = None
             else:
                 digits = raw_digits


### PR DESCRIPTION
## Summary
- Ignore empty or whitespace OCR boxes when extracting confidences and update text list to match
- Evaluate idle villager low-confidence status using confidences of digit boxes only
- Add regression test ensuring blank boxes don't trigger low-confidence failures

## Testing
- `pytest tests/ocr_failures/test_low_confidence.py::TestResourceLowConfidence::test_blank_boxes_do_not_flag_low_confidence -q`
- `pytest tests/ocr_helpers/test_parse_confidences.py::test_alignment_and_placeholder_values tests/ocr_helpers/test_parse_confidences.py::test_handles_missing_conf_key -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7a22b4b3c83259092823e14c4f3bf