### PR TITLE
Refine resource OCR color masking

### DIFF
--- a/config.json
+++ b/config.json
@@ -33,6 +33,8 @@
     "wood_stockpile_ocr_conf_threshold": 45,
     "wood_stockpile_color_pass": true,
     "//wood_stockpile_color_pass": "Validate wood stockpile with a second color-mask OCR pass.",
+    "food_stockpile_color_pass": true,
+    "//food_stockpile_color_pass": "Validate food stockpile with a second color-mask OCR pass.",
     "food_stockpile_ocr_conf_threshold": 40,
     "gold_stockpile_ocr_conf_threshold": 45,
     "stone_stockpile_ocr_conf_threshold": 45,

--- a/config.sample.json
+++ b/config.sample.json
@@ -39,6 +39,8 @@
     "wood_stockpile_ocr_conf_threshold": 45,
     "wood_stockpile_color_pass": true,
     "//wood_stockpile_color_pass": "Validate wood stockpile with a second color-mask OCR pass.",
+    "food_stockpile_color_pass": true,
+    "//food_stockpile_color_pass": "Validate food stockpile with a second color-mask OCR pass.",
     "food_stockpile_ocr_conf_threshold": 45,
     "gold_stockpile_ocr_conf_threshold": 45,
     "stone_stockpile_ocr_conf_threshold": 45,


### PR DESCRIPTION
## Summary
- avoid cross-shaped close for wood stockpile digits
- run broader HSV color mask for wood and food before fallback
- add `food_stockpile_color_pass` config toggle

## Testing
- `pytest` *(fail: 89 failed, 142 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a7194e8c83258403c082a4fe028a