### PR TITLE
Allow low confidence digit fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Configuration options in `config.json` allow adjusting how resource numbers are 
 * `execute_ocr` returns a `(digits, data, mask, low_conf)` tuple. When no attempt
   meets the confidence threshold, the highest-confidence digits are returned with
   `low_conf=True` so callers can decide whether to accept or retry the value.
+* `allow_low_conf_digits` – when `true`, OCR results that resemble digits are
+  returned even if their confidence falls below the threshold (default
+  `false`).
 * `allow_low_conf_population` – when `true`, population digits are returned even
   when OCR confidence falls below the threshold. Enable this only if population
   OCR is reliable (default `false`). This option conflicts with

--- a/config.sample.json
+++ b/config.sample.json
@@ -18,7 +18,7 @@
   "ocr_conf_max_attempts": 10,
   "//ocr_conf_max_attempts": "Full OCR retries before only lowering the confidence threshold.",
   "allow_low_conf_digits": false,
-  "//allow_low_conf_digits": "Accept OCR digits even when confidence is below the threshold.",
+  "//allow_low_conf_digits": "Return digits that look like numbers even when OCR confidence is below the threshold.",
   "allow_low_conf_population": false,
   "//allow_low_conf_population": "Accept population digits even when confidence is below the threshold; enable only if population OCR is reliable. Cannot be combined with 'treat_low_conf_as_failure'.",
   "allow_zero_confidence_digits": true,

--- a/script/resources/reader/core.py
+++ b/script/resources/reader/core.py
@@ -154,6 +154,15 @@ def _ocr_resource(
             )
             if digits_retry:
                 digits, data, mask = digits_retry, data_retry, mask_retry
+    if (
+        low_conf
+        and not digits
+        and CFG.get("allow_low_conf_digits")
+        and data.get("text")
+    ):
+        raw_digits = "".join(filter(str.isdigit, "".join(data["text"])))
+        if raw_digits:
+            digits = raw_digits
     treat_low_conf_as_failure = (
         CFG.get("treat_low_conf_as_failure", True)
         and not CFG.get("allow_low_conf_digits", False)


### PR DESCRIPTION
## Summary
- Return digit strings when OCR text looks numeric and `allow_low_conf_digits` is enabled even if confidence is low
- Document `allow_low_conf_digits` in sample config and README

## Testing
- `pytest` *(fails: Resource ROI and OCR tests, 88 failed, 144 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7aa33b318832596b66cc88fd5f656