### PR TITLE
Align OCR text and confidence lists

### DIFF
--- a/script/resources/ocr/confidence.py
+++ b/script/resources/ocr/confidence.py
@@ -25,14 +25,11 @@ def parse_confidences(data):
     if not raw_conf:
         return None
 
-    texts = data.get("text") or []
     filtered_texts: list[str] = []
     filtered_conf: list[float] = []
-    conf_iter = iter(raw_conf)
-    for t in texts:
+    for t, c in zip(data.get("text") or [], raw_conf):
         if not str(t).strip():
             continue
-        c = next(conf_iter, "0")
         try:
             val = float(c)
         except (ValueError, TypeError):
@@ -43,6 +40,7 @@ def parse_confidences(data):
         filtered_conf.append(val)
 
     data["text"] = filtered_texts
+    data["conf"] = filtered_conf
     return filtered_conf
 
 

--- a/tests/ocr_helpers/test_parse_confidences.py
+++ b/tests/ocr_helpers/test_parse_confidences.py
@@ -23,6 +23,19 @@ def test_handles_missing_conf_key():
     assert parse_confidences(data) == [0.0, 0.0]
 
 
+def test_empty_text_entries_are_idempotent():
+    data = {
+        "text": ["", "foo", ""],
+        "conf": ["10", "20", "30"],
+    }
+    expected = [20.0]
+    assert parse_confidences(data) == expected
+    # second invocation should yield the same result and leave data consistent
+    assert parse_confidences(data) == expected
+    assert data["text"] == ["foo"]
+    assert data["conf"] == expected
+
+
 def test_read_resources_logs_sanitized_confidences(caplog):
     frame = np.zeros((10, 10, 3), dtype=np.uint8)
     gray = np.zeros((10, 10), dtype=np.uint8)


### PR DESCRIPTION
## Summary
- Pair OCR text and confidence entries when parsing, filtering out empty text while keeping both lists in sync
- Add regression test ensuring `parse_confidences` remains consistent when invoked multiple times on data with empty text entries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytesseract')*
- `pytest tests/ocr_helpers/test_parse_confidences.py -q`
- `pytest tests/ocr_helpers -q` *(fails: AttributeError: module 'script.resources.ocr' has no attribute 'CFG')*

------
https://chatgpt.com/codex/tasks/task_e_68b7b0c4e2588325a02f4aedbc2e43da