### PR TITLE
Handle ambiguous population digits via fallback

### DIFF
--- a/config.json
+++ b/config.json
@@ -26,7 +26,7 @@
     "gold_stockpile_low_conf_fallback": false,
     "stone_stockpile_low_conf_fallback": false,
     "population_limit_low_conf_fallback": false,
-    "//population_limit_low_conf_fallback": "Set true to reuse last population or accept zero-confidence population digits matching cur/cap.",
+    "//population_limit_low_conf_fallback": "Set true to reuse last population or accept zero/low-confidence population digits (including ambiguous pairs) matching cur/cap.",
     "idle_villager_low_conf_fallback": true,
     "idle_villager_low_conf_streak": 5,
     "//*_low_conf_fallback": "Use cached value when OCR confidence is low.",

--- a/config.sample.json
+++ b/config.sample.json
@@ -31,7 +31,7 @@
     "gold_stockpile_low_conf_fallback": false,
     "stone_stockpile_low_conf_fallback": false,
     "population_limit_low_conf_fallback": false,
-    "//population_limit_low_conf_fallback": "Return best OCR digits after ocr_retry_limit attempts even if confidence is low; set true to enable.",
+    "//population_limit_low_conf_fallback": "Return best OCR digits after ocr_retry_limit attempts even if confidence is low or ambiguous; set true to enable.",
     "idle_villager_low_conf_fallback": false,
     "//idle_villager_low_conf_fallback": "Set true to reuse last value on low-confidence OCR.",
     "idle_villager_low_conf_streak": 5,


### PR DESCRIPTION
## Summary
- Allow ambiguous population OCR results to fall back when zero-confidence digits or low-confidence fallback is enabled
- Warn and return digits instead of raising when ambiguous population is accepted
- Clarify population fallback behaviour in configs
- Test ambiguous population fallback and zero-confidence options

## Testing
- `pytest tests/test_population_ocr_conf.py -q`
- `pytest -q` *(fails: TesseractNotFoundError and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b65775488325a5a91c3e46ae3e93