### PR TITLE
Propagate population ROI expansion errors

### DIFF
--- a/script/resources/reader/roi.py
+++ b/script/resources/reader/roi.py
@@ -223,16 +223,13 @@ def expand_population_roi_after_failure(
         y1 - y0,
     )
     roi_expanded = frame[y0:y1, x0:x1]
-    try:
-        cur_pop, pop_cap, low_conf = _read_population_from_roi(
-            roi_expanded,
-            conf_threshold=res_conf_threshold,
-            roi_bbox=(x0, y0, x1 - x0, y1 - y0),
-            failure_count=failure_count + 1,
-        )
-        return cur_pop, pop_cap, roi_expanded, x0, y0, x1 - x0, y1 - y0, low_conf
-    except common.PopulationReadError:
-        return None
+    cur_pop, pop_cap, low_conf = _read_population_from_roi(
+        roi_expanded,
+        conf_threshold=res_conf_threshold,
+        roi_bbox=(x0, y0, x1 - x0, y1 - y0),
+        failure_count=failure_count + 1,
+    )
+    return cur_pop, pop_cap, roi_expanded, x0, y0, x1 - x0, y1 - y0, low_conf
 
 __all__ = [
     "prepare_roi",


### PR DESCRIPTION
## Summary
- propagate `PopulationReadError` from population ROI expansion so errors reflect the final OCR attempt
- stop swallowing errors in `expand_population_roi_after_failure`
- add regression test ensuring error message reports last attempt and ROI after failed expansion

## Testing
- `pytest tests/test_population_roi.py::TestPopulationROI::test_population_error_reports_final_attempt tests/test_population_roi.py::TestPopulationROI::test_population_expansion_error_includes_final_attempt_and_roi -q`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*


------
https://chatgpt.com/codex/tasks/task_e_68b7bdac6de88325922c2d86bf82fa03