### PR TITLE
Include idle ROI extra width in auto calibration

### DIFF
--- a/script/resources/panel/calibration.py
+++ b/script/resources/panel/calibration.py
@@ -63,6 +63,7 @@ def _auto_calibrate_from_icons(frame, cache_obj: cache.ResourceCache = cache.RES
         cfg.max_widths,
         cfg.min_widths,
         cfg.min_pop_width,
+        cfg.idle_roi_extra_width,
         cfg.min_requireds,
         detected_rel,
     )

--- a/tests/resource_rois/test_calibration.py
+++ b/tests/resource_rois/test_calibration.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 import script.common as common
 import script.resources as resources
 import script.resources.reader as reader
+from script.resources.panel import ResourcePanelCfg
+import script.screen_utils as screen_utils
 
 
 class TestCalibration(TestCase):
@@ -47,3 +49,76 @@ class TestCalibration(TestCase):
         span = reader._LAST_REGION_SPANS.get("wood_stockpile")
         self.assertEqual(span, (50, 70))
         self.assertGreater(span[1], span[0])
+
+    def test_auto_calibrate_passes_idle_extra_width(self):
+        frame = np.zeros((20, 40, 3), dtype=np.uint8)
+
+        cfg_obj = ResourcePanelCfg(
+            match_threshold=0.0,
+            scales=[1.0],
+            pad_left=[0] * 6,
+            pad_right=[0] * 6,
+            icon_trims=[0] * 6,
+            max_widths=[0] * 6,
+            min_widths=[0] * 6,
+            min_requireds=[0] * 6,
+            top_pct=0.0,
+            height_pct=1.0,
+            idle_roi_extra_width=7,
+            min_pop_width=11,
+            pop_roi_extra_width=0,
+        )
+
+        captured = {}
+
+        def fake_compute(*args):
+            captured["args"] = args
+            return {}, {}, {}
+
+        with patch.object(screen_utils, "_load_icon_templates", lambda: None), \
+            patch(
+                "script.resources.panel.calibration._get_resource_panel_cfg",
+                return_value=cfg_obj,
+            ), \
+            patch.object(
+                resources.panel.calibration.cv2,
+                "cvtColor",
+                lambda src, code: np.zeros(src.shape[:2], dtype=np.uint8),
+            ), \
+            patch.object(
+                resources.panel.calibration.cv2,
+                "resize",
+                lambda img, *a, **k: img,
+            ), \
+            patch.object(
+                resources.panel.calibration.cv2,
+                "matchTemplate",
+                lambda *a, **k: np.array([[1.0]], dtype=np.float32),
+            ), \
+            patch.object(
+                resources.panel.calibration.cv2,
+                "minMaxLoc",
+                lambda res: (0.0, float(res.max()), (0, 0), (0, 0)),
+            ), \
+            patch.dict(
+                screen_utils.ICON_TEMPLATES,
+                {
+                    "wood_stockpile": np.zeros((5, 5), dtype=np.uint8),
+                    "food_stockpile": np.zeros((5, 5), dtype=np.uint8),
+                },
+                clear=True,
+            ), \
+            patch.object(
+                resources.panel.calibration,
+                "compute_resource_rois",
+                side_effect=fake_compute,
+            ):
+            resources.panel.calibration._auto_calibrate_from_icons(
+                frame, resources.RESOURCE_CACHE
+            )
+
+        args = captured.get("args")
+        self.assertIsNotNone(args)
+        self.assertEqual(args[9], cfg_obj.min_pop_width)
+        self.assertEqual(args[10], cfg_obj.idle_roi_extra_width)
+        self.assertEqual(args[11], cfg_obj.min_requireds)


### PR DESCRIPTION
## Summary
- pass `idle_roi_extra_width` into `compute_resource_rois` during auto calibration
- test automatic calibration parameter ordering, including idle ROI extra width

## Testing
- `pytest tests/resource_rois`


------
https://chatgpt.com/codex/tasks/task_e_68b7c01f87988325aac675ee0f7e7901