### PR TITLE
Use idle icon bounds for idle villager ROI

### DIFF
--- a/config.json
+++ b/config.json
@@ -59,6 +59,10 @@
     "//population_ocr_roi_expand_growth": "Exponent controlling population ROI growth rate; >1 grows faster.",
     "population_idle_padding": 6,
     "//population_idle_padding": "Pixels to keep between population ROI and idle villager icon.",
+    "idle_icon_inner_trim": 0,
+    "//idle_icon_inner_trim": "Pixels to trim inside the idle villager icon ROI on each side.",
+    "idle_icon_inner_pct": 0.0,
+    "//idle_icon_inner_pct": "Alternative percentage trim for the idle villager icon when inner_trim is null.",
     "ocr_kernel_size": 1,
     "ocr_top_crop": 1,
     "ocr_top_crop_overrides": {

--- a/config.sample.json
+++ b/config.sample.json
@@ -65,6 +65,10 @@
     "//population_ocr_roi_expand_growth": "Exponent controlling population ROI growth rate; >1 grows faster.",
     "population_idle_padding": 6,
     "//population_idle_padding": "Pixels to keep between population ROI and idle villager icon.",
+    "idle_icon_inner_trim": 0,
+    "//idle_icon_inner_trim": "Pixels to trim inside the idle villager icon ROI on each side.",
+    "idle_icon_inner_pct": 0.0,
+    "//idle_icon_inner_pct": "Alternative percentage trim for the idle villager icon when inner_trim is null.",
     "ocr_kernel_size": 1,
     "ocr_top_crop": 2,
     "ocr_top_crop_overrides": {

--- a/script/resources/reader/roi.py
+++ b/script/resources/reader/roi.py
@@ -29,23 +29,9 @@ def prepare_roi(
     """
     x, y, w, h = regions[name]
 
-    # Keep idle-villager ROI from encroaching on the population area
-    if name == "idle_villager" and "population_limit" in regions:
-        pop_x, _py, pop_w, _ph = regions["population_limit"]
-        pop_right = pop_x + pop_w
-        if x < pop_right:
-            # Trim any overlap on the left side
-            shift = pop_right - x
-            x = pop_right
-            w = max(0, w - shift)
-            regions[name] = (x, y, w, h)
-
     deficit = get_narrow_roi_deficit(name)
     if deficit:
-        if name == "idle_villager":
-            expand_left = 0
-            expand_right = deficit
-        elif name == "population_limit":
+        if name == "population_limit":
             expand_left = deficit
             expand_right = 0
         else:
@@ -55,10 +41,6 @@ def prepare_roi(
         orig_w = w
         x = max(0, orig_x - expand_left)
         right = min(frame.shape[1], orig_x + orig_w + expand_right)
-        if name == "idle_villager" and "population_limit" in regions:
-            pop_right = regions["population_limit"][0] + regions["population_limit"][2]
-            if x < pop_right:
-                x = pop_right
         w = max(0, right - x)
         regions[name] = (x, y, w, h)
         logger.debug(

--- a/tests/resource_rois/test_compute_rois.py
+++ b/tests/resource_rois/test_compute_rois.py
@@ -114,7 +114,7 @@ class TestComputeResourceROIs(TestCase):
 
         self.assertEqual(result, {"wood_stockpile"})
 
-    def test_food_and_idle_rois_accommodate_three_digits(self):
+    def test_food_roi_accommodates_three_digits(self):
         detected = {
             "wood_stockpile": (0, 0, 10, 10),
             "food_stockpile": (50, 0, 10, 10),
@@ -138,9 +138,7 @@ class TestComputeResourceROIs(TestCase):
             detected=detected,
         )
         self.assertGreaterEqual(regions["food_stockpile"][2], 30)
-        self.assertGreaterEqual(regions["idle_villager"][2], 30)
         self.assertNotIn("food_stockpile", narrow)
-        self.assertNotIn("idle_villager", narrow)
 
     def test_food_roi_width_can_exceed_60_when_configured(self):
         detected = {
@@ -244,7 +242,7 @@ class TestComputeResourceROIs(TestCase):
             right, idle_left - common.CFG.get("population_idle_padding", 6)
         )
 
-    def test_idle_roi_generated_when_span_non_positive(self):
+    def test_idle_roi_uses_icon_bounds_when_span_non_positive(self):
         detected = {
             "population_limit": (0, 0, 5, 5),
             "idle_villager": (10, 0, 5, 5),
@@ -264,8 +262,8 @@ class TestComputeResourceROIs(TestCase):
             detected=detected,
         )
         self.assertIn("idle_villager", regions)
-        self.assertEqual(regions["idle_villager"], (15, 0, 10, 10))
-        self.assertEqual(spans["idle_villager"], (15, 25))
+        self.assertEqual(regions["idle_villager"], (10, 0, 5, 10))
+        self.assertEqual(spans["idle_villager"], (10, 15))
 
 
 class TestNarrowROIExpansion(TestCase):

--- a/tests/test_idle_villager_roi.py
+++ b/tests/test_idle_villager_roi.py
@@ -41,261 +41,49 @@ import script.screen_utils as screen_utils
 
 
 class TestIdleVillagerROI(TestCase):
-    def test_idle_villager_roi_uses_digit_span(self):
-        frame = np.zeros((50, 100, 3), dtype=np.uint8)
-        panel_box = (10, 15, 80, 20)  # x, y, w, h
-        xi, yi = 5, 4
-        icon_h, icon_w = 5, 5
-
-        def fake_imread(path, flags=0):
-            name = os.path.splitext(os.path.basename(path))[0]
-            if name == "idle_villager":
-                return np.ones((icon_h, icon_w), dtype=np.uint8)
-            return np.zeros((icon_h, icon_w), dtype=np.uint8)
-
-        def fake_match(img, templ, method):
-            h = img.shape[0] - templ.shape[0] + 1
-            w = img.shape[1] - templ.shape[1] + 1
-            res = np.zeros((h, w), dtype=np.float32)
-            if np.all(templ == 1):
-                res[yi, xi] = 0.95
-            return res
-
-        def fake_minmax(res):
-            max_val = float(res.max())
-            max_loc = tuple(np.unravel_index(res.argmax(), res.shape)[::-1])
-            return 0.0, max_val, (0, 0), max_loc
-
-        def fake_cvtColor(src, code):
-            return np.zeros(src.shape[:2], dtype=np.uint8)
-
-        def fake_compute(pl, pr, top, height, *args, **kwargs):
-            left = pl + xi + icon_w
-            span = (left, left + 10)
-            regions = {"idle_villager": (left, top, 10, height)}
-            return regions, {"idle_villager": span}, {}
-
-        with patch("script.resources.find_template", return_value=(panel_box, 0.9, None)), \
-            patch("script.resources.cv2.cvtColor", side_effect=fake_cvtColor), \
-            patch("script.resources.cv2.resize", side_effect=lambda img, *a, **k: img), \
-            patch("script.resources.cv2.matchTemplate", side_effect=fake_match), \
-            patch("script.resources.cv2.minMaxLoc", side_effect=fake_minmax), \
-            patch("script.resources.cv2.imread", side_effect=fake_imread), \
-            patch("script.resources.panel.detection.compute_resource_rois", side_effect=fake_compute), \
-            patch.dict(screen_utils.ICON_TEMPLATES, {}, clear=True), \
-            patch.dict(
-                common.CFG["resource_panel"],
-                {
-                    "roi_padding_left": [0] * 6,
-                    "roi_padding_right": [0] * 6,
-                    "icon_trim_pct": [0] * 6,
-                    "scales": [1.0],
-                    "match_threshold": 0.5,
-                    "max_width": 999,
-                    "min_width": 0,
-                },
-            ), patch.dict(
-                common.CFG["profiles"]["aoe1de"]["resource_panel"],
-                {"icon_trim_pct": [0] * 6},
-            ):
-                regions = resources.locate_resource_panel(frame)
-
-        self.assertIn("idle_villager", regions)
-        roi = regions["idle_villager"]
-        cfg_obj = resources.panel._get_resource_panel_cfg()
-        top = panel_box[1] + int(cfg_obj.top_pct * panel_box[3])
-        height = int(cfg_obj.height_pct * panel_box[3])
-        expected = (panel_box[0] + xi + icon_w, top, 10, height)
-        self.assertEqual(roi, expected)
-        self.assertEqual(roi[2], 10)
-        self.assertGreater(roi[3], 0)
-
-    def test_idle_villager_roi_clamped_before_population(self):
-        frame = np.zeros((50, 100, 3), dtype=np.uint8)
-        panel_box = (10, 15, 80, 20)
-        xi, yi = 5, 4
-        icon_h, icon_w = 5, 5
-
-        def fake_imread(path, flags=0):
-            name = os.path.splitext(os.path.basename(path))[0]
-            if name == "idle_villager":
-                return np.ones((icon_h, icon_w), dtype=np.uint8)
-            return np.zeros((icon_h, icon_w), dtype=np.uint8)
-
-        def fake_match(img, templ, method):
-            h = img.shape[0] - templ.shape[0] + 1
-            w = img.shape[1] - templ.shape[1] + 1
-            res = np.zeros((h, w), dtype=np.float32)
-            if np.all(templ == 1):
-                res[yi, xi] = 0.95
-            return res
-
-        def fake_minmax(res):
-            max_val = float(res.max())
-            max_loc = tuple(np.unravel_index(res.argmax(), res.shape)[::-1])
-            return 0.0, max_val, (0, 0), max_loc
-
-        def fake_cvtColor(src, code):
-            return np.zeros(src.shape[:2], dtype=np.uint8)
-
-        def fake_compute(pl, pr, top, height, *args, **kwargs):
-            offset = 20
-            pop_span = (pl + offset, pl + offset + 20)
-            idle_left = pl + xi + icon_w
-            idle_width = pop_span[0] - idle_left
-            regions = {
-                "population_limit": (pl + offset, top, 10, height),
-                "idle_villager": (idle_left, top, idle_width, height),
-            }
-            spans = {
-                "population_limit": pop_span,
-                "idle_villager": (idle_left, idle_left + idle_width),
-            }
-            return regions, spans, {}
-
-        with patch("script.resources.find_template", return_value=(panel_box, 0.9, None)), \
-            patch("script.resources.cv2.cvtColor", side_effect=fake_cvtColor), \
-            patch("script.resources.cv2.resize", side_effect=lambda img, *a, **k: img), \
-            patch("script.resources.cv2.matchTemplate", side_effect=fake_match), \
-            patch("script.resources.cv2.minMaxLoc", side_effect=fake_minmax), \
-            patch("script.resources.cv2.imread", side_effect=fake_imread), \
-            patch("script.resources.panel.detection.compute_resource_rois", side_effect=fake_compute), \
-            patch.dict(screen_utils.ICON_TEMPLATES, {}, clear=True), \
-            patch.dict(
-                common.CFG["resource_panel"],
-                {
-                    "roi_padding_left": [0] * 6,
-                    "roi_padding_right": [0] * 6,
-                    "icon_trim_pct": [0] * 6,
-                    "scales": [1.0],
-                    "match_threshold": 0.5,
-                    "max_width": 999,
-                    "min_width": 0,
-                },
-            ), patch.dict(
-                common.CFG["profiles"]["aoe1de"]["resource_panel"],
-                {"icon_trim_pct": [0] * 6},
-            ):
-                regions = resources.locate_resource_panel(frame)
-
-        self.assertIn("idle_villager", regions)
-        roi = regions["idle_villager"]
-        cfg_obj = resources.panel._get_resource_panel_cfg()
-        top = panel_box[1] + int(cfg_obj.top_pct * panel_box[3])
-        height = int(cfg_obj.height_pct * panel_box[3])
-        self.assertEqual(roi[1], top)
-        self.assertEqual(roi[3], height)
-        pop_left = panel_box[0] + 20
-        expected_width = pop_left - (panel_box[0] + xi + icon_w)
-        self.assertEqual(roi[2], expected_width)
-
-    def test_idle_villager_roi_shrinks_near_population(self):
-        frame = np.zeros((50, 100, 3), dtype=np.uint8)
-        panel_box = (10, 15, 80, 20)
-        xi, yi = 5, 4
-        icon_h, icon_w = 5, 5
-
-        def fake_imread(path, flags=0):
-            name = os.path.splitext(os.path.basename(path))[0]
-            if name == "idle_villager":
-                return np.ones((icon_h, icon_w), dtype=np.uint8)
-            return np.zeros((icon_h, icon_w), dtype=np.uint8)
-
-        def fake_match(img, templ, method):
-            h = img.shape[0] - templ.shape[0] + 1
-            w = img.shape[1] - templ.shape[1] + 1
-            res = np.zeros((h, w), dtype=np.float32)
-            if np.all(templ == 1):
-                res[yi, xi] = 0.95
-            return res
-
-        def fake_minmax(res):
-            max_val = float(res.max())
-            max_loc = tuple(np.unravel_index(res.argmax(), res.shape)[::-1])
-            return 0.0, max_val, (0, 0), max_loc
-
-        def fake_cvtColor(src, code):
-            return np.zeros(src.shape[:2], dtype=np.uint8)
-
-        def fake_compute(pl, pr, top, height, *args, **kwargs):
-            offset = 25
-            pop_span = (pl + offset, pl + offset + 20)
-            idle_left = pl + xi + icon_w
-            idle_width = pop_span[0] - idle_left
-            regions = {
-                "population_limit": (pl + offset, top, 10, height),
-                "idle_villager": (idle_left, top, idle_width, height),
-            }
-            spans = {
-                "population_limit": pop_span,
-                "idle_villager": (idle_left, idle_left + idle_width),
-            }
-            return regions, spans, {}
-
-        with patch("script.resources.find_template", return_value=(panel_box, 0.9, None)), \
-            patch("script.resources.cv2.cvtColor", side_effect=fake_cvtColor), \
-            patch("script.resources.cv2.resize", side_effect=lambda img, *a, **k: img), \
-            patch("script.resources.cv2.matchTemplate", side_effect=fake_match), \
-            patch("script.resources.cv2.minMaxLoc", side_effect=fake_minmax), \
-            patch("script.resources.cv2.imread", side_effect=fake_imread), \
-            patch("script.resources.panel.detection.compute_resource_rois", side_effect=fake_compute), \
-            patch.dict(screen_utils.ICON_TEMPLATES, {}, clear=True), \
-            patch.dict(
-                common.CFG["resource_panel"],
-                {
-                    "roi_padding_left": [0] * 6,
-                    "roi_padding_right": [0] * 6,
-                    "icon_trim_pct": [0] * 6,
-                    "scales": [1.0],
-                    "match_threshold": 0.5,
-                    "max_width": 999,
-                    "min_width": 0,
-                },
-            ), patch.dict(
-                common.CFG["profiles"]["aoe1de"]["resource_panel"],
-                {"icon_trim_pct": [0] * 6},
-            ):
-                regions = resources.locate_resource_panel(frame)
-
-        self.assertIn("idle_villager", regions)
-        roi = regions["idle_villager"]
-        cfg_obj = resources.panel._get_resource_panel_cfg()
-        top = panel_box[1] + int(cfg_obj.top_pct * panel_box[3])
-        height = int(cfg_obj.height_pct * panel_box[3])
-        self.assertEqual(roi[1], top)
-        self.assertEqual(roi[3], height)
-        pop_left = panel_box[0] + 25
-        expected_width = pop_left - (panel_box[0] + xi + icon_w)
-        self.assertEqual(roi[2], expected_width)
-
-    def test_idle_villager_roi_uses_extra_width_when_no_span(self):
-        frame = np.zeros((50, 100, 3), dtype=np.uint8)
-        panel_box = (10, 15, 80, 20)
-        xi, yi = 5, 4
-        icon_h, icon_w = 5, 5
-
+    def test_idle_villager_roi_uses_icon_bounds(self):
         detected = {
-            "population_limit": (0, 0, 10, 10),
-            "idle_villager": (xi, yi, icon_w, icon_h),
+            "idle_villager": (10, 0, 20, 10),
         }
-        regions, _spans, _narrow = resources.compute_resource_rois(
+        regions, spans, _narrow = resources.compute_resource_rois(
             0,
-            70,
+            100,
             0,
             10,
-            [0, 0, 0, 0, 0, 100],
+            [0] * 6,
             [0] * 6,
             [0] * 6,
             [999] * 6,
             [0] * 6,
             0,
-            15,
+            0,
             detected=detected,
         )
-
         self.assertIn("idle_villager", regions)
-        roi = regions["idle_villager"]
-        self.assertEqual(roi[2], 15)
+        self.assertEqual(regions["idle_villager"], (10, 0, 20, 10))
+        self.assertEqual(spans["idle_villager"], (10, 30))
+
+    def test_idle_villager_roi_respects_inner_trim_config(self):
+        detected = {
+            "idle_villager": (10, 0, 20, 10),
+        }
+        with patch.dict(resources.CFG, {"idle_icon_inner_trim": 3}, clear=False):
+            regions, spans, _ = resources.compute_resource_rois(
+                0,
+                100,
+                0,
+                10,
+                [0] * 6,
+                [0] * 6,
+                [0] * 6,
+                [999] * 6,
+                [0] * 6,
+                0,
+                0,
+                detected=detected,
+            )
+        self.assertEqual(regions["idle_villager"], (13, 0, 14, 10))
+        self.assertEqual(spans["idle_villager"], (13, 27))
 
     def test_detect_resource_regions_uses_configured_idle_roi_when_missing(self):
         frame = np.zeros((50, 100, 3), dtype=np.uint8)


### PR DESCRIPTION
## Summary
- compute idle-villager ROI from the icon bounds with configurable inner trimming
- expose `idle_icon_inner_trim`/`idle_icon_inner_pct` in configs for fine-tuning
- simplify idle ROI handling and update tests for new approach

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7c35a09208325a987203fee5697ec