### PR TITLE
Clamp idle villager ROI trim and document config

### DIFF
--- a/config.json
+++ b/config.json
@@ -60,9 +60,9 @@
     "population_idle_padding": 6,
     "//population_idle_padding": "Pixels to keep between population ROI and idle villager icon.",
     "idle_icon_inner_trim": 0,
-    "//idle_icon_inner_trim": "Pixels to trim inside the idle villager icon ROI on each side.",
+    "//idle_icon_inner_trim": "Pixels to trim inside the idle villager icon ROI on each side; total trim is capped at 50% of the icon width.",
     "idle_icon_inner_pct": 0.0,
-    "//idle_icon_inner_pct": "Alternative percentage trim for the idle villager icon when inner_trim is null.",
+    "//idle_icon_inner_pct": "Alternative percentage-based trim for the idle villager icon when inner_trim is null; total trim is capped at 50% of the icon width.",
     "ocr_kernel_size": 1,
     "ocr_top_crop": 1,
     "ocr_top_crop_overrides": {

--- a/config.sample.json
+++ b/config.sample.json
@@ -66,9 +66,9 @@
     "population_idle_padding": 6,
     "//population_idle_padding": "Pixels to keep between population ROI and idle villager icon.",
     "idle_icon_inner_trim": 0,
-    "//idle_icon_inner_trim": "Pixels to trim inside the idle villager icon ROI on each side.",
+    "//idle_icon_inner_trim": "Pixels to trim inside the idle villager icon ROI on each side; total trim is capped at 50% of the icon width.",
     "idle_icon_inner_pct": 0.0,
-    "//idle_icon_inner_pct": "Alternative percentage trim for the idle villager icon when inner_trim is null.",
+    "//idle_icon_inner_pct": "Alternative percentage-based trim for the idle villager icon when inner_trim is null; total trim is capped at 50% of the icon width.",
     "ocr_kernel_size": 1,
     "ocr_top_crop": 2,
     "ocr_top_crop_overrides": {

--- a/script/resources/panel/roi.py
+++ b/script/resources/panel/roi.py
@@ -51,7 +51,8 @@ def compute_resource_rois(
                 inner_trim = int(round(CFG.get("idle_icon_inner_pct", 0.0) * cur_w))
             else:
                 inner_trim = int(inner_trim)
-            inner_trim = max(0, min(inner_trim, cur_w // 2))
+            max_trim = cur_w // 4
+            inner_trim = max(0, min(inner_trim, max_trim))
 
             left = panel_left + cur_x + inner_trim
             right = panel_left + cur_x + cur_w - inner_trim

--- a/tests/test_idle_villager_roi.py
+++ b/tests/test_idle_villager_roi.py
@@ -118,3 +118,47 @@ class TestIdleVillagerROI(TestCase):
 
         self.assertEqual(regions["idle_villager"], detected["idle_villager"])
 
+    def test_idle_villager_extreme_inner_trim_not_negative(self):
+        detected = {
+            "idle_villager": (10, 0, 20, 10),
+        }
+        with patch.dict(resources.CFG, {"idle_icon_inner_trim": 999}, clear=False):
+            regions, spans, _ = resources.compute_resource_rois(
+                0,
+                100,
+                0,
+                10,
+                [0] * 6,
+                [0] * 6,
+                [0] * 6,
+                [999] * 6,
+                [0] * 6,
+                0,
+                0,
+                detected=detected,
+            )
+        self.assertEqual(regions["idle_villager"], (15, 0, 10, 10))
+        self.assertEqual(spans["idle_villager"], (15, 25))
+
+        with patch.dict(
+            resources.CFG,
+            {"idle_icon_inner_trim": None, "idle_icon_inner_pct": 0.9},
+            clear=False,
+        ):
+            regions, spans, _ = resources.compute_resource_rois(
+                0,
+                100,
+                0,
+                10,
+                [0] * 6,
+                [0] * 6,
+                [0] * 6,
+                [999] * 6,
+                [0] * 6,
+                0,
+                0,
+                detected=detected,
+            )
+        self.assertEqual(regions["idle_villager"], (15, 0, 10, 10))
+        self.assertEqual(spans["idle_villager"], (15, 25))
+


### PR DESCRIPTION
## Summary
- document `idle_icon_inner_trim` and `idle_icon_inner_pct` with 50% width cap
- clamp idle villager ROI trimming to half the icon width
- test that extreme inner trims do not produce negative ROI width

## Testing
- `pytest tests/test_idle_villager_roi.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7ca13a54483258618c10ff8d36237