### PR TITLE
Use icon bounds for resource panel ROI

### DIFF
--- a/script/resources/panel/detection.py
+++ b/script/resources/panel/detection.py
@@ -104,8 +104,15 @@ def locate_resource_panel(frame, cache_obj: cache.ResourceCache = cache.RESOURCE
         detected["population_limit"] = (px, yi, pw, ph)
         cache_obj.last_icon_bounds["population_limit"] = (px, yi, pw, ph)
 
-    top = y + int(cfg.top_pct * h)
-    height = int(cfg.height_pct * h)
+    if detected:
+        min_y = min(v[1] for v in detected.values())
+        max_y = max(v[1] + v[3] for v in detected.values())
+    else:
+        min_y = int(cfg.top_pct * h)
+        max_y = min_y + int(cfg.height_pct * h)
+
+    top = y + min_y
+    height = max_y - min_y
 
     regions, spans, narrow = compute_resource_rois(
         x,

--- a/tests/resource_rois/test_compute_rois.py
+++ b/tests/resource_rois/test_compute_rois.py
@@ -93,8 +93,6 @@ class TestComputeResourceROIs(TestCase):
                 "match_threshold": 0.5,
                 "max_width": 999,
                 "min_width": min_widths,
-                "top_pct": 0.0,
-                "height_pct": 1.0,
             }), patch.dict(
                 common.CFG["profiles"]["aoe1de"]["resource_panel"],
                 {"icon_trim_pct": [0] * 6},

--- a/tests/test_resource_rois.py
+++ b/tests/test_resource_rois.py
@@ -130,8 +130,6 @@ class TestResourceROIs(TestCase):
                 "match_threshold": 0.5,
                 "max_width": 999,
                 "min_width": 0,
-                "top_pct": 0.0,
-                "height_pct": 1.0,
             },
         ), patch.dict(
             common.CFG["profiles"]["aoe1de"]["resource_panel"],
@@ -237,8 +235,6 @@ class TestResourceROIs(TestCase):
                 "match_threshold": 0.5,
                 "max_width": 999,
                 "min_width": 0,
-                "top_pct": 0.0,
-                "height_pct": 1.0,
             }), patch.dict(
                 common.CFG["profiles"]["aoe1de"]["resource_panel"],
                 {"icon_trim_pct": [0] * 6},
@@ -285,8 +281,6 @@ class TestResourceROIs(TestCase):
                 "match_threshold": 0.5,
                 "max_width": 999,
                 "min_width": min_width,
-                "top_pct": 0.0,
-                "height_pct": 1.0,
             }), patch.dict(
                 common.CFG["profiles"]["aoe1de"]["resource_panel"],
                 {"icon_trim_pct": [0] * 6},
@@ -336,8 +330,6 @@ class TestResourceROIs(TestCase):
                 "match_threshold": 0.5,
                 "max_width": max_widths,
                 "min_width": 0,
-                "top_pct": 0.0,
-                "height_pct": 1.0,
             }), patch.dict(
                 common.CFG["profiles"]["aoe1de"]["resource_panel"],
                 {"icon_trim_pct": [0] * 6},
@@ -427,8 +419,6 @@ class TestResourceROIs(TestCase):
                         "match_threshold": 0.5,
                         "max_width": 999,
                         "min_width": 0,
-                        "top_pct": 0.0,
-                        "height_pct": 1.0,
                     },
                 ), patch.dict(
                     common.CFG["profiles"]["aoe1de"]["resource_panel"],


### PR DESCRIPTION
## Summary
- derive resource panel ROI from detected icon positions instead of config percentages
- update ROI tests to drop dependence on `top_pct` and `height_pct`

## Testing
- `pytest tests/test_wood_stockpile_ocr.py::TestWoodStockpileOCR::test_wood_stockpile_detects_300 -q` *(fails: RuntimeError: Invalid Tesseract OCR path)*
- `pytest -q` *(fails: many tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b7cb6655c0832580e93ea394d763ab