### PR TITLE
Avoid expanding resource ROIs into icons

### DIFF
--- a/tests/resource_rois/test_compute_rois.py
+++ b/tests/resource_rois/test_compute_rois.py
@@ -9,7 +9,7 @@ import script.screen_utils as screen_utils
 
 
 class TestComputeResourceROIs(TestCase):
-    def test_build_rois_reduce_width_when_gap_below_min(self):
+    def test_build_rois_reports_narrow_without_expansion(self):
         detected = {
             "wood_stockpile": (0, 0, 5, 5),
             "food_stockpile": (15, 0, 5, 5),
@@ -31,12 +31,11 @@ class TestComputeResourceROIs(TestCase):
         roi = regions["wood_stockpile"]
         span_left = 7  # icon_right + pad_left
         span_right = 13  # next_icon_left - pad_right
-        pad_extra = int(round(detected["wood_stockpile"][2] * 0.25))
-        self.assertEqual(roi[0], span_left - pad_extra)
-        self.assertEqual(roi[0] + roi[2], span_right + pad_extra)
-        self.assertEqual(roi[2], span_right - span_left + 2 * pad_extra)
+        self.assertEqual(roi[0], span_left)
+        self.assertEqual(roi[0] + roi[2], span_right)
+        self.assertEqual(roi[2], span_right - span_left)
         self.assertIn("wood_stockpile", narrow)
-        self.assertEqual(narrow["wood_stockpile"], 22)
+        self.assertEqual(narrow["wood_stockpile"], 24)
 
     def test_ignores_non_positive_span(self):
         detected = {

--- a/tests/resource_rois/test_consecutive_spacing.py
+++ b/tests/resource_rois/test_consecutive_spacing.py
@@ -1,6 +1,7 @@
-import script.resources as resources
 from unittest import TestCase
 from unittest.mock import patch
+
+import script.resources as resources
 
 
 class TestConsecutiveIconSpacing(TestCase):
@@ -71,8 +72,8 @@ class TestConsecutiveIconSpacing(TestCase):
             cur_x, _cy, cur_w, _ch = detected[cur]
             cur_right = panel_left + cur_x + cur_w
             next_left = panel_left + detected[nxt][0]
-            idle_pad = 6 if cur == "population_limit" and nxt == "idle_villager" else 0
-            available = (next_left - pad[0] - idle_pad) - (cur_right + pad[0])
+            available = (next_left - pad[0]) - (cur_right + pad[0])
             if available < min_span:
                 expected_narrow.add(cur)
         self.assertEqual(set(narrow.keys()), expected_narrow)
+


### PR DESCRIPTION
## Summary
- stop stretching resource ROIs inside icon bounds when gaps are narrow
- simplify fallback ROI generation and ignore narrow-span tracking
- update ROI spacing tests to match non-expanding behaviour

## Testing
- `pytest tests/resource_rois/test_compute_rois.py::TestComputeResourceROIs::test_build_rois_reports_narrow_without_expansion -q`
- `pytest tests/resource_rois/test_consecutive_spacing.py::TestConsecutiveIconSpacing::test_spans_and_narrow_flags -q`
- `pytest -q` *(fails: TesseractNotFoundError: /usr/bin/tesseract is not installed or it's not in your PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68b89b64070c8325b96c3ade5fdebb02