### PR TITLE
Adjust resource ROI vertical alignment

### DIFF
--- a/script/resources/panel/calibration.py
+++ b/script/resources/panel/calibration.py
@@ -49,8 +49,10 @@ def _auto_calibrate_from_icons(frame, cache_obj: cache.ResourceCache = cache.RES
         for name, (x, y, w, h) in detected.items()
     }
 
-    top = panel_top + int(cfg.top_pct * panel_height)
-    height = int(cfg.height_pct * panel_height)
+    min_y = min(y for _x, y, _w, _h in detected_rel.values())
+    max_y = max(y + h for _x, y, _w, h in detected_rel.values())
+    top = panel_top + min_y
+    height = max_y - min_y
 
     regions, spans, narrow = compute_resource_rois(
         panel_left,

--- a/script/resources/panel/detection.py
+++ b/script/resources/panel/detection.py
@@ -107,12 +107,11 @@ def locate_resource_panel(frame, cache_obj: cache.ResourceCache = cache.RESOURCE
     if detected:
         min_y = min(v[1] for v in detected.values())
         max_y = max(v[1] + v[3] for v in detected.values())
+        top = y + min_y
+        height = max_y - min_y
     else:
-        min_y = int(cfg.top_pct * h)
-        max_y = min_y + int(cfg.height_pct * h)
-
-    top = y + min_y
-    height = max_y - min_y
+        top = y + int(cfg.top_pct * h)
+        height = int(cfg.height_pct * h)
 
     regions, spans, narrow = compute_resource_rois(
         x,

--- a/tests/test_idle_villager_roi.py
+++ b/tests/test_idle_villager_roi.py
@@ -111,7 +111,9 @@ class TestIdleVillagerROI(TestCase):
             "width_pct": 0.04,
             "height_pct": 0.05,
         }
-        with patch("script.resources.panel.locate_resource_panel", return_value=detected), \
+        with patch.object(resources, "locate_resource_panel", return_value=detected), \
+            patch.object(resources.panel, "locate_resource_panel", return_value=detected), \
+            patch.object(resources.panel.detection, "locate_resource_panel", return_value=detected), \
             patch.dict(resources.CFG, {"idle_villager_roi": cfg}, clear=False), \
             patch.object(common, "HUD_ANCHOR", None):
             regions = resources.detect_resource_regions(frame, ["idle_villager"])


### PR DESCRIPTION
## Summary
- align resource ROIs to individual icon positions
- pass correct panel top to ROI computations
- update tests for new ROI bounds

## Testing
- `pytest tests/resource_rois/test_compute_rois.py tests/test_fallback_rois_from_slice.py tests/test_idle_villager_roi.py tests/test_population_roi_bounds.py -q`
- `pytest` *(fails: missing dependencies such as pytesseract, mss)*

------
https://chatgpt.com/codex/tasks/task_e_68b89da36e208325ac5dc336e42f66af