### PR TITLE
Refine population ROI boundary tests

### DIFF
--- a/tests/test_population_limit_fallback.py
+++ b/tests/test_population_limit_fallback.py
@@ -158,7 +158,7 @@ def test_population_roi_expansion_respects_idle_villager_boundary():
     mock_read_fn = patch("script.resources.ocr.executor._read_population_from_roi", side_effect=fake_read)
     with patch.dict(
         resources.common.CFG,
-        {"population_ocr_roi_expand_base": 50},
+        {"population_ocr_roi_expand_base": 50, "population_idle_padding": 6},
         clear=False,
     ), mock_read_fn as mock_exec, patch(
         "script.resources.reader.roi._read_population_from_roi",
@@ -177,5 +177,9 @@ def test_population_roi_expansion_respects_idle_villager_boundary():
 
     assert expansion["res"] is not None
     x0 = expansion["res"][3]
+    y0 = expansion["res"][4]
     width = expansion["res"][5]
-    assert x0 + width <= regions["idle_villager"][0]
+    height = expansion["res"][6]
+    assert x0 + width <= regions["idle_villager"][0] - 6
+    assert y0 == regions["population_limit"][1]
+    assert height == regions["population_limit"][3]

--- a/tests/test_population_roi.py
+++ b/tests/test_population_roi.py
@@ -179,6 +179,7 @@ class TestPopulationROI(TestCase):
         frame = np.zeros((40, 40, 3), dtype=np.uint8)
         bbox = {"left": 10, "top": 10, "width": 4, "height": 4}
         widths = []
+        bboxes = []
 
         def fake_grab(bbox=None):
             if bbox is None:
@@ -193,6 +194,7 @@ class TestPopulationROI(TestCase):
 
         def fake_pop(roi, conf_threshold=None, roi_bbox=None, failure_count=0):
             widths.append(roi.shape[1])
+            bboxes.append(roi_bbox)
             if roi.shape[1] <= 4:
                 raise common.PopulationReadError("tight")
             return 12, 34, False
@@ -218,6 +220,10 @@ class TestPopulationROI(TestCase):
         self.assertFalse(low_conf)
         self.assertEqual((cur, cap), (12, 34))
         self.assertGreater(widths[1], widths[0])
+        self.assertEqual(bboxes[0][1], bbox["top"])
+        self.assertEqual(bboxes[0][3], bbox["height"])
+        self.assertEqual(bboxes[1][1], bbox["top"])
+        self.assertEqual(bboxes[1][3], bbox["height"])
         self.assertEqual(
             resources.RESOURCE_CACHE.resource_failure_counts.get("population_limit"),
             0,
@@ -270,6 +276,10 @@ class TestPopulationROI(TestCase):
         self.assertEqual(bboxes[0][0] + bboxes[0][2], initial_right)
         self.assertEqual(bboxes[1][0] + bboxes[1][2], initial_right)
         self.assertLess(bboxes[1][0], bbox["left"])
+        self.assertEqual(bboxes[0][1], bbox["top"])
+        self.assertEqual(bboxes[0][3], bbox["height"])
+        self.assertEqual(bboxes[1][1], bbox["top"])
+        self.assertEqual(bboxes[1][3], bbox["height"])
 
     def test_population_string_with_slash(self):
         roi = np.zeros((10, 10, 3), dtype=np.uint8)

--- a/tests/test_population_roi_bounds.py
+++ b/tests/test_population_roi_bounds.py
@@ -113,8 +113,12 @@ class TestPopulationROIBounds(TestCase):
 
         assert expansion["res"] is not None
         x0 = expansion["res"][3]
+        y0 = expansion["res"][4]
         width = expansion["res"][5]
+        height = expansion["res"][6]
         assert x0 + width <= regions["idle_villager"][0] - 6
+        assert y0 == regions["population_limit"][1]
+        assert height == regions["population_limit"][3]
 
     def test_expansion_grows_equally_for_missing_slash(self):
         frame = np.zeros((20, 200, 3), dtype=np.uint8)
@@ -169,9 +173,13 @@ class TestPopulationROIBounds(TestCase):
         res = expansion["res"]
         assert res is not None
         x0 = res[3]
+        y0 = res[4]
         width = res[5]
-        orig_x, _oy, orig_w, _oh = regions["population_limit"]
+        height = res[6]
+        orig_x, orig_y, orig_w, orig_h = regions["population_limit"]
         left_expand = orig_x - x0
         right_expand = x0 + width - (orig_x + orig_w)
         assert abs(left_expand - right_expand) <= 1
         assert width >= 66
+        assert y0 == orig_y
+        assert height == orig_h


### PR DESCRIPTION
## Summary
- tighten resource ROI tests to ensure regions stay within icon bounds
- expect population ROI expansion to preserve icon-aligned top/height
- add coverage for narrow population ROIs respecting idle villager padding

## Testing
- `pytest` *(fails: assertion height == 10)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a299dcbc8325b624d626ca9a957a