### PR TITLE
Refactor resource panel ROI boundaries

### DIFF
--- a/tests/resource_rois/test_consecutive_spacing.py
+++ b/tests/resource_rois/test_consecutive_spacing.py
@@ -56,8 +56,8 @@ class TestConsecutiveIconSpacing(TestCase):
             cur_x, _cy, cur_w, _ch = detected[cur]
             cur_right = panel_left + cur_x + cur_w
             next_left = panel_left + detected[nxt][0]
-            self.assertGreaterEqual(span_left, cur_right)
-            self.assertLessEqual(span_right, next_left)
+            self.assertEqual(span_left, cur_right)
+            self.assertEqual(span_right, next_left)
 
         # idle villager span remains within its icon
         idle_left, idle_right = spans["idle_villager"]


### PR DESCRIPTION
## Summary
- compute resource ROIs by spanning full gap between consecutive icons
- remove padding and max-width clamps, only warn on narrow spans
- adjust population ROI to end at idle villager icon
- derive ROI vertical bounds from current/next icon union
- update tests for new ROI behavior and optional config lists

## Testing
- `pytest tests/resource_rois/test_compute_rois.py tests/resource_rois/test_consecutive_spacing.py tests/test_compute_resource_rois_empty_lists.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2'; TesseractNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ad13dc2c832598f1635773085a19