### PR TITLE
Remove population idle padding subtraction

### DIFF
--- a/config.json
+++ b/config.json
@@ -57,7 +57,7 @@
     "//population_ocr_roi_expand_step": "Additional pixels to grow the population ROI per consecutive failure.",
     "population_ocr_roi_expand_growth": 2.0,
     "//population_ocr_roi_expand_growth": "Exponent controlling population ROI growth rate; >1 grows faster.",
-    "population_idle_padding": 6,
+    "population_idle_padding": 0,
     "//population_idle_padding": "Pixels to keep between population ROI and idle villager icon.",
     "idle_icon_inner_trim": 0,
     "//idle_icon_inner_trim": "Pixels to trim inside the idle villager icon ROI on each side; total trim is capped at 50% of the icon width.",

--- a/config.sample.json
+++ b/config.sample.json
@@ -63,7 +63,7 @@
     "//population_ocr_roi_expand_step": "Additional pixels to grow the population ROI per consecutive failure.",
     "population_ocr_roi_expand_growth": 2.0,
     "//population_ocr_roi_expand_growth": "Exponent controlling population ROI growth rate; >1 grows faster.",
-    "population_idle_padding": 6,
+    "population_idle_padding": 0,
     "//population_idle_padding": "Pixels to keep between population ROI and idle villager icon.",
     "idle_icon_inner_trim": 0,
     "//idle_icon_inner_trim": "Pixels to trim inside the idle villager icon ROI on each side; total trim is capped at 50% of the icon width.",

--- a/script/hud.py
+++ b/script/hud.py
@@ -91,7 +91,7 @@ def read_population_from_hud(retries=1, conf_threshold=None, save_failed_roi=Fal
     if idle_bounds and "population_limit" in regions:
         left, top, width, height = regions["population_limit"]
         idle_left = idle_bounds[0]
-        clamp_right = idle_left - CFG.get("population_idle_padding", 6)
+        clamp_right = idle_left - CFG.get("population_idle_padding", 0)
         if clamp_right < left + width:
             width = max(0, clamp_right - left)
             regions["population_limit"] = (left, top, width, height)

--- a/script/resources/ocr/executor.py
+++ b/script/resources/ocr/executor.py
@@ -835,7 +835,7 @@ def _extract_population(
             low_conf = getattr(exc, "low_conf", False)
             low_conf_digits = getattr(exc, "low_conf_digits", None)
             max_right = (
-                regions["idle_villager"][0] - CFG.get("population_idle_padding", 6)
+                regions["idle_villager"][0] - CFG.get("population_idle_padding", 0)
                 if "idle_villager" in regions
                 else None
             )

--- a/tests/resource_rois/test_compute_rois.py
+++ b/tests/resource_rois/test_compute_rois.py
@@ -189,24 +189,29 @@ class TestComputeResourceROIs(TestCase):
             "idle_villager": (15, 0, 5, 5),
         }
         min_pop_width = 10
-        with patch.dict(resources.CFG, {"population_idle_padding": 6}, clear=False):
-            regions, _spans, narrow = resources.compute_resource_rois(
-                0,
-                40,
-                0,
-                10,
-                [0] * 6,
-                [0] * 6,
-                [0] * 6,
-                [999] * 6,
-                [0] * 6,
-                min_pop_width,
-                0,
-                [0] * 6,
-                detected=detected,
-            )
+        regions, _spans, narrow = resources.compute_resource_rois(
+            0,
+            40,
+            0,
+            10,
+            [0] * 6,
+            [0] * 6,
+            [0] * 6,
+            [999] * 6,
+            [0] * 6,
+            min_pop_width,
+            0,
+            [0] * 6,
+            detected=detected,
+        )
         roi = regions["population_limit"]
-        self.assertEqual(roi, (5, 0, 10, 5))
+        left, top, width, height = roi
+        idle_left = detected["idle_villager"][0]
+        self.assertEqual(left, 5)
+        self.assertEqual(top, 0)
+        self.assertEqual(width, 10)
+        self.assertEqual(height, 5)
+        self.assertEqual(left + width, idle_left)
         self.assertIn("population_limit", narrow)
         self.assertEqual(narrow["population_limit"], 20)
 

--- a/tests/test_resource_rois.py
+++ b/tests/test_resource_rois.py
@@ -95,7 +95,6 @@ class TestResourceROIs(TestCase):
             icon_y_positions if icon_y_positions is not None else [0] * len(self.positions)
         )
         x_positions = list(self.positions)
-        x_positions[-1] -= common.CFG.get("population_idle_padding", 6)
         loc_iter = iter(zip(x_positions, y_positions))
 
         def fake_minmax(res):
@@ -161,8 +160,6 @@ class TestResourceROIs(TestCase):
         next_icon_left = self.panel_box[0] + self.positions[index + 1]
         expected_left = icon_right
         expected_right = next_icon_left
-        if name == "population_limit":
-            expected_right = next_icon_left - common.CFG.get("population_idle_padding", 6)
         self.assertEqual(left, expected_left, f"{name} left not at icon boundary")
         self.assertEqual(right, expected_right, f"{name} right not at next icon boundary")
 


### PR DESCRIPTION
## Summary
- default `population_idle_padding` to zero so population ROI extends to the idle icon
- clamp helpers now assume zero padding
- update tests to expect population ROI right edge at idle icon

## Testing
- `pytest tests/test_resource_rois.py tests/resource_rois/test_compute_rois.py`
- `pytest` *(fails: cv2.error in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b240a18c8325a332613ef6aeb927