### PR TITLE
Improve food ROI and OCR debugging

### DIFF
--- a/script/resources/panel/roi.py
+++ b/script/resources/panel/roi.py
@@ -42,6 +42,7 @@ def compute_resource_rois(
     # Offset from icon-relative coordinates to absolute screen coordinates
     min_y = min(v[1] for v in detected.values())
     panel_top = top - min_y
+    panel_bottom = top + height
 
     regions = {}
     spans = {}
@@ -132,7 +133,11 @@ def compute_resource_rois(
         roi_y = min(cur_y, next_y)
         roi_bottom = max(cur_y + cur_h, next_y + next_h)
         roi_top = panel_top + roi_y
-        roi_height = roi_bottom - roi_y
+        abs_bottom = panel_top + roi_bottom
+        if current == "food_stockpile":
+            roi_top = max(top, roi_top - 1)
+            abs_bottom = min(panel_bottom, abs_bottom + 1)
+        roi_height = abs_bottom - roi_top
 
         regions[current] = (left, roi_top, width, roi_height)
         logger.debug(

--- a/script/resources/reader/core.py
+++ b/script/resources/reader/core.py
@@ -112,8 +112,9 @@ def _ocr_resource(
         )
         return digits, data, mask, low_conf
 
+    _ret, gray_proc = cv2.threshold(gray, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
     digits, data, mask, low_conf = execute_ocr(
-        gray,
+        gray_proc,
         color=roi,
         conf_threshold=res_conf_threshold,
         roi=roi_bbox,
@@ -550,6 +551,7 @@ def _process_resource(
         debug_dir.mkdir(exist_ok=True)
         ts = int(time.time() * 1000)
         cv2.imwrite(str(debug_dir / f"resource_{name}_roi_{ts}.png"), roi)
+        cv2.imwrite(str(debug_dir / f"resource_{name}_gray_{ts}.png"), gray)
         if mask is not None:
             cv2.imwrite(str(debug_dir / f"resource_{name}_thresh_{ts}.png"), mask)
     value, cache_hit, low_conf_flag, no_digit_flag = _handle_cache_and_fallback(

--- a/tests/test_food_stockpile_ocr.py
+++ b/tests/test_food_stockpile_ocr.py
@@ -79,6 +79,25 @@ class TestFoodStockpileOCR(TestCase):
         self.assertGreaterEqual(max(confs), threshold)
         self.assertFalse(low_conf)
 
+    def test_food_stockpile_detects_999_yellow_digits(self):
+        roi = np.full((60, 150, 3), (50, 50, 50), dtype=np.uint8)
+        cv2.putText(
+            roi,
+            "999",
+            (10, 45),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            1.5,
+            (0, 255, 255),
+            2,
+            cv2.LINE_AA,
+        )
+        gray = preprocess_roi(roi)
+        digits, data, _mask, low_conf = execute_ocr(
+            gray, color=roi, resource="food_stockpile"
+        )
+        self.assertEqual(digits, "999")
+        self.assertFalse(low_conf)
+
     def test_full_match_preferred_over_shorter_when_confidences_close(self):
         masks = [np.zeros((1, 1), dtype=np.uint8), np.zeros((1, 1), dtype=np.uint8)]
         psms = [6]

--- a/tests/test_resource_rois.py
+++ b/tests/test_resource_rois.py
@@ -211,7 +211,21 @@ class TestResourceROIs(TestCase):
     def test_food_stockpile_roi_vertical_bounds(self):
         y_positions = [0, 2, 4, 1, 3, 5]
         regions, _ = self._locate_regions(icon_y_positions=y_positions)
-        self._assert_vertical_bounds(regions, 1)
+        name = self.icons[1]
+        roi = regions[name]
+        top = roi[1]
+        height = roi[3]
+        bottom = top + height
+
+        icon_y = self.panel_box[1] + y_positions[1]
+        icon_bottom = icon_y + self.icon_height
+        next_icon_y = self.panel_box[1] + y_positions[2]
+        next_icon_bottom = next_icon_y + self.icon_height
+        expected_top = min(icon_y, next_icon_y)
+        expected_bottom = max(icon_bottom, next_icon_bottom)
+
+        self.assertLessEqual(top, expected_top)
+        self.assertGreaterEqual(bottom, expected_bottom)
 
     def test_gold_stockpile_roi_vertical_bounds(self):
         y_positions = [0, 2, 4, 1, 3, 5]


### PR DESCRIPTION
## Summary
- extend food stockpile ROI vertically to avoid clipping three-digit values
- run Otsu thresholding during OCR and save grayscale snapshots when debug is enabled
- test yellow three-digit food values and presence of debug images

## Testing
- `pytest tests/test_food_stockpile_ocr.py::TestFoodStockpileOCR::test_food_stockpile_detects_999_yellow_digits -q`
- `pytest tests/test_resource_rois.py -q`
- `pytest tests/test_resource_debug_images.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8c25a8f3083258358733adc84e11c