### PR TITLE
Allow configuring starting resource tolerance

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,19 @@ initial numbers, set `skip_starting_resource_validation` to `true` in
 resource readings, allowing you to troubleshoot without blocking mission
 progress.
 
+To loosen the check instead of skipping it, configure
+`resource_validation_tolerance` in `config.json`:
+
+```json
+"resource_validation_tolerance": {
+  "initial": 10,
+  "increment": 5
+}
+```
+
+Validation begins with a ±`initial` margin and expands by `increment` after
+each failed attempt, up to `initial + increment`.
+
 ### Manual ROI overrides
 
 Automatic ROI detection may fail on unusual HUD layouts. Optional sections in

--- a/campaign.py
+++ b/campaign.py
@@ -100,9 +100,11 @@ def main():
             res_tolerances = common.CFG.get("resource_validation_tolerances", {})
             if non_zero and not skip_validation:
                 retry_limit = common.CFG.get("resource_validation_retries", 3)
-                tolerance = 10
-                max_tolerance = 15
-                relaxed_threshold = 20
+                tol_cfg = common.CFG.get("resource_validation_tolerance", {})
+                tolerance = tol_cfg.get("initial", 10)
+                increment = tol_cfg.get("increment", 5)
+                max_tolerance = tolerance + increment
+                relaxed_threshold = tolerance + 2 * increment
                 attempt = 1
                 while True:
                     frame = screen_utils._grab_frame()
@@ -156,7 +158,7 @@ def main():
                             else:
                                 raise
                         attempt += 1
-                        tolerance = min(max_tolerance, tolerance + 5)
+                        tolerance = min(max_tolerance, tolerance + increment)
                         low_conf = resources.RESOURCE_CACHE.last_low_confidence
                         no_digits = resources.RESOURCE_CACHE.last_no_digits
                         for k in e.failing_keys:

--- a/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
+++ b/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
@@ -75,9 +75,14 @@ def main() -> None:
     res_vals, (cur_pop, pop_cap) = pop_check
 
     # Validação dos recursos iniciais
+    tol_cfg = common.CFG.get("resource_validation_tolerance", {})
+    tolerance = tol_cfg.get("initial", 10)
     try:
         resources.validate_starting_resources(
-            res_vals, info.starting_resources, raise_on_error=True
+            res_vals,
+            info.starting_resources,
+            tolerance=tolerance,
+            raise_on_error=True,
         )
     except resources.ResourceValidationError as exc:
         logger.error("Erro na validação dos recursos iniciais: %s", exc)

--- a/config.json
+++ b/config.json
@@ -87,6 +87,7 @@
   "resource_cache_ttl": 1.5,
   "resource_cache_max_age": null,
   "resource_cache_tolerance": 100,
+  "resource_validation_tolerance": {"initial": 10, "increment": 5},
   "disable_roi_overrides_on_calibration": false,
   "roi_variance_threshold": 5,
   "keys": {


### PR DESCRIPTION
## Summary
- make starting resource tolerance and increment configurable via `resource_validation_tolerance`
- use configured values in campaign launcher and Egypt 1 mission
- document `resource_validation_tolerance` in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b8c816a5b48325849058dadfcda987