### PR TITLE
Handle food cache mismatch

### DIFF
--- a/script/resources/reader/core.py
+++ b/script/resources/reader/core.py
@@ -442,18 +442,21 @@ def _handle_cache_and_fallback(
         if CFG.get(fallback_key, False) and name in cache_obj.last_resource_values:
             cached_val = cache_obj.last_resource_values[name]
             tol = CFG.get("resource_cache_tolerance", 100)
-            expected = CFG.get("starting_resources", {}).get(name)
-            compare = value if digits is not None else expected
-            if compare is not None and abs(cached_val - compare) > tol:
+            reference = (
+                int(digits)
+                if digits is not None
+                else CFG.get("starting_resources", {}).get(name)
+            )
+            if reference is not None and abs(cached_val - reference) > tol:
                 logger.warning(
                     "Discarding cached value for %s due to mismatch with %d",
                     name,
-                    compare,
+                    reference,
                 )
-                cache_obj.last_resource_values[name] = compare if compare is not None else cached_val
+                cache_obj.last_resource_values[name] = reference
                 cache_obj.last_resource_ts[name] = time.time()
                 cache_obj.resource_failure_counts[name] = 0
-                return compare, False, False, no_digit_flag
+                return reference, False, False, no_digit_flag
             cache_hit = True
             value = cached_val
             logger.warning(


### PR DESCRIPTION
## Summary
- verify cached food values against newly read digits or starting resources before falling back
- add test to ensure stale food cache is ignored when delta exceeds tolerance

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pytest tests/test_food_stockpile_ocr.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8d99f8dc08325b1d82fb772c9a31e