### PR TITLE
Implement centralized resource cache reset

### DIFF
--- a/campaign.py
+++ b/campaign.py
@@ -76,9 +76,7 @@ def main():
         idle_start = getattr(info, "starting_idle_villagers", info.starting_villagers)
 
         # Reset resource cache to prevent stale OCR values across scenarios
-        resources.RESOURCE_CACHE.last_resource_values.clear()
-        resources.RESOURCE_CACHE.last_resource_ts.clear()
-        resources.RESOURCE_CACHE.resource_failure_counts.clear()
+        resources.cache.reset()
 
         resources.RESOURCE_CACHE.last_resource_values["idle_villager"] = idle_start
         resources.RESOURCE_CACHE.last_resource_ts["idle_villager"] = time.time()

--- a/script/resources/cache.py
+++ b/script/resources/cache.py
@@ -50,6 +50,34 @@ _LAST_REGION_BOUNDS = None
 # Track last available spans for each region
 _LAST_REGION_SPANS: dict[str, tuple[int, int]] = {}
 
+
+def reset(cache_obj: ResourceCache = RESOURCE_CACHE) -> None:
+    """Clear cached resource detection state.
+
+    Parameters
+    ----------
+    cache_obj:
+        The :class:`ResourceCache` instance to reset. Defaults to the module's
+        shared :data:`RESOURCE_CACHE`.
+    """
+
+    cache_obj.last_icon_bounds.clear()
+    cache_obj.last_resource_values.clear()
+    cache_obj.last_resource_ts.clear()
+    cache_obj.resource_failure_counts.clear()
+    cache_obj.last_debug_image_ts.clear()
+    cache_obj.last_debug_failure_set.clear()
+    cache_obj.last_debug_failure_ts = None
+    cache_obj.last_low_confidence.clear()
+    cache_obj.last_no_digits.clear()
+
+    _LAST_READ_FROM_CACHE.clear()
+    _NARROW_ROIS.clear()
+    _NARROW_ROI_DEFICITS.clear()
+    global _LAST_REGION_BOUNDS
+    _LAST_REGION_BOUNDS = None
+    _LAST_REGION_SPANS.clear()
+
 __all__ = [
     "ResourceCache",
     "RESOURCE_CACHE",
@@ -61,4 +89,5 @@ __all__ = [
     "_RESOURCE_DEBUG_COOLDOWN",
     "_LAST_REGION_BOUNDS",
     "_LAST_REGION_SPANS",
+    "reset",
 ]


### PR DESCRIPTION
## Summary
- add `reset` helper to clear `ResourceCache` and global state
- call `reset` when starting campaign instead of manual clears

## Testing
- `pytest` *(fails: 113 failed, 138 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f03e5a3c83259132d280898c1ce1