### PR TITLE
Rename load_icon_templates utility

### DIFF
--- a/script/resources/panel/calibration.py
+++ b/script/resources/panel/calibration.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 def _auto_calibrate_from_icons(frame, cache_obj: cache.ResourceCache = cache.RESOURCE_CACHE):
     """Locate resource icons directly on the frame to derive ROI regions."""
 
-    screen_utils._load_icon_templates()
+    screen_utils.load_icon_templates()
     gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
 
     cfg = _get_resource_panel_cfg()

--- a/script/resources/panel/detection.py
+++ b/script/resources/panel/detection.py
@@ -66,7 +66,7 @@ def locate_resource_panel(frame, cache_obj: cache.ResourceCache = cache.RESOURCE
     panel_gray = cv2.cvtColor(frame[y : y + h, x : x + w], cv2.COLOR_BGR2GRAY)
 
     cfg = _get_resource_panel_cfg()
-    screen_utils._load_icon_templates()
+    screen_utils.load_icon_templates()
 
     detected = {}
     for name in RESOURCE_ICON_ORDER:

--- a/script/screen_utils.py
+++ b/script/screen_utils.py
@@ -83,7 +83,7 @@ if "idle_villager" not in ICON_NAMES:
 ICON_TEMPLATES = {}
 
 
-def _load_icon_templates():
+def load_icon_templates():
     for name in ICON_NAMES:
         if name in ICON_TEMPLATES:
             continue
@@ -93,3 +93,15 @@ def _load_icon_templates():
             logger.warning("Icon asset missing: %s", path)
             continue
         ICON_TEMPLATES[name] = icon
+
+
+__all__ = [
+    "mss_session",
+    "init_sct",
+    "teardown_sct",
+    "get_monitor",
+    "load_icon_templates",
+    "HUD_TEMPLATE",
+    "ICON_NAMES",
+    "ICON_TEMPLATES",
+]

--- a/tests/resource_rois/test_calibration.py
+++ b/tests/resource_rois/test_calibration.py
@@ -75,7 +75,7 @@ class TestCalibration(TestCase):
             captured["args"] = args
             return {}, {}, {}
 
-        with patch.object(screen_utils, "_load_icon_templates", lambda: None), \
+        with patch.object(screen_utils, "load_icon_templates", lambda: None), \
             patch(
                 "script.resources.panel.calibration._get_resource_panel_cfg",
                 return_value=cfg_obj,

--- a/tests/resource_rois/test_compute_rois.py
+++ b/tests/resource_rois/test_compute_rois.py
@@ -82,7 +82,7 @@ class TestComputeResourceROIs(TestCase):
             patch("script.resources.cv2.resize", lambda img, *a, **k: img), \
             patch("script.resources.cv2.matchTemplate", lambda *a, **k: np.zeros((100, 200), dtype=np.float32)), \
             patch("script.resources.cv2.minMaxLoc", side_effect=fake_minmax), \
-            patch.object(screen_utils, "_load_icon_templates", lambda: None), \
+              patch.object(screen_utils, "load_icon_templates", lambda: None), \
             patch.object(screen_utils, "HUD_TEMPLATE", np.zeros((1, 1), dtype=np.uint8)), \
             patch.dict(screen_utils.ICON_TEMPLATES, {name: np.zeros((5, 5), dtype=np.uint8) for name in icons}, clear=True), \
             patch.dict(common.CFG["resource_panel"], {

--- a/tests/test_compute_resource_rois_empty_lists.py
+++ b/tests/test_compute_resource_rois_empty_lists.py
@@ -38,7 +38,7 @@ sys.modules.setdefault("pyautogui", types.SimpleNamespace())
 sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: None))
 sys.modules.setdefault(
     "script.screen_utils",
-    types.SimpleNamespace(ICON_TEMPLATES={}, HUD_TEMPLATE=None, _load_icon_templates=lambda: None),
+    types.SimpleNamespace(ICON_TEMPLATES={}, HUD_TEMPLATE=None, load_icon_templates=lambda: None),
 )
 sys.modules.setdefault(
     "script.common",

--- a/tests/test_population_limit_fallback.py
+++ b/tests/test_population_limit_fallback.py
@@ -69,7 +69,7 @@ def test_population_limit_fallback_estimates_width_with_padding():
     cfg = _make_cfg()
 
     with patch.object(detection, "detect_hud", return_value=((0, 0, 200, 20), 1.0)), \
-        patch.object(resources.screen_utils, "_load_icon_templates", lambda: None), \
+        patch.object(resources.screen_utils, "load_icon_templates", lambda: None), \
         patch.dict(resources.screen_utils.ICON_TEMPLATES, {"idle_villager": np.zeros((hi, wi), dtype=np.uint8)}, clear=True), \
         patch.object(resources.cv2, "cvtColor", lambda src, code: np.zeros(src.shape[:2], dtype=np.uint8)), \
         patch.object(resources.cv2, "resize", lambda img, *a, **k: img), \

--- a/tests/test_resource_min_required_width.py
+++ b/tests/test_resource_min_required_width.py
@@ -36,7 +36,7 @@ sys.modules.setdefault("pyautogui", types.SimpleNamespace())
 sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: None))
 sys.modules.setdefault(
     "script.screen_utils",
-    types.SimpleNamespace(ICON_TEMPLATES={}, HUD_TEMPLATE=None, _load_icon_templates=lambda: None),
+    types.SimpleNamespace(ICON_TEMPLATES={}, HUD_TEMPLATE=None, load_icon_templates=lambda: None),
 )
 sys.modules.setdefault(
     "script.common",

--- a/tests/test_resource_rois.py
+++ b/tests/test_resource_rois.py
@@ -118,7 +118,7 @@ class TestResourceROIs(TestCase):
         ), patch(
             "script.resources.cv2.minMaxLoc", side_effect=fake_minmax
         ), patch.object(
-            screen_utils, "_load_icon_templates", lambda: None
+            screen_utils, "load_icon_templates", lambda: None
         ), patch.object(
             screen_utils, "HUD_TEMPLATE", np.zeros((1, 1), dtype=np.uint8)
         ), patch.dict(
@@ -289,7 +289,7 @@ class TestResourceROIs(TestCase):
             patch("script.resources.cv2.resize", lambda img, *a, **k: img), \
             patch("script.resources.cv2.matchTemplate", lambda *a, **k: np.zeros((100, 200), dtype=np.float32)), \
             patch("script.resources.cv2.minMaxLoc", side_effect=fake_minmax), \
-            patch.object(screen_utils, "_load_icon_templates", lambda: None), \
+            patch.object(screen_utils, "load_icon_templates", lambda: None), \
             patch.object(screen_utils, "HUD_TEMPLATE", np.zeros((1, 1), dtype=np.uint8)), \
             patch.dict(screen_utils.ICON_TEMPLATES, {name: np.zeros((5, 5), dtype=np.uint8) for name in icons}, clear=True), \
             patch.dict(common.CFG["resource_panel"], {
@@ -335,7 +335,7 @@ class TestResourceROIs(TestCase):
             patch("script.resources.cv2.resize", lambda img, *a, **k: img), \
             patch("script.resources.cv2.matchTemplate", lambda *a, **k: np.zeros((100, 200), dtype=np.float32)), \
             patch("script.resources.cv2.minMaxLoc", side_effect=fake_minmax), \
-            patch.object(screen_utils, "_load_icon_templates", lambda: None), \
+              patch.object(screen_utils, "load_icon_templates", lambda: None), \
             patch.object(screen_utils, "HUD_TEMPLATE", np.zeros((1, 1), dtype=np.uint8)), \
             patch.dict(screen_utils.ICON_TEMPLATES, {name: np.zeros((5, 5), dtype=np.uint8) for name in icons}, clear=True), \
             patch.dict(common.CFG["resource_panel"], {
@@ -384,7 +384,7 @@ class TestResourceROIs(TestCase):
             patch("script.resources.cv2.resize", lambda img, *a, **k: img), \
             patch("script.resources.cv2.matchTemplate", lambda *a, **k: np.zeros((100, 200), dtype=np.float32)), \
             patch("script.resources.cv2.minMaxLoc", side_effect=fake_minmax), \
-            patch.object(screen_utils, "_load_icon_templates", lambda: None), \
+              patch.object(screen_utils, "load_icon_templates", lambda: None), \
             patch.object(screen_utils, "HUD_TEMPLATE", np.zeros((1, 1), dtype=np.uint8)), \
             patch.dict(screen_utils.ICON_TEMPLATES, {name: np.zeros((5, 5), dtype=np.uint8) for name in icons}, clear=True), \
             patch.dict(common.CFG["resource_panel"], {
@@ -469,7 +469,7 @@ class TestResourceROIs(TestCase):
                 patch("script.resources.cv2.resize", lambda img, *a, **k: img), \
                 patch("script.resources.cv2.matchTemplate", lambda *a, **k: np.zeros((100, 200), dtype=np.float32)), \
                 patch("script.resources.cv2.minMaxLoc", side_effect=fake_minmax), \
-                patch.object(screen_utils, "_load_icon_templates", lambda: None), \
+                patch.object(screen_utils, "load_icon_templates", lambda: None), \
                 patch.dict(
                     screen_utils.ICON_TEMPLATES,
                     {name: np.zeros((icon_size, icon_size), dtype=np.uint8) for name in self.icons},


### PR DESCRIPTION
## Summary
- rename `_load_icon_templates` to `load_icon_templates`
- expose `load_icon_templates` in `screen_utils.__all__`
- update imports and tests for new name

## Testing
- `pytest -q` *(fails: 134 failed, 117 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f187b9588325909765b07c52847b