### PR TITLE
Refactor PyAutoGUI setup into explicit function

### DIFF
--- a/campaign.py
+++ b/campaign.py
@@ -12,6 +12,7 @@ import script.hud as hud
 import script.resources.reader as resources
 import script.screen_utils as screen_utils
 from script.config_utils import parse_scenario_info
+from script.input_utils import configure_pyautogui
 
 
 def _calculate_next_tolerance(tolerance: int, increment: int, max_tolerance: int) -> int:
@@ -265,6 +266,7 @@ def main() -> None:
         format="%(asctime)s - %(levelname)s - %(message)s",
     )
     logger = logging.getLogger("campaign_bot")
+    configure_pyautogui()
 
     screen_utils.init_sct()
     try:

--- a/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
+++ b/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
@@ -43,6 +43,7 @@ def main() -> None:
     logger.info(
         "Enter the campaign mission (Hunting). The script starts when the HUD is detected…"
     )
+    input_utils.configure_pyautogui()
 
     try:
         anchor, asset = hud.wait_hud(timeout=90)

--- a/campaigns/Ascent_of_Egypt/Egypt_2_Foraging.py
+++ b/campaigns/Ascent_of_Egypt/Egypt_2_Foraging.py
@@ -18,6 +18,7 @@ import script.common as common
 import script.hud as hud
 import script.resources.reader as resources
 from script.config_utils import parse_scenario_info
+import script.input_utils as input_utils
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +39,7 @@ def main() -> None:
     logger.info(
         "Enter the campaign mission (Foraging). The script starts when the HUD is detected…"
     )
+    input_utils.configure_pyautogui()
 
     try:
         anchor, asset = hud.wait_hud(timeout=90)

--- a/script/input_utils.py
+++ b/script/input_utils.py
@@ -7,8 +7,22 @@ from . import screen_utils
 
 logger = logging.getLogger(__name__)
 
-pg.PAUSE = 0.05
-pg.FAILSAFE = True  # mouse no canto sup-esq aborta instantaneamente
+
+def configure_pyautogui(pause: float = 0.05, failsafe: bool = True) -> None:
+    """Configure global PyAutoGUI settings used by the bot.
+
+    Args:
+        pause (float): Delay applied after each PyAutoGUI call. Defaults to
+            ``0.05`` seconds.
+        failsafe (bool): Whether moving the cursor to the top-left corner
+            aborts automation. Defaults to ``True``.
+
+    Returns:
+        None
+    """
+
+    pg.PAUSE = pause
+    pg.FAILSAFE = failsafe  # mouse no canto sup-esq aborta instantaneamente
 
 
 def _screen_size() -> tuple[int, int]:


### PR DESCRIPTION
## Summary
- add `configure_pyautogui()` helper to set PyAutoGUI pause and fail-safe
- call `configure_pyautogui()` from campaign and scenario entry points

## Testing
- `pytest -q` *(fails: 135 failed, 122 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8fafca4248325a6ae367197c7f046