### PR TITLE
refactor: encapsulate screen capture

### DIFF
--- a/campaign.py
+++ b/campaign.py
@@ -268,7 +268,7 @@ def main() -> None:
     logger = logging.getLogger("campaign_bot")
     configure_pyautogui()
 
-    screen_utils.init_sct()
+    screen_utils.screen_capture.init_sct()
     try:
         logger.info(
             "Enter the campaign mission (%s). The script starts when the HUD is detected…",
@@ -357,7 +357,7 @@ def main() -> None:
             func()
         logger.info("Mission '%s' completed.", module_name)
     finally:
-        screen_utils.teardown_sct()
+        screen_utils.screen_capture.teardown_sct()
 
 
 if __name__ == "__main__":

--- a/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
+++ b/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
@@ -85,7 +85,7 @@ def main() -> None:
     # Validação dos recursos iniciais
     tol_cfg = common.CFG.get("resource_validation_tolerance", {})
     tolerance = tol_cfg.get("initial", 10)
-    frame = screen_utils.grab_frame()
+    frame = screen_utils.screen_capture.grab_frame()
     rois = getattr(resources, "_LAST_REGION_BOUNDS", {})
     try:
         resources.validate_starting_resources(

--- a/script/hud.py
+++ b/script/hud.py
@@ -35,7 +35,7 @@ def wait_hud(timeout=60):
         )
     last_score = -1.0
     while time.time() - t0 < timeout:
-        frame = screen_utils.grab_frame()
+        frame = screen_utils.screen_capture.grab_frame()
         box, score, heat = find_template(
             frame, tmpl, threshold=CFG["threshold"], scales=CFG["scales"]
         )
@@ -161,7 +161,7 @@ def read_population_from_hud(retries=1, conf_threshold=None, save_failed_roi=Fal
     if conf_threshold is None:
         conf_threshold = CFG.get("ocr_conf_threshold", 60)
 
-    frame_full = screen_utils.grab_frame()
+    frame_full = screen_utils.screen_capture.grab_frame()
     roi_bbox = calculate_population_roi(frame_full)
     try:
         cur, limit, low_conf = resources.read_population_from_roi(

--- a/script/resources/ocr/executor.py
+++ b/script/resources/ocr/executor.py
@@ -724,7 +724,7 @@ def read_population_from_roi(
     attempt_errors: list[common.PopulationReadError] = []
     last_exc = None
     for attempt in range(retries):
-        roi = screen_utils.grab_frame({"left": x, "top": y, "width": w, "height": h})
+        roi = screen_utils.screen_capture.grab_frame({"left": x, "top": y, "width": w, "height": h})
         try:
             cur_pop, pop_cap, low_conf = _read_population_from_roi(
                 roi,
@@ -750,7 +750,7 @@ def read_population_from_roi(
             failure_count = cache_obj.resource_failure_counts.get(
                 "population_limit", 0
             )
-            frame_full = screen_utils.grab_frame()
+            frame_full = screen_utils.screen_capture.grab_frame()
             try:
                 expansion = expand_population_roi_after_failure(
                     frame_full,

--- a/script/resources/reader/core.py
+++ b/script/resources/reader/core.py
@@ -804,7 +804,7 @@ def read_resources_from_hud(
     if force_delay is not None:
         time.sleep(force_delay)
 
-    frame = screen_utils.grab_frame()
+    frame = screen_utils.screen_capture.grab_frame()
 
     if required_icons is None:
         required_icons = list(RESOURCE_ICON_ORDER)
@@ -837,7 +837,7 @@ def gather_hud_stats(
     if force_delay is not None:
         time.sleep(force_delay)
 
-    frame = screen_utils.grab_frame()
+    frame = screen_utils.screen_capture.grab_frame()
 
     icon_cfg = CFG.get("hud_icons", {})
     provided_lists = not (required_icons is None and optional_icons is None)

--- a/tests/ocr_failures/test_debug_outputs.py
+++ b/tests/ocr_failures/test_debug_outputs.py
@@ -24,7 +24,7 @@ def test_discard_low_confidence_logged(caplog):
     resources.RESOURCE_CACHE.last_resource_values["wood_stockpile"] = 0
     with patch.dict(resources.CFG, {"wood_stockpile_low_conf_fallback": False}, clear=False), \
          patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
-        patch("script.screen_utils.grab_frame", side_effect=fake_grab_frame), \
+        patch("script.screen_utils.screen_capture.grab_frame", side_effect=fake_grab_frame), \
          patch("script.resources.ocr.masks._ocr_digits_better", side_effect=fake_ocr), \
          patch("script.resources.reader.pytesseract.image_to_string", return_value=""), \
          patch("script.resources.reader.cv2.imwrite"), \

--- a/tests/ocr_failures/test_failure_cache.py
+++ b/tests/ocr_failures/test_failure_cache.py
@@ -89,7 +89,7 @@ class TestFailureCache(TestCase):
         frame = np.zeros((600, 600, 3), dtype=np.uint8)
 
         with patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
-            patch("script.screen_utils.grab_frame", return_value=frame), \
+            patch("script.screen_utils.screen_capture.grab_frame", return_value=frame), \
              patch("script.resources.reader.execute_ocr", side_effect=fake_ocr), \
              patch("script.resources.reader.pytesseract.image_to_string", return_value=""), \
              patch("script.resources.reader.cv2.imwrite"):
@@ -115,7 +115,7 @@ class TestFailureCache(TestCase):
         frame = np.zeros((600, 600, 3), dtype=np.uint8)
 
         with patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
-            patch("script.screen_utils.grab_frame", return_value=frame), \
+            patch("script.screen_utils.screen_capture.grab_frame", return_value=frame), \
              patch("script.resources.reader.execute_ocr", side_effect=fake_ocr) as ocr_mock, \
              patch("script.resources.reader.pytesseract.image_to_string", return_value=""), \
              patch("script.resources.reader.cv2.imwrite"):
@@ -145,7 +145,7 @@ class TestFailureCache(TestCase):
             return "", {"text": [""]}, None, False
 
         with patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
-            patch("script.screen_utils.grab_frame", return_value=frame), \
+            patch("script.screen_utils.screen_capture.grab_frame", return_value=frame), \
              patch("script.resources.reader.preprocess_roi", side_effect=lambda roi: roi[..., 0]), \
              patch("script.resources.reader.execute_ocr", side_effect=fake_execute), \
              patch.dict(resources._LAST_REGION_SPANS, {"wood_stockpile": (0, 120)}, clear=True), \
@@ -172,7 +172,7 @@ class TestFailureCache(TestCase):
         )
 
         with patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
-            patch("script.screen_utils.grab_frame", return_value=frame), \
+            patch("script.screen_utils.screen_capture.grab_frame", return_value=frame), \
              patch("script.resources.reader.execute_ocr", side_effect=fake_ocr), \
              patch("script.resources.reader.pytesseract.image_to_string", return_value=""), \
              patch("script.resources.reader.cv2.imwrite"):
@@ -194,7 +194,7 @@ class TestFailureCache(TestCase):
 
         with patch.dict(resources.CFG, {"ocr_retry_limit": 2}, clear=False), \
              patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
-            patch("script.screen_utils.grab_frame", return_value=frame), \
+            patch("script.screen_utils.screen_capture.grab_frame", return_value=frame), \
              patch("script.resources.reader.execute_ocr", side_effect=fake_ocr), \
              patch("script.resources.reader.pytesseract.image_to_string", return_value=""), \
              patch("script.resources.reader.cv2.imwrite"):
@@ -219,7 +219,7 @@ class TestFailureCache(TestCase):
             return "", {"text": [""]}, np.zeros((1, 1), dtype=np.uint8), False
 
         with patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
-            patch("script.screen_utils.grab_frame", return_value=frame), \
+            patch("script.screen_utils.screen_capture.grab_frame", return_value=frame), \
              patch("script.resources.reader.preprocess_roi", side_effect=lambda r: r[..., 0] if r.ndim == 3 else r), \
              patch("script.resources.reader.execute_ocr", side_effect=fake_execute), \
              patch("script.resources.reader.pytesseract.image_to_string", return_value=""), \
@@ -263,7 +263,7 @@ class TestFailureCache(TestCase):
         frame = np.zeros((600, 600, 3), dtype=np.uint8)
 
         with patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
-            patch("script.screen_utils.grab_frame", return_value=frame), \
+            patch("script.screen_utils.screen_capture.grab_frame", return_value=frame), \
              patch("script.resources.reader.execute_ocr", side_effect=fake_ocr), \
              patch("script.resources.reader.pytesseract.image_to_string", return_value=""), \
              patch("script.resources.reader.cv2.imwrite"):

--- a/tests/ocr_failures/test_failure_modes.py
+++ b/tests/ocr_failures/test_failure_modes.py
@@ -58,7 +58,7 @@ def test_read_resources_handles_missing_non_required_icons():
         return ocr_seq.pop(0)
 
     with patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
-        patch("script.screen_utils.grab_frame", side_effect=fake_grab_frame), \
+        patch("script.screen_utils.screen_capture.grab_frame", side_effect=fake_grab_frame), \
          patch("script.resources.ocr.masks._ocr_digits_better", side_effect=fake_ocr), \
          patch("script.resources.reader.pytesseract.image_to_string", return_value=""), \
          patch("script.resources.reader.cv2.imwrite"):
@@ -83,7 +83,7 @@ def test_discard_low_confidence_without_fallback():
     resources.RESOURCE_CACHE.last_resource_values["wood_stockpile"] = 0
     with patch.dict(resources.CFG, {"wood_stockpile_low_conf_fallback": False}, clear=False), \
          patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
-        patch("script.screen_utils.grab_frame", side_effect=fake_grab_frame), \
+        patch("script.screen_utils.screen_capture.grab_frame", side_effect=fake_grab_frame), \
          patch("script.resources.ocr.masks._ocr_digits_better", side_effect=fake_ocr) as ocr_mock, \
          patch("script.resources.reader.pytesseract.image_to_string", return_value="") as img2str_mock, \
          patch("script.resources.reader.cv2.imwrite"):
@@ -114,7 +114,7 @@ def test_low_confidence_triggers_fallback():
     resources.RESOURCE_CACHE.last_resource_values["wood_stockpile"] = 0
     with patch.dict(resources.CFG, {"wood_stockpile_low_conf_fallback": False}, clear=False), \
          patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
-        patch("script.screen_utils.grab_frame", side_effect=fake_grab_frame), \
+        patch("script.screen_utils.screen_capture.grab_frame", side_effect=fake_grab_frame), \
          patch("script.resources.ocr.masks._ocr_digits_better", side_effect=fake_ocr) as ocr_mock, \
          patch("script.resources.reader.pytesseract.image_to_string", return_value="") as img2str_mock, \
          patch("script.resources.reader.cv2.imwrite"):
@@ -140,7 +140,7 @@ def test_confidence_zero_does_not_call_image_to_string():
     resources.RESOURCE_CACHE.last_resource_values["wood_stockpile"] = 0
     with patch.dict(resources.CFG, {"wood_stockpile_low_conf_fallback": False, "allow_zero_confidence_digits": False}, clear=False), \
          patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
-        patch("script.screen_utils.grab_frame", side_effect=fake_grab_frame), \
+        patch("script.screen_utils.screen_capture.grab_frame", side_effect=fake_grab_frame), \
          patch("script.resources.ocr.masks._ocr_digits_better", side_effect=fake_ocr), \
          patch("script.resources.reader.pytesseract.image_to_string", return_value="") as img2str_mock, \
          patch("script.resources.reader.cv2.imwrite"):
@@ -168,7 +168,7 @@ def test_missing_optional_icon_not_in_results():
 
     frame = np.zeros((600, 600, 3), dtype=np.uint8)
     with patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
-        patch("script.screen_utils.grab_frame", return_value=frame), \
+        patch("script.screen_utils.screen_capture.grab_frame", return_value=frame), \
          patch("script.resources.ocr.masks._ocr_digits_better", side_effect=fake_ocr), \
          patch("script.resources.reader.pytesseract.image_to_string", return_value=""), \
          patch("script.resources.reader.cv2.imwrite"):

--- a/tests/ocr_failures/test_low_confidence.py
+++ b/tests/ocr_failures/test_low_confidence.py
@@ -101,7 +101,7 @@ class TestResourceLowConfidence(TestCase):
         resources.RESOURCE_CACHE.last_resource_values["wood_stockpile"] = 0
         with patch.dict(resources.CFG, {"wood_stockpile_low_conf_fallback": False, "allow_zero_confidence_digits": False}, clear=False), \
             patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
-            patch("script.screen_utils.grab_frame", side_effect=fake_grab_frame), \
+            patch("script.screen_utils.screen_capture.grab_frame", side_effect=fake_grab_frame), \
             patch("script.resources.ocr.masks._ocr_digits_better", side_effect=fake_ocr) as ocr_mock, \
             patch("script.resources.reader.pytesseract.image_to_string", return_value="") as img2str_mock, \
             patch("script.resources.reader.cv2.imwrite"):
@@ -158,7 +158,7 @@ class TestResourceLowConfidence(TestCase):
         resources.RESOURCE_CACHE.last_resource_values["wood_stockpile"] = 0
         with patch.dict(resources.CFG, {"wood_stockpile_low_conf_fallback": False}, clear=False), \
             patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
-            patch("script.screen_utils.grab_frame", side_effect=fake_grab_frame), \
+            patch("script.screen_utils.screen_capture.grab_frame", side_effect=fake_grab_frame), \
             patch("script.resources.ocr.masks._ocr_digits_better", side_effect=fake_ocr), \
             patch("script.resources.reader.pytesseract.image_to_string", return_value=""), \
             patch("script.resources.reader.cv2.imwrite"):
@@ -194,7 +194,7 @@ class TestResourceLowConfidence(TestCase):
         resources.RESOURCE_CACHE.last_resource_values["wood_stockpile"] = 0
         with patch.dict(resources.CFG, {"wood_stockpile_low_conf_fallback": False}, clear=False), \
             patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
-            patch("script.screen_utils.grab_frame", side_effect=fake_grab_frame), \
+            patch("script.screen_utils.screen_capture.grab_frame", side_effect=fake_grab_frame), \
             patch("script.resources.ocr.masks._ocr_digits_better", side_effect=fake_ocr) as ocr_mock, \
             patch("script.resources.reader.pytesseract.image_to_string", return_value="") as img2str_mock, \
             patch("script.resources.reader.cv2.imwrite"):
@@ -220,7 +220,7 @@ class TestResourceLowConfidence(TestCase):
         resources.RESOURCE_CACHE.last_resource_values["wood_stockpile"] = 0
         with patch.dict(resources.CFG, {"wood_stockpile_low_conf_fallback": False}, clear=False), \
             patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
-            patch("script.screen_utils.grab_frame", side_effect=fake_grab_frame), \
+            patch("script.screen_utils.screen_capture.grab_frame", side_effect=fake_grab_frame), \
             patch("script.resources.ocr.masks._ocr_digits_better", side_effect=fake_ocr), \
             patch("script.resources.reader.pytesseract.image_to_string", return_value="") as img2str_mock, \
             patch("script.resources.reader.cv2.imwrite"):

--- a/tests/ocr_failures/test_no_digits.py
+++ b/tests/ocr_failures/test_no_digits.py
@@ -159,7 +159,7 @@ class TestNoDigits(TestCase):
             return ocr_seq.pop(0)
 
         with patch("script.resources.reader.detect_resource_regions", side_effect=fake_detect), \
-            patch("script.screen_utils.grab_frame", side_effect=fake_grab_frame), \
+            patch("script.screen_utils.screen_capture.grab_frame", side_effect=fake_grab_frame), \
              patch("script.resources.ocr.masks._ocr_digits_better", side_effect=fake_ocr), \
              patch("script.resources.reader.pytesseract.image_to_string", return_value=""), \
              patch("script.resources.reader.cv2.imwrite"):

--- a/tests/test_campaign_cache_reset.py
+++ b/tests/test_campaign_cache_reset.py
@@ -54,8 +54,8 @@ class TestCampaignCacheReset(TestCase):
                     "campaign.argparse.ArgumentParser.parse_args",
                     return_value=types.SimpleNamespace(scenario="dummy"),
                 ), \
-                patch("campaign.screen_utils.init_sct"), \
-                patch("campaign.screen_utils.teardown_sct"), \
+                patch("campaign.screen_utils.screen_capture.init_sct"), \
+                patch("campaign.screen_utils.screen_capture.teardown_sct"), \
                 patch("campaign.hud.wait_hud", return_value=({}, "asset")), \
                 patch("campaign.resources.gather_hud_stats", side_effect=gather_side_effect), \
                 patch("campaign.logging.getLogger", return_value=logger_mock), \

--- a/tests/test_campaign_resource_read_error_surface.py
+++ b/tests/test_campaign_resource_read_error_surface.py
@@ -48,8 +48,8 @@ class TestResourceReadErrorSurface(TestCase):
                 "campaign.argparse.ArgumentParser.parse_args",
                 return_value=types.SimpleNamespace(scenario="dummy"),
             ), \
-            patch("campaign.screen_utils.init_sct"), \
-            patch("campaign.screen_utils.teardown_sct"), \
+            patch("campaign.screen_utils.screen_capture.init_sct"), \
+            patch("campaign.screen_utils.screen_capture.teardown_sct"), \
             patch("campaign.hud.wait_hud", return_value=({}, "asset")), \
             patch(
                 "campaign.resources.gather_hud_stats",

--- a/tests/test_campaign_resource_validation.py
+++ b/tests/test_campaign_resource_validation.py
@@ -84,8 +84,8 @@ class TestCampaignResourceValidation(TestCase):
                 "campaign.argparse.ArgumentParser.parse_args",
                 return_value=types.SimpleNamespace(scenario="dummy"),
             ), \
-            patch("campaign.screen_utils.init_sct"), \
-            patch("campaign.screen_utils.teardown_sct"), \
+            patch("campaign.screen_utils.screen_capture.init_sct"), \
+            patch("campaign.screen_utils.screen_capture.teardown_sct"), \
             patch("campaign.hud.wait_hud", return_value=({}, "asset")), \
             patch("campaign.resources.gather_hud_stats", side_effect=gh_side_effect), \
             patch(

--- a/tests/test_campaign_starting_resources_none.py
+++ b/tests/test_campaign_starting_resources_none.py
@@ -54,8 +54,8 @@ class TestCampaignNoStartingResources(TestCase):
                 "campaign.argparse.ArgumentParser.parse_args",
                 return_value=types.SimpleNamespace(scenario="dummy"),
             ), \
-            patch("campaign.screen_utils.init_sct"), \
-            patch("campaign.screen_utils.teardown_sct"), \
+            patch("campaign.screen_utils.screen_capture.init_sct"), \
+            patch("campaign.screen_utils.screen_capture.teardown_sct"), \
             patch("campaign.hud.wait_hud", return_value=({}, "asset")), \
             patch("campaign.resources.gather_hud_stats", return_value=({}, (0, 0))), \
             patch("campaign.resources.validate_starting_resources", validate_mock), \

--- a/tests/test_gather_hud_stats.py
+++ b/tests/test_gather_hud_stats.py
@@ -233,8 +233,8 @@ class TestGatherHudStats(TestCase):
 
         with patch("campaign.parse_scenario_info", return_value=info), \
              patch("campaign.argparse.ArgumentParser.parse_args", return_value=types.SimpleNamespace(scenario="dummy")), \
-             patch("campaign.screen_utils.init_sct"), \
-             patch("campaign.screen_utils.teardown_sct"), \
+             patch("campaign.screen_utils.screen_capture.init_sct"), \
+             patch("campaign.screen_utils.screen_capture.teardown_sct"), \
              patch("campaign.hud.wait_hud", return_value=({}, "assets/resources.png")), \
              patch("campaign.resources.gather_hud_stats", return_value=({}, (0, 0))) as gh, \
              patch("campaign.resources.validate_starting_resources"):

--- a/tests/test_hud_anchor.py
+++ b/tests/test_hud_anchor.py
@@ -48,7 +48,7 @@ class TestHudAnchor(TestCase):
 
     def test_wait_hud_raises_without_template(self):
         with patch.object(hud.screen_utils, "HUD_TEMPLATE", None), \
-            patch("script.screen_utils.grab_frame") as grab_mock:
+            patch("script.screen_utils.screen_capture.grab_frame") as grab_mock:
             with self.assertRaises(RuntimeError) as ctx:
                 hud.wait_hud(timeout=1)
         grab_mock.assert_not_called()
@@ -57,7 +57,7 @@ class TestHudAnchor(TestCase):
     def test_wait_hud_sets_asset(self):
         common.HUD_ANCHOR = None
         fake_frame = np.zeros((100, 100, 3), dtype=np.uint8)
-        with patch("script.screen_utils.grab_frame", return_value=fake_frame), \
+        with patch("script.screen_utils.screen_capture.grab_frame", return_value=fake_frame), \
              patch("script.hud.find_template", return_value=((10, 20, 30, 40), 0.9, None)):
             anchor, asset = hud.wait_hud(timeout=1)
         self.assertEqual(asset, ASSET)
@@ -82,7 +82,7 @@ class TestHudAnchor(TestCase):
             return d, {"text": [d]}, np.zeros((1, 1), dtype=np.uint8)
 
         with patch("script.resources.reader.locate_resource_panel", return_value={}), \
-            patch("script.screen_utils.grab_frame", side_effect=fake_grab_frame), \
+            patch("script.screen_utils.screen_capture.grab_frame", side_effect=fake_grab_frame), \
              patch("script.resources.reader._ocr_digits_better", side_effect=fake_ocr), \
              patch("script.resources.reader.preprocess_roi", side_effect=lambda roi: np.zeros((52, 90), dtype=np.uint8)), \
              patch(

--- a/tests/test_idle_villager_ocr.py
+++ b/tests/test_idle_villager_ocr.py
@@ -51,7 +51,7 @@ class TestIdleVillagerOCR(TestCase):
         with patch(
             "script.resources.reader.core.detect_resource_regions",
             side_effect=fake_detect,
-        ), patch("script.screen_utils.grab_frame", return_value=frame), patch(
+        ), patch("script.screen_utils.screen_capture.grab_frame", return_value=frame), patch(
             "script.resources.reader.pytesseract.image_to_data",
             return_value={"text": ["1", "2"], "conf": ["90", "90"]},
         ) as img2data, patch(
@@ -84,7 +84,7 @@ class TestIdleVillagerOCR(TestCase):
         with patch(
             "script.resources.reader.core.detect_resource_regions",
             side_effect=fake_detect,
-        ), patch("script.screen_utils.grab_frame", return_value=frame), patch(
+        ), patch("script.screen_utils.screen_capture.grab_frame", return_value=frame), patch(
             "script.resources.reader.pytesseract.image_to_data",
             return_value={"text": ["1", "2"], "conf": [-1, "0", "95"]},
         ) as img2data, patch(
@@ -114,7 +114,7 @@ class TestIdleVillagerOCR(TestCase):
         with patch(
             "script.resources.reader.core.detect_resource_regions",
             side_effect=fake_detect,
-        ), patch("script.screen_utils.grab_frame", return_value=frame), patch(
+        ), patch("script.screen_utils.screen_capture.grab_frame", return_value=frame), patch(
             "script.resources.reader.pytesseract.image_to_data",
             return_value={"text": ["1"], "conf": [low_conf]},
         ), patch(
@@ -140,7 +140,7 @@ class TestIdleVillagerOCR(TestCase):
         with patch(
             "script.resources.reader.core.detect_resource_regions",
             side_effect=fake_detect,
-        ), patch("script.screen_utils.grab_frame", return_value=frame), patch(
+        ), patch("script.screen_utils.screen_capture.grab_frame", return_value=frame), patch(
             "script.resources.reader.pytesseract.image_to_data",
             return_value={"text": ["1", "2"], "conf": ["0", "95"]},
         ) as img2data, patch(
@@ -165,7 +165,7 @@ class TestIdleVillagerOCR(TestCase):
         with patch(
             "script.resources.reader.core.detect_resource_regions",
             side_effect=fake_detect,
-        ), patch("script.screen_utils.grab_frame", return_value=frame), patch(
+        ), patch("script.screen_utils.screen_capture.grab_frame", return_value=frame), patch(
             "script.resources.reader.pytesseract.image_to_data",
             return_value=low_conf,
         ):
@@ -193,7 +193,7 @@ class TestIdleVillagerOCR(TestCase):
         with patch(
             "script.resources.reader.core.detect_resource_regions",
             side_effect=fake_detect,
-        ), patch("script.screen_utils.grab_frame", return_value=frame), patch(
+        ), patch("script.screen_utils.screen_capture.grab_frame", return_value=frame), patch(
             "script.resources.reader.pytesseract.image_to_data",
             return_value=low_conf,
         ):
@@ -219,7 +219,7 @@ class TestIdleVillagerOCR(TestCase):
         with patch(
             "script.resources.reader.core.detect_resource_regions",
             side_effect=fake_detect,
-        ), patch("script.screen_utils.grab_frame", return_value=frame), patch(
+        ), patch("script.screen_utils.screen_capture.grab_frame", return_value=frame), patch(
             "script.resources.reader.pytesseract.image_to_data",
             return_value={"text": ["3"], "conf": [low_conf]},
         ), patch(
@@ -252,7 +252,7 @@ class TestIdleVillagerOCR(TestCase):
                 "script.resources.reader.core.detect_resource_regions",
                 side_effect=fake_detect,
             ), patch(
-                "script.screen_utils.grab_frame", return_value=frame
+                "script.screen_utils.screen_capture.grab_frame", return_value=frame
             ), patch(
                 "script.resources.reader.pytesseract.image_to_data",
                 return_value={"text": [str(val)], "conf": ["95"]},

--- a/tests/test_population_roi.py
+++ b/tests/test_population_roi.py
@@ -57,7 +57,7 @@ class TestPopulationROI(TestCase):
             patch.dict(common.CFG["areas"], {"pop_box": [2.0, 2.0, 0.1, 0.1]}), \
             patch.dict(common.CFG, {"population_limit_roi": None}, clear=False), \
             patch("script.resources.locate_resource_panel", return_value={}), \
-            patch("script.screen_utils.grab_frame", return_value=np.zeros((1, 1, 3))) as grab_mock, \
+            patch("script.screen_utils.screen_capture.grab_frame", return_value=np.zeros((1, 1, 3))) as grab_mock, \
             patch("script.resources.ocr.executor.execute_ocr") as ocr_mock:
             with self.assertRaises(common.PopulationReadError) as ctx:
                 hud.read_population_from_hud(
@@ -78,7 +78,7 @@ class TestPopulationROI(TestCase):
             h, w = bbox["height"], bbox["width"]
             return np.zeros((h, w, 3), dtype=np.uint8)
 
-        with patch("script.screen_utils.grab_frame", side_effect=fake_grab), \
+        with patch("script.screen_utils.screen_capture.grab_frame", side_effect=fake_grab), \
             patch("script.resources.locate_resource_panel", return_value={}), \
             patch("script.input_utils._screen_size", return_value=(200, 200)), \
             patch.dict(common.CFG["areas"], {"pop_box": [0.1, 0.1, 0.5, 0.5]}), \
@@ -118,7 +118,7 @@ class TestPopulationROI(TestCase):
             recorded["roi"] = src
             return src
 
-        with patch("script.screen_utils.grab_frame", side_effect=fake_grab), \
+        with patch("script.screen_utils.screen_capture.grab_frame", side_effect=fake_grab), \
             patch("script.resources.locate_resource_panel", return_value={}), \
             patch("script.input_utils._screen_size", return_value=(200, 200)), \
             patch.dict(common.CFG["areas"], {"pop_box": pop_box}), \
@@ -162,7 +162,7 @@ class TestPopulationROI(TestCase):
             patch.dict(common.CFG["areas"], {"pop_box": [0.1, 0.1, -0.5, 0.2]}), \
             patch.dict(common.CFG, {"population_limit_roi": None}, clear=False), \
             patch("script.resources.locate_resource_panel", return_value={}), \
-            patch("script.screen_utils.grab_frame", return_value=np.zeros((1, 1, 3))) as grab_mock, \
+            patch("script.screen_utils.screen_capture.grab_frame", return_value=np.zeros((1, 1, 3))) as grab_mock, \
             patch("script.resources.ocr.executor.execute_ocr") as ocr_mock, \
             patch("script.resources.ocr.executor.time.sleep") as sleep_mock:
             with self.assertRaises(common.PopulationReadError) as ctx:
@@ -208,7 +208,7 @@ class TestPopulationROI(TestCase):
                 "population_ocr_roi_expand_growth": 1.0,
             },
             clear=False,
-        ), patch("script.screen_utils.grab_frame", side_effect=fake_grab), patch(
+        ), patch("script.screen_utils.screen_capture.grab_frame", side_effect=fake_grab), patch(
             "script.resources.ocr.executor._read_population_from_roi",
             side_effect=fake_pop,
         ), patch(
@@ -260,7 +260,7 @@ class TestPopulationROI(TestCase):
                 "population_ocr_roi_expand_growth": 1.0,
             },
             clear=False,
-        ), patch("script.screen_utils.grab_frame", side_effect=fake_grab), patch(
+        ), patch("script.screen_utils.screen_capture.grab_frame", side_effect=fake_grab), patch(
             "script.resources.ocr.executor._read_population_from_roi",
             side_effect=fake_pop,
         ), patch(
@@ -311,7 +311,7 @@ class TestPopulationROI(TestCase):
         def failing_read(*args, **kwargs):
             raise common.PopulationReadError("text='0/0', confs=[0]")
 
-        with patch("script.screen_utils.grab_frame", side_effect=fake_grab), patch(
+        with patch("script.screen_utils.screen_capture.grab_frame", side_effect=fake_grab), patch(
             "script.resources.ocr.executor._read_population_from_roi",
             side_effect=failing_read,
         ), patch(
@@ -418,7 +418,7 @@ class TestPopulationROI(TestCase):
             {"allow_low_conf_population": True, "treat_low_conf_as_failure": True},
             clear=False,
         ), patch(
-            "script.screen_utils.grab_frame", return_value=roi
+            "script.screen_utils.screen_capture.grab_frame", return_value=roi
         ), patch(
             "script.resources.ocr.executor._read_population_from_roi",
             return_value=(12, 34, True),
@@ -445,7 +445,7 @@ class TestPopulationROI(TestCase):
             {"allow_low_conf_population": True, "treat_low_conf_as_failure": True},
             clear=False,
         ), patch(
-            "script.screen_utils.grab_frame", return_value=roi
+            "script.screen_utils.screen_capture.grab_frame", return_value=roi
         ), patch(
             "script.resources.ocr.executor._read_population_from_roi",
             side_effect=failing_read,

--- a/tests/test_resource_debug_images.py
+++ b/tests/test_resource_debug_images.py
@@ -56,7 +56,7 @@ class TestResourceDebugImages(TestCase):
         def fake_ocr(gray):
             return "", {"text": [""]}, np.zeros((1, 1), dtype=np.uint8)
 
-        with patch("script.screen_utils.grab_frame", side_effect=fake_grab_frame), \
+        with patch("script.screen_utils.screen_capture.grab_frame", side_effect=fake_grab_frame), \
              patch(
                  "script.resources.reader.locate_resource_panel",
                  return_value={
@@ -114,7 +114,7 @@ class TestResourceDebugImages(TestCase):
         resources.RESOURCE_CACHE.last_resource_values.clear()
         resources.RESOURCE_CACHE.last_resource_ts.clear()
         resources.RESOURCE_CACHE.resource_failure_counts.clear()
-        with patch("script.screen_utils.grab_frame", side_effect=fake_grab_frame), \
+        with patch("script.screen_utils.screen_capture.grab_frame", side_effect=fake_grab_frame), \
              patch(
                  "script.resources.reader.locate_resource_panel",
                  return_value={

--- a/tests/test_resource_force_delay.py
+++ b/tests/test_resource_force_delay.py
@@ -50,7 +50,7 @@ class TestResourceForceDelay(TestCase):
             return np.zeros((1, 1, 3), dtype=np.uint8)
 
         with patch("script.resources.reader.time.sleep", side_effect=fake_sleep), \
-            patch("script.resources.reader.screen_utils.grab_frame", side_effect=fake_grab), \
+            patch("script.resources.reader.screen_utils.screen_capture.grab_frame", side_effect=fake_grab), \
             patch("script.resources.reader.detect_resource_regions", return_value={}), \
             patch("script.resources.reader.handle_ocr_failure"):
             resources.read_resources_from_hud([], force_delay=0.1)

--- a/tools/campaign.py
+++ b/tools/campaign.py
@@ -17,7 +17,7 @@ HUD_TEMPLATES = ["assets/resources.png"]
 HUD_TEMPLATE = np.zeros((1, 1), dtype=np.uint8)
 
 # Default helpers (can be monkeypatched in tests)
-grab_frame = screen_utils.grab_frame
+grab_frame = screen_utils.screen_capture.grab_frame
 find_template = hud.find_template
 locate_resource_panel = panel.locate_resource_panel
 _read_population_from_roi = _read_population_from_roi_func

--- a/tools/detect_hud.py
+++ b/tools/detect_hud.py
@@ -8,7 +8,7 @@ import script.resources as resources
 
 
 def main():
-    frame = screen_utils.grab_frame()
+    frame = screen_utils.screen_capture.grab_frame()
     box, score = resources.detect_hud(frame)
     print(box, score)
 


### PR DESCRIPTION
## Summary
- introduce `ScreenCapture` class to manage mss session and monitor
- update modules and tests to use `screen_capture` instance

## Testing
- `pytest` *(fails: 47 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b8fc40377883258e49394b141223a3