### PR TITLE
Introduce explicit configuration initialization

### DIFF
--- a/campaign.py
+++ b/campaign.py
@@ -234,7 +234,7 @@ def wait_for_hud_with_retry(
                     f"HUD not detected after {max_retries} attempts; exiting script."
                 ) from e
 
-def main() -> None:
+def main(config_path: str | Path | None = None) -> None:
     """Run a campaign mission based on command-line arguments.
 
     The function parses CLI options, configures logging and screen capture,
@@ -242,6 +242,7 @@ def main() -> None:
     and executes the mission module for the chosen scenario.
 
     Args:
+        config_path: Optional configuration file path.
         --scenario (str): Path to the scenario text file. Defaults to the
             configuration value or
             ``campaigns/Ascent_of_Egypt/Egypt_1_Hunting.txt``.
@@ -250,6 +251,7 @@ def main() -> None:
         None
     """
 
+    common.init_common(config_path)
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--scenario",

--- a/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
+++ b/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
@@ -27,7 +27,7 @@ import script.screen_utils as screen_utils
 logger = logging.getLogger(__name__)
 
 
-def main() -> None:
+def main(config_path: str | Path | None = None) -> None:
     """Run the automation routine for the *Hunting* mission.
 
     The function performs the following high level steps:
@@ -40,6 +40,7 @@ def main() -> None:
         the rest of the automation knows the correct starting state.
     """
 
+    common.init_common(config_path)
     logger.info(
         "Enter the campaign mission (Hunting). The script starts when the HUD is detected…"
     )

--- a/campaigns/Ascent_of_Egypt/Egypt_2_Foraging.py
+++ b/campaigns/Ascent_of_Egypt/Egypt_2_Foraging.py
@@ -23,7 +23,7 @@ import script.input_utils as input_utils
 logger = logging.getLogger(__name__)
 
 
-def main() -> None:
+def main(config_path: str | Path | None = None) -> None:
     """Run the automation routine for the *Foraging* mission.
 
     The function performs the following high level steps:
@@ -36,6 +36,7 @@ def main() -> None:
         the rest of the automation knows the correct starting state.
     """
 
+    common.init_common(config_path)
     logger.info(
         "Enter the campaign mission (Foraging). The script starts when the HUD is detected…"
     )

--- a/script/hud.py
+++ b/script/hud.py
@@ -13,14 +13,13 @@ from pathlib import Path
 import cv2
 
 from .template_utils import find_template
-from .config_utils import load_config
 from . import screen_utils
 from . import common, resources, input_utils
 from .resources import reader as resource_reader
+from .common import CFG
 
 ROOT = Path(__file__).resolve().parent.parent
 
-CFG = load_config()
 logger = logging.getLogger(__name__)
 
 

--- a/script/resources/__init__.py
+++ b/script/resources/__init__.py
@@ -7,12 +7,11 @@ from types import SimpleNamespace
 import cv2
 import numpy as np
 
-from ..config_utils import load_config
 from .. import screen_utils, common
 from ..template_utils import find_template
 
 ROOT = Path(__file__).resolve().parent.parent
-CFG = load_config()
+CFG = common.CFG
 logger = logging.getLogger(__name__)
 
 RESOURCE_ICON_ORDER = [

--- a/script/resources/cache.py
+++ b/script/resources/cache.py
@@ -2,10 +2,7 @@
 
 from dataclasses import dataclass, field
 
-from ..config_utils import load_config
-
-# Load configuration at module import
-CFG = load_config()
+from ..common import CFG
 
 
 @dataclass

--- a/script/screen_utils.py
+++ b/script/screen_utils.py
@@ -8,12 +8,9 @@ import numpy as np
 import cv2
 from mss import mss
 
-from .config_utils import load_config
-
 ROOT = Path(__file__).resolve().parent.parent
 ASSETS = ROOT / "assets"
 
-CFG = load_config()
 logger = logging.getLogger(__name__)
 
 

--- a/tests/ocr_failures/test_failure_cache.py
+++ b/tests/ocr_failures/test_failure_cache.py
@@ -54,6 +54,7 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 import script.common as common
+common.init_common()
 import script.resources.reader as resources
 
 

--- a/tests/resource_rois/test_calibration.py
+++ b/tests/resource_rois/test_calibration.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import script.common as common
+common.init_common()
 import script.resources as resources
 import script.resources.reader as reader
 from script.resources.panel import ResourcePanelCfg

--- a/tests/resource_rois/test_compute_rois.py
+++ b/tests/resource_rois/test_compute_rois.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import script.common as common
+common.init_common()
 import script.resources as resources
 import script.resources.reader as reader
 import script.screen_utils as screen_utils

--- a/tests/test_build_house.py
+++ b/tests/test_build_house.py
@@ -33,6 +33,7 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
+common.init_common()
 import script.input_utils as input_utils
 import script.units.villager as villager
 

--- a/tests/test_foraging_scenario.py
+++ b/tests/test_foraging_scenario.py
@@ -62,6 +62,7 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
+common.init_common()
 import script.config_utils as config_utils
 import script.resources as resources
 

--- a/tests/test_hud_anchor.py
+++ b/tests/test_hud_anchor.py
@@ -33,6 +33,7 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
+common.init_common()
 import script.hud as hud
 import script.resources.reader as resources
 import tools.campaign as cb

--- a/tests/test_hunting_scenario.py
+++ b/tests/test_hunting_scenario.py
@@ -60,6 +60,7 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
+common.init_common()
 import script.config_utils as config_utils
 import script.resources as resources
 

--- a/tests/test_idle_villager_roi.py
+++ b/tests/test_idle_villager_roi.py
@@ -36,6 +36,7 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
+common.init_common()
 import script.resources as resources
 import script.screen_utils as screen_utils
 

--- a/tests/test_internal_population.py
+++ b/tests/test_internal_population.py
@@ -49,6 +49,7 @@ os.environ.setdefault("TESSERACT_CMD", "/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
+common.init_common()
 import script.buildings.town_center as tc
 import script.units.villager as villager
 import script.config_utils as config_utils

--- a/tests/test_missing_hotkeys.py
+++ b/tests/test_missing_hotkeys.py
@@ -31,6 +31,7 @@ sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
+common.init_common()
 import script.units.villager as villager
 
 

--- a/tests/test_missing_resource_bar.py
+++ b/tests/test_missing_resource_bar.py
@@ -31,6 +31,7 @@ sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
+common.init_common()
 import script.buildings.town_center as tc
 import script.units.villager as villager
 

--- a/tests/test_ocr_config.py
+++ b/tests/test_ocr_config.py
@@ -33,6 +33,7 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
+common.init_common()
 import script.resources as resources
 from script.resources.ocr import masks
 from script.resources.ocr.masks import _ocr_digits_better

--- a/tests/test_population_roi.py
+++ b/tests/test_population_roi.py
@@ -47,6 +47,7 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
+common.init_common()
 import script.hud as hud
 import script.resources as resources
 

--- a/tests/test_population_roi_bounds.py
+++ b/tests/test_population_roi_bounds.py
@@ -61,6 +61,7 @@ for name in list(sys.modules):
 
 import script.resources as resources
 import script.common as common
+common.init_common()
 
 
 class TestPopulationROIBounds(TestCase):

--- a/tests/test_resource_debug_images.py
+++ b/tests/test_resource_debug_images.py
@@ -35,6 +35,7 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
+common.init_common()
 import script.resources.reader as resources
 
 

--- a/tests/test_resource_helpers.py
+++ b/tests/test_resource_helpers.py
@@ -35,6 +35,7 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
+common.init_common()
 import script.resources.reader as resources
 
 

--- a/tests/test_resource_roi_validation.py
+++ b/tests/test_resource_roi_validation.py
@@ -62,6 +62,7 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
+common.init_common()
 import script.resources as resources
 import script.resources.reader as reader
 

--- a/tests/test_resource_rois.py
+++ b/tests/test_resource_rois.py
@@ -54,6 +54,7 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
+common.init_common()
 import script.resources as resources
 import script.screen_utils as screen_utils
 

--- a/tests/test_select_idle_villager.py
+++ b/tests/test_select_idle_villager.py
@@ -34,6 +34,7 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.units.villager as villager
 import script.common as common
+common.init_common()
 
 
 class TestSelectIdleVillager(TestCase):

--- a/tests/test_stone_roi_config.py
+++ b/tests/test_stone_roi_config.py
@@ -33,6 +33,7 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
+common.init_common()
 import script.resources as resources
 
 

--- a/tools/detect_hud.py
+++ b/tools/detect_hud.py
@@ -1,13 +1,16 @@
 import os
 import sys
+from pathlib import Path
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 import script.screen_utils as screen_utils
 import script.resources as resources
+import script.common as common
 
 
-def main():
+def main(config_path: str | Path | None = None):
+    common.init_common(config_path)
     frame = screen_utils.screen_capture.grab_frame()
     box, score = resources.detect_hud(frame)
     print(box, score)


### PR DESCRIPTION
## Summary
- add `init_common` helper to load config and wire up Tesseract
- avoid loading config on import across modules and call init in entry points
- allow optional config path for easier test setup
- adjust tests and utilities to initialise config explicitly

## Testing
- `pytest` *(fails: 143 failed, 114 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8fdb0a04c832592ee1ba7d2844f3a