### PR TITLE
chore: standardize logging language

### DIFF
--- a/campaign.py
+++ b/campaign.py
@@ -352,7 +352,7 @@ def main(config_path: str | Path | None = None) -> None:
         sig = inspect.signature(func)
         accepts_info = "info" in sig.parameters
         logger.info("Starting mission '%s'.", module_name)
-        logger.info("Tentando cumprir os objetivos do cenário %s...", module_name)
+        logger.info("Attempting to complete scenario objectives for %s...", module_name)
         if accepts_info:
             func(info)
         else:

--- a/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
+++ b/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
@@ -83,7 +83,7 @@ def main(config_path: str | Path | None = None) -> None:
         return
     res_vals, (cur_pop, pop_cap) = pop_check
 
-    # Validação dos recursos iniciais
+    # Validate initial resources
     tol_cfg = common.CFG.get("resource_validation_tolerance", {})
     tolerance = tol_cfg.get("initial", 10)
     frame = screen_utils.screen_capture.grab_frame()
@@ -98,7 +98,7 @@ def main(config_path: str | Path | None = None) -> None:
             rois=rois,
         )
     except resources.ResourceValidationError as exc:
-        logger.error("Erro na validação dos recursos iniciais: %s", exc)
+        logger.error("Error validating starting resources: %s", exc)
         raise
 
     hud_idle = res_vals.get("idle_villager")
@@ -126,7 +126,7 @@ def main(config_path: str | Path | None = None) -> None:
     logger.info("Setup complete.")
     if "PYTEST_CURRENT_TEST" in os.environ:
         logger.info(
-            "Variável PYTEST_CURRENT_TEST detectada; run_mission será pulado."
+            "PYTEST_CURRENT_TEST variable detected; run_mission will be skipped."
         )
     if "PYTEST_CURRENT_TEST" not in os.environ:
         run_mission(info)

--- a/campaigns/Ascent_of_Egypt/Egypt_2_Foraging.py
+++ b/campaigns/Ascent_of_Egypt/Egypt_2_Foraging.py
@@ -71,13 +71,13 @@ def main(config_path: str | Path | None = None) -> None:
         )
         return
 
-    # Validação dos recursos iniciais
+    # Validate initial resources
     try:
         resources.validate_starting_resources(
             res_vals, info.starting_resources, raise_on_error=True
         )
     except resources.ResourceValidationError as exc:
-        logger.error("Erro na validação dos recursos iniciais: %s", exc)
+        logger.error("Error validating starting resources: %s", exc)
         raise
 
     hud_idle = res_vals.get("idle_villager")

--- a/script/resources/reader/core.py
+++ b/script/resources/reader/core.py
@@ -788,7 +788,7 @@ def _read_resources(
     cache._LAST_READ_FROM_CACHE = cache_hits
     cache_obj.last_low_confidence = set(low_confidence)
     cache_obj.last_no_digits = set(no_digits)
-    logger.info("Resumo de recursos detectados: %s", results)
+    logger.info("Summary of detected resources: %s", results)
     return results, (cur_pop, pop_cap)
 
 


### PR DESCRIPTION
## Summary
- standardize mission startup logging to English in campaign runner
- translate scenario scripts and resource reader log messages to English

## Testing
- `pytest` *(fails: 122 failed, 135 passed, 3 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b90105797883259c4db66190c9c78a