### PR TITLE
Refactor common state management with BotState dataclass

### DIFF
--- a/campaigns/Ascent_of_Egypt/Egypt_2_Foraging.py
+++ b/campaigns/Ascent_of_Egypt/Egypt_2_Foraging.py
@@ -15,6 +15,7 @@ import time
 from pathlib import Path
 
 import script.common as common
+from script.common import BotState, STATE
 import script.hud as hud
 import script.resources.reader as resources
 from script.config_utils import parse_scenario_info
@@ -23,7 +24,7 @@ import script.input_utils as input_utils
 logger = logging.getLogger(__name__)
 
 
-def main(config_path: str | Path | None = None) -> None:
+def main(config_path: str | Path | None = None, state: BotState = STATE) -> None:
     """Run the automation routine for the *Foraging* mission.
 
     The function performs the following high level steps:
@@ -36,7 +37,7 @@ def main(config_path: str | Path | None = None) -> None:
         the rest of the automation knows the correct starting state.
     """
 
-    common.init_common(config_path)
+    common.init_common(config_path, state)
     logger.info(
         "Enter the campaign mission (Foraging). The script starts when the HUD is detected…"
     )
@@ -98,9 +99,9 @@ def main(config_path: str | Path | None = None) -> None:
     resources.RESOURCE_CACHE.last_resource_ts["idle_villager"] = now
 
     # Atualize população e limites
-    common.CURRENT_POP = cur_pop
-    common.POP_CAP = pop_cap
-    common.TARGET_POP = info.objective_villagers
+    state.current_pop = cur_pop
+    state.pop_cap = pop_cap
+    state.target_pop = info.objective_villagers
 
     logger.info("Setup complete.")
 

--- a/script/buildings/town_center.py
+++ b/script/buildings/town_center.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 import script.common as common
+from script.common import BotState, STATE
 import script.resources.reader as resources
 import script.input_utils as input_utils
 from script.units.villager import build_house, select_idle_villager
@@ -9,15 +10,15 @@ from script.units.villager import build_house, select_idle_villager
 logger = logging.getLogger(__name__)
 
 
-def train_villagers(target_pop: int):
+def train_villagers(target_pop: int, state: BotState = STATE):
     """Fila aldeões na Town Center até atingir ``target_pop``."""
-    input_utils._press_key_safe(common.CFG["keys"]["select_tc"], 0.10)
+    input_utils._press_key_safe(state.config["keys"]["select_tc"], 0.10)
 
-    while common.CURRENT_POP < target_pop:
+    while state.current_pop < target_pop:
         # Always reselect the Town Center to ensure subsequent commands
         # affect the correct building, especially after actions that may
         # change the selection (e.g. building houses).
-        input_utils._press_key_safe(common.CFG["keys"]["select_tc"], 0.10)
+        input_utils._press_key_safe(state.config["keys"]["select_tc"], 0.10)
 
         res_vals = None
         food = None
@@ -53,11 +54,11 @@ def train_villagers(target_pop: int):
                 food,
             )
             break
-        input_utils._press_key_safe(common.CFG["keys"]["train_vill"], 0.0)
-        common.CURRENT_POP += 1
-        if common.CURRENT_POP == common.POP_CAP:
-            if select_idle_villager():
-                if build_house():
+        input_utils._press_key_safe(state.config["keys"]["train_vill"], 0.0)
+        state.current_pop += 1
+        if state.current_pop == state.pop_cap:
+            if select_idle_villager(state=state):
+                if build_house(state=state):
                     logger.info("House built to increase population")
                 else:
                     logger.warning("Failed to build house to increase population")
@@ -66,5 +67,5 @@ def train_villagers(target_pop: int):
             # Reselect the Town Center after attempting to build a house so
             # that further villager training continues from the correct
             # building.
-            input_utils._press_key_safe(common.CFG["keys"]["select_tc"], 0.10)
+            input_utils._press_key_safe(state.config["keys"]["select_tc"], 0.10)
         time.sleep(0.10)

--- a/script/common.py
+++ b/script/common.py
@@ -1,12 +1,11 @@
-"""Utility functions for interacting with the game screen.
-
-This module bundles screen-capture helpers, HUD detection and OCR routines.
-"""
+"""Utility functions and shared state for interacting with the game screen."""
 
 from pathlib import Path
 import os
 import shutil
 import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict
 
 import pytesseract
 from .config_utils import load_config
@@ -14,12 +13,26 @@ from .config_utils import load_config
 ROOT = Path(__file__).resolve().parent.parent
 ASSETS = ROOT / "assets"
 
-# Global configuration dictionary populated by ``init_common``.
-CFG: dict = {}
+
+@dataclass
+class BotState:
+    """Container for global bot state."""
+
+    config: Dict[str, Any] = field(default_factory=dict)
+    current_pop: int = 0
+    pop_cap: int = 0
+    target_pop: int = 0
+
+
+# Default shared state instance
+STATE = BotState()
 logger = logging.getLogger(__name__)
 
+# Backwards compatibility for modules/tests importing ``common.CFG``
+CFG = STATE.config
 
-def init_common(path: str | Path | None = None) -> dict:
+
+def init_common(path: str | Path | None = None, state: BotState | None = None) -> BotState:
     """Load configuration and configure Tesseract.
 
     Parameters
@@ -27,17 +40,23 @@ def init_common(path: str | Path | None = None) -> dict:
     path:
         Optional path to the configuration file. Defaults to the standard
         configuration file when ``None``.
+    state:
+        Optional :class:`BotState` instance to update. If ``None`` the module
+        level :data:`STATE` is used.
 
     Returns
     -------
-    dict
-        The loaded configuration dictionary.
+    BotState
+        The updated state instance.
     """
 
-    CFG.clear()
-    CFG.update(load_config(path))
+    if state is None:
+        state = STATE
 
-    tesseract_cmd = os.environ.get("TESSERACT_CMD") or CFG.get("tesseract_path")
+    state.config.clear()
+    state.config.update(load_config(path))
+
+    tesseract_cmd = os.environ.get("TESSERACT_CMD") or state.config.get("tesseract_path")
     path_lookup = shutil.which("tesseract")
     if tesseract_cmd:
         tesseract_path = Path(tesseract_cmd)
@@ -52,22 +71,17 @@ def init_common(path: str | Path | None = None) -> dict:
             pytesseract.pytesseract.tesseract_cmd = path_lookup
         else:
             raise RuntimeError(
-                "Invalid Tesseract OCR path. Install Tesseract or update 'tesseract_path' in config.json."
+                "Invalid Tesseract OCR path. Install Tesseract or update 'tesseract_path' in config.json.",
             )
     elif path_lookup:
         pytesseract.pytesseract.tesseract_cmd = path_lookup
     else:
         raise RuntimeError(
-            "Invalid Tesseract OCR path. Install Tesseract or update 'tesseract_path' in config.json."
+            "Invalid Tesseract OCR path. Install Tesseract or update 'tesseract_path' in config.json.",
         )
 
-    return CFG
+    return state
 
-
-# Contadores internos de população
-CURRENT_POP = 0
-POP_CAP = 0
-TARGET_POP = 0
 
 # Posição detectada do HUD usada apenas como referência
 HUD_ANCHOR = None
@@ -79,5 +93,4 @@ class PopulationReadError(RuntimeError):
 
 class ResourceReadError(RuntimeError):
     """Raised when resource values cannot be extracted from the HUD."""
-
 

--- a/script/hud.py
+++ b/script/hud.py
@@ -15,7 +15,9 @@ import cv2
 from .template_utils import find_template
 from . import screen_utils, common, resources
 from .resources import reader as resource_reader
-from .common import CFG
+from .common import STATE
+
+CFG = STATE.config
 
 ROOT = Path(__file__).resolve().parent.parent
 

--- a/script/resources/__init__.py
+++ b/script/resources/__init__.py
@@ -10,7 +10,7 @@ from .. import common
 from ..template_utils import find_template
 
 ROOT = Path(__file__).resolve().parent.parent
-CFG = common.CFG
+CFG = common.STATE.config
 logger = logging.getLogger(__name__)
 
 RESOURCE_ICON_ORDER = [

--- a/script/resources/cache.py
+++ b/script/resources/cache.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass, field
 
-from ..common import CFG
+from ..common import STATE
 
 
 @dataclass
@@ -35,6 +35,9 @@ _NARROW_ROIS: set[str] = set()
 _NARROW_ROI_DEFICITS: dict[str, int] = {}
 
 # Maximum age (in seconds) for cached resource values
+# Config shortcut for brevity
+CFG = STATE.config
+
 _RESOURCE_CACHE_TTL = CFG.get("resource_cache_ttl", 1.5)
 # Optional hard limit on cache age before rejection
 _RESOURCE_CACHE_MAX_AGE = CFG.get("resource_cache_max_age")

--- a/tests/test_build_house.py
+++ b/tests/test_build_house.py
@@ -33,7 +33,7 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
-common.init_common()
+state = common.init_common()
 import script.input_utils as input_utils
 import script.units.villager as villager
 
@@ -45,7 +45,7 @@ class TestClickAndBuildHouse(TestCase):
         click_mock.assert_called_once_with(100, 100, button="right")
 
     def test_build_house_uses_right_click_and_updates_population(self):
-        common.POP_CAP = 4
+        state.pop_cap = 4
         expected_coords = tuple(common.CFG["areas"]["house_spot"])
         with patch(
             "script.resources.reader.read_resources_from_hud",
@@ -55,9 +55,9 @@ class TestClickAndBuildHouse(TestCase):
             patch("script.input_utils._click_norm") as click_mock, \
             patch("script.hud.read_population_from_hud", return_value=(0, 8, False)) as read_pop_mock, \
             patch("script.units.villager.time.sleep"):
-            result = villager.build_house()
+            result = villager.build_house(state=state)
         self.assertTrue(result)
-        self.assertEqual(common.POP_CAP, 8)
+        self.assertEqual(state.pop_cap, 8)
         self.assertEqual(click_mock.call_count, 2)
         self.assertEqual(click_mock.call_args_list[0].args, expected_coords)
         self.assertEqual(click_mock.call_args_list[1].args, expected_coords)
@@ -87,7 +87,7 @@ class TestBuildHouseResourceRetry(TestCase):
         click_mock.assert_not_called()
 
     def test_build_house_recovers_from_transient_failure(self):
-        common.POP_CAP = 4
+        state.pop_cap = 4
         side_effect = [
             common.ResourceReadError("fail1"),
             ({"wood_stockpile": 100}, (None, None)),
@@ -102,7 +102,7 @@ class TestBuildHouseResourceRetry(TestCase):
         ), patch("script.units.villager.time.sleep"), patch(
             "script.hud.wait_hud"
         ):
-            result = villager.build_house()
+            result = villager.build_house(state=state)
         self.assertTrue(result)
         self.assertEqual(read_mock.call_count, 2)
-        self.assertEqual(common.POP_CAP, 8)
+        self.assertEqual(state.pop_cap, 8)

--- a/tests/test_compute_resource_rois_empty_lists.py
+++ b/tests/test_compute_resource_rois_empty_lists.py
@@ -42,7 +42,12 @@ sys.modules.setdefault(
 )
 sys.modules.setdefault(
     "script.common",
-    types.SimpleNamespace(CFG={"resource_panel": {}}, HUD_ANCHOR={"left": 0, "width": 0}),
+    types.SimpleNamespace(
+        STATE=types.SimpleNamespace(
+            config={"resource_panel": {}}, current_pop=0, pop_cap=0, target_pop=0
+        ),
+        HUD_ANCHOR={"left": 0, "width": 0},
+    ),
 )
 sys.modules.setdefault("script.input_utils", types.SimpleNamespace())
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_foraging_scenario.py
+++ b/tests/test_foraging_scenario.py
@@ -62,7 +62,7 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
-common.init_common()
+state = common.init_common()
 import script.config_utils as config_utils
 import script.resources as resources
 
@@ -103,9 +103,9 @@ class TestForagingScenario(TestCase):
                 run_name="__main__",
             )
 
-            self.assertEqual(common.CURRENT_POP, info.starting_villagers)
-            self.assertEqual(common.POP_CAP, info.population_limit)
-            self.assertEqual(common.TARGET_POP, info.objective_villagers)
+            self.assertEqual(state.current_pop, info.starting_villagers)
+            self.assertEqual(state.pop_cap, info.population_limit)
+            self.assertEqual(state.target_pop, info.objective_villagers)
             self.assertEqual(
                 resources.reader.RESOURCE_CACHE.last_resource_values, gathered
             )

--- a/tests/test_hunting_scenario.py
+++ b/tests/test_hunting_scenario.py
@@ -60,7 +60,7 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
-common.init_common()
+state = common.init_common()
 import script.config_utils as config_utils
 import script.resources as resources
 
@@ -98,9 +98,9 @@ class TestHuntingScenario(TestCase):
                 run_name="__main__",
             )
 
-            self.assertEqual(common.CURRENT_POP, info.starting_villagers)
-            self.assertEqual(common.POP_CAP, info.population_limit)
-            self.assertEqual(common.TARGET_POP, info.objective_villagers)
+            self.assertEqual(state.current_pop, info.starting_villagers)
+            self.assertEqual(state.pop_cap, info.population_limit)
+            self.assertEqual(state.target_pop, info.objective_villagers)
             self.assertEqual(
                 resources.reader.RESOURCE_CACHE.last_resource_values, gathered
             )

--- a/tests/test_internal_population.py
+++ b/tests/test_internal_population.py
@@ -49,7 +49,7 @@ os.environ.setdefault("TESSERACT_CMD", "/bin/true")
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
-common.init_common()
+state = common.init_common()
 import script.buildings.town_center as tc
 import script.units.villager as villager
 import script.config_utils as config_utils
@@ -75,10 +75,10 @@ class TestInternalPopulation(TestCase):
         self.assertEqual(info.starting_buildings, {"Town Center": 1})
 
     def test_train_villagers_updates_population_without_ocr(self):
-        common.CURRENT_POP = 3
-        common.POP_CAP = 4
-        def fake_build_house():
-            common.POP_CAP += 4
+        state.current_pop = 3
+        state.pop_cap = 4
+        def fake_build_house(state=state):
+            state.pop_cap += 4
             return True
 
         with patch(
@@ -88,9 +88,9 @@ class TestInternalPopulation(TestCase):
              patch("script.buildings.town_center.build_house", side_effect=fake_build_house) as build_house_mock, \
              patch("script.buildings.town_center.select_idle_villager", return_value=True), \
              patch("script.hud.read_population_from_hud") as read_pop_mock:
-            tc.train_villagers(7)
-            self.assertEqual(common.CURRENT_POP, 7)
-            self.assertEqual(common.POP_CAP, 8)
+            tc.train_villagers(7, state=state)
+            self.assertEqual(state.current_pop, 7)
+            self.assertEqual(state.pop_cap, 8)
             build_house_mock.assert_called_once()
             read_pop_mock.assert_not_called()
 

--- a/tests/test_missing_resource_bar.py
+++ b/tests/test_missing_resource_bar.py
@@ -31,28 +31,28 @@ sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.common as common
-common.init_common()
+state = common.init_common()
 import script.buildings.town_center as tc
 import script.units.villager as villager
 
 
 class TestMissingResourceBar(TestCase):
     def test_train_villagers_handles_missing_bar(self):
-        common.CURRENT_POP = 3
-        common.POP_CAP = 5
+        state.current_pop = 3
+        state.pop_cap = 5
         with patch(
             "script.resources.reader.read_resources_from_hud",
             side_effect=common.ResourceReadError("missing"),
         ), \
              patch("script.buildings.town_center.select_idle_villager", return_value=True), \
              patch("script.buildings.town_center.build_house"):
-            tc.train_villagers(5)
-        self.assertEqual(common.CURRENT_POP, 3)
+            tc.train_villagers(5, state=state)
+        self.assertEqual(state.current_pop, 3)
 
     def test_build_house_handles_missing_bar(self):
-        common.POP_CAP = 4
+        state.pop_cap = 4
         with patch(
             "script.resources.reader.read_resources_from_hud",
             side_effect=common.ResourceReadError("missing"),
         ):
-            self.assertFalse(villager.build_house())
+            self.assertFalse(villager.build_house(state=state))

--- a/tests/test_population_roi_bounds.py
+++ b/tests/test_population_roi_bounds.py
@@ -46,11 +46,16 @@ sys.modules.setdefault("pytesseract", types.SimpleNamespace(pytesseract=types.Si
 os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 
 # Provide minimal common module for resources import
+_cfg = {}
 sys.modules["script.common"] = types.SimpleNamespace(
-    CFG={},
+    STATE=types.SimpleNamespace(
+        config=_cfg, current_pop=0, pop_cap=0, target_pop=0
+    ),
+    CFG=_cfg,
     HUD_ANCHOR={},
     PopulationReadError=RuntimeError,
     ResourceReadError=RuntimeError,
+    init_common=lambda *a, **k: None,
 )
 
 # Ensure project root is importable
@@ -60,6 +65,7 @@ for name in list(sys.modules):
         del sys.modules[name]
 
 import script.resources as resources
+del sys.modules["script.common"]
 import script.common as common
 common.init_common()
 

--- a/tests/test_resource_min_required_width.py
+++ b/tests/test_resource_min_required_width.py
@@ -40,7 +40,12 @@ sys.modules.setdefault(
 )
 sys.modules.setdefault(
     "script.common",
-    types.SimpleNamespace(CFG={"resource_panel": {}}, HUD_ANCHOR={"left": 0, "width": 0}),
+    types.SimpleNamespace(
+        STATE=types.SimpleNamespace(
+            config={"resource_panel": {}}, current_pop=0, pop_cap=0, target_pop=0
+        ),
+        HUD_ANCHOR={"left": 0, "width": 0},
+    ),
 )
 sys.modules.setdefault("script.input_utils", types.SimpleNamespace())
 

--- a/tests/test_select_idle_villager.py
+++ b/tests/test_select_idle_villager.py
@@ -34,7 +34,7 @@ os.environ.setdefault("TESSERACT_CMD", "/usr/bin/true")
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import script.units.villager as villager
 import script.common as common
-common.init_common()
+state = common.init_common()
 
 
 class TestSelectIdleVillager(TestCase):
@@ -79,7 +79,7 @@ class TestSelectIdleVillager(TestCase):
 
     def test_low_conf_population_resets_last_idle_count(self):
         villager._last_idle_villager_count = 3
-        common.CURRENT_POP = 5
+        state.current_pop = 5
         reads = iter([
             ({"idle_villager": 1}, (None, None)),
             ({"idle_villager": 1}, (None, None)),
@@ -87,9 +87,9 @@ class TestSelectIdleVillager(TestCase):
         with patch("script.input_utils._press_key_safe") as press_mock, \
              patch("script.resources.reader.read_resources_from_hud", side_effect=lambda *a, **k: next(reads)), \
              patch("script.hud.read_population_from_hud", return_value=(7, 10, True)):
-            villager.select_idle_villager()
+            villager.select_idle_villager(state=state)
             press_mock.assert_not_called()
-        self.assertEqual(common.CURRENT_POP, 5)
+        self.assertEqual(state.current_pop, 5)
         self.assertEqual(villager._last_idle_villager_count, 0)
 
     def test_population_error_resets_last_idle_count(self):


### PR DESCRIPTION
## Summary
- introduce `BotState` dataclass to hold config and population counters
- refactor game logic to use `BotState` instead of module globals
- update tests to work with the shared state instance

## Testing
- `pytest tests/test_population_roi_bounds.py tests/test_resource_debug_images.py tests/test_resource_force_delay.py tests/test_resource_helpers.py tests/test_resource_min_required_width.py tests/test_resource_panel_cfg.py tests/test_resource_roi_validation.py tests/test_resource_rois.py tests/test_starting_resource_debug.py tests/test_stone_roi_config.py tests/test_wood_stockpile_ocr.py` *(fails: missing attributes in stub modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b904ec54c48325b6f05f54773c2bd4