### PR TITLE
Add context manager for temporary PyAutoGUI failsafe

### DIFF
--- a/tests/test_temporary_failsafe.py
+++ b/tests/test_temporary_failsafe.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import types
+from unittest import TestCase
+from unittest.mock import patch
+import numpy as np
+
+# Stub modules requiring GUI before importing bot modules
+
+dummy_pg = types.SimpleNamespace(
+    PAUSE=0,
+    FAILSAFE=True,
+    size=lambda: (200, 200),
+    click=lambda *a, **k: None,
+    moveTo=lambda *a, **k: None,
+    press=lambda *a, **k: None,
+)
+
+
+class DummyMSS:
+    monitors = [{}, {"left": 0, "top": 0, "width": 200, "height": 200}]
+
+    def grab(self, region):
+        h, w = region["height"], region["width"]
+        return np.zeros((h, w, 4), dtype=np.uint8)
+
+
+dummy_cv2 = types.SimpleNamespace(
+    imread=lambda *a, **k: np.zeros((1, 1), dtype=np.uint8),
+    IMREAD_GRAYSCALE=0,
+)
+
+sys.modules.setdefault("pyautogui", dummy_pg)
+sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: DummyMSS()))
+sys.modules.setdefault("cv2", dummy_cv2)
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import script.input_utils as input_utils
+
+
+class TestTemporaryFailsafe(TestCase):
+    def test_restores_state_on_exit(self):
+        pg = input_utils.pg
+        pg.FAILSAFE = True
+        with input_utils.temporary_failsafe_disabled():
+            self.assertFalse(pg.FAILSAFE)
+        self.assertTrue(pg.FAILSAFE)
+
+    def test_restores_state_on_exception(self):
+        pg = input_utils.pg
+        pg.FAILSAFE = True
+        with self.assertRaises(RuntimeError):
+            with input_utils.temporary_failsafe_disabled():
+                self.assertFalse(pg.FAILSAFE)
+                raise RuntimeError("boom")
+        self.assertTrue(pg.FAILSAFE)
+
+    def test_move_cursor_safe_uses_center_and_restores_state(self):
+        pg = input_utils.pg
+        pg.FAILSAFE = True
+        with patch("script.input_utils.pg.moveTo") as move_mock:
+            input_utils._move_cursor_safe()
+        move_mock.assert_called_once_with(100, 100)
+        self.assertTrue(pg.FAILSAFE)


### PR DESCRIPTION
## Summary
- add `temporary_failsafe_disabled` context manager to save and restore `pg.FAILSAFE`
- refactor `_move_cursor_safe` to use the context manager
- add tests covering context manager and cursor centering

## Testing
- `pytest tests/test_temporary_failsafe.py -q`
- `pytest -q` *(fails: cv2 template matching errors, population OCR errors, assertion mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_68b907da2e60832592ea48455b5ae790