### PR TITLE
refactor: extract ROI candidate iterator

### DIFF
--- a/config.json
+++ b/config.json
@@ -54,6 +54,8 @@
     "//food_stockpile_max_width": "Maximum width of the food stockpile ROI.",
     "ocr_retry_limit": 3,
     "//ocr_retry_limit": "Consecutive OCR failures before using fallback value.",
+    "ocr_candidate_widths": [64, 56, 48],
+    "//ocr_candidate_widths": "Candidate widths used when scanning a resource span.",
     "ocr_roi_expand_base": 3,
     "//ocr_roi_expand_base": "Base pixel margin to expand OCR ROI after a miss.",
     "ocr_roi_expand_step": 3,

--- a/config.sample.json
+++ b/config.sample.json
@@ -58,6 +58,8 @@
     "//food_stockpile_max_width": "Maximum width of the food stockpile ROI.",
     "ocr_retry_limit": 3,
     "//ocr_retry_limit": "Consecutive OCR failures before using fallback value.",
+    "ocr_candidate_widths": [64, 56, 48],
+    "//ocr_candidate_widths": "Candidate widths used when scanning a resource span.",
     "ocr_roi_expand_base": 3,
     "//ocr_roi_expand_base": "Base pixel margin to expand OCR ROI after a miss.",
     "ocr_roi_expand_step": 3,


### PR DESCRIPTION
## Summary
- extract `iter_candidate_rois` to generate candidate ROI widths and anchors
- make candidate widths configurable via `ocr_candidate_widths`
- document OCR retry flow and ROI iterator for easier testing

## Testing
- `pytest` *(fails: 49 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b90eb1f3fc832587673f4e98a1f6fd