### PR TITLE
Simplify villager training and house building

### DIFF
--- a/script/buildings/town_center.py
+++ b/script/buildings/town_center.py
@@ -3,7 +3,6 @@ import time
 
 import script.common as common
 from script.common import BotState, STATE
-import script.resources.reader as resources
 import script.input_utils as input_utils
 from script.units.villager import build_house, select_idle_villager
 
@@ -20,40 +19,6 @@ def train_villagers(target_pop: int, state: BotState = STATE):
         # change the selection (e.g. building houses).
         input_utils._press_key_safe(state.config["keys"]["select_tc"], 0.10)
 
-        res_vals = None
-        food = None
-        for attempt in range(1, 2):
-            logger.debug(
-                "Attempt %s to read food from HUD while training villagers", attempt
-            )
-            try:
-                res_vals, _ = resources.read_resources_from_hud(["food_stockpile"])
-            except common.ResourceReadError as exc:
-                logger.error(
-                    "Resource read error while training villagers (attempt %s): %s",
-                    attempt,
-                    exc,
-                )
-            else:
-                food = res_vals.get("food_stockpile")
-                if isinstance(food, int):
-                    break
-                logger.warning(
-                    "food_stockpile not detected (attempt %s); HUD may not be updated",
-                    attempt,
-                )
-            time.sleep(0.2)
-        if not isinstance(food, int):
-            logger.error(
-                "Failed to obtain food stockpile after 1 attempt; stopping villager training"
-            )
-            break
-        if food < 50:
-            logger.info(
-                "Insufficient food (%s) to train villagers.",
-                food,
-            )
-            break
         input_utils._press_key_safe(state.config["keys"]["train_vill"], 0.0)
         state.current_pop += 1
         if state.current_pop == state.pop_cap:

--- a/tests/test_internal_population.py
+++ b/tests/test_internal_population.py
@@ -81,16 +81,12 @@ class TestInternalPopulation(TestCase):
             state.pop_cap += 4
             return True
 
-        with patch(
-            "script.resources.reader.read_resources_from_hud",
-            return_value=({"food_stockpile": 500}, (None, None)),
-        ), \
+        with patch("script.resources.reader.read_resources_from_hud") as read_mock, \
              patch("script.buildings.town_center.build_house", side_effect=fake_build_house) as build_house_mock, \
-             patch("script.buildings.town_center.select_idle_villager", return_value=True), \
-             patch("script.hud.read_population_from_hud") as read_pop_mock:
+             patch("script.buildings.town_center.select_idle_villager", return_value=True):
             tc.train_villagers(7, state=state)
             self.assertEqual(state.current_pop, 7)
             self.assertEqual(state.pop_cap, 8)
             build_house_mock.assert_called_once()
-            read_pop_mock.assert_not_called()
+            read_mock.assert_not_called()
 


### PR DESCRIPTION
## Summary
- Stop reading HUD resources when training villagers; rely on internal state instead
- Build houses without HUD reads and update population cap via state
- Adapt tests to reflect new resource-independent logic

## Testing
- `pytest` *(fails: cv2.error, assertion failures in resource ROI tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f1c0726c8325919dbd0a28ec9975