### PR TITLE
Simplify idle villager selection

### DIFF
--- a/script/units/villager.py
+++ b/script/units/villager.py
@@ -1,67 +1,20 @@
 import logging
 import time
 
-import script.common as common
 from script.common import BotState, STATE
-import script.hud as hud
-import script.resources.reader as resources
 import script.input_utils as input_utils
 
 logger = logging.getLogger(__name__)
 
-# Último valor válido de aldeões ociosos lido do HUD
-_last_idle_villager_count = 0
-
 
 def select_idle_villager(delay: float = 0.1, state: BotState = STATE) -> bool:
-    """Tenta selecionar um aldeão ocioso usando a tecla configurada.
+    """Pressiona imediatamente a tecla configurada para selecionar um aldeão ocioso."""
 
-    Lê o valor de ``idle_villager`` e o compara com a população atual. Se o
-    valor de ``idle_villager`` exceder a população detectada, considera a
-    leitura inválida e tenta novamente ou recorre ao último valor conhecido.
-    """
-
-    global _last_idle_villager_count
-
-    for attempt in range(2):
-        try:
-            res_vals, _ = resources.read_resources_from_hud(["idle_villager"])
-        except common.ResourceReadError as exc:  # pragma: no cover - falha de OCR
-            logger.error("Failed to read idle_villager: %s", exc)
-            return False
-
-        idle_vill = res_vals.get("idle_villager")
-        if not isinstance(idle_vill, int):
-            return False
-
-        cur_pop, _, low_conf = hud.read_population_from_hud()
-        if low_conf:
-            _last_idle_villager_count = 0
-            continue
-        state.current_pop = cur_pop
-
-        if (cur_pop and idle_vill > cur_pop) or (
-            state.current_pop and idle_vill > state.current_pop
-        ):
-            logger.warning(
-                "Idle villager count %s exceeds population %s; retrying",
-                idle_vill,
-                cur_pop,
-            )
-            time.sleep(0.05)
-            continue
-
-        _last_idle_villager_count = idle_vill
-        if idle_vill > 0:
-            input_utils._press_key_safe(state.config["keys"]["idle_vill"], delay)
-            return True
+    key = state.config["keys"].get("idle_vill")
+    if not key:
         return False
-
-    # Após tentativas sem leitura válida, usa o último valor conhecido
-    if _last_idle_villager_count > 0:
-        input_utils._press_key_safe(state.config["keys"]["idle_vill"], delay)
-        return True
-    return False
+    input_utils._press_key_safe(key, delay)
+    return True
 
 
 def build_house(state: BotState = STATE):


### PR DESCRIPTION
## Summary
- streamline idle villager selection to press configured key directly
- adjust unit tests for new behavior

## Testing
- `pytest tests/test_select_idle_villager.py -q`
- `pytest -q` *(fails: OpenCV threshold errors and missing Tesseract path)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f31ffb44832587141cfed243a4f9