### PR TITLE
Fix indentation for starting resource validation in Hunting mission

### DIFF
--- a/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
+++ b/campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py
@@ -90,7 +90,7 @@ def main(config_path: str | Path | None = None, state: BotState = STATE) -> None
     frame = screen_utils.screen_capture.grab_frame()
     rois = getattr(resources, "_LAST_REGION_BOUNDS", {})
     try:
-    resources.validate_starting_resources(
+        resources.validate_starting_resources(
             res_vals,
             info.starting_resources,
             tolerance=tolerance,


### PR DESCRIPTION
## Summary
- Align starting resource validation call within its try block in the Hunting scenario

## Testing
- `python -m py_compile campaigns/Ascent_of_Egypt/Egypt_1_Hunting.py`
- `pytest tests/test_hunting_scenario.py::TestHuntingScenario::test_main_initialises_counters -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9f741cac0832594a7f34e8671ce54