### PR TITLE
Add stateful house building confirmation with telemetry

### DIFF
--- a/script/units/villager.py
+++ b/script/units/villager.py
@@ -1,8 +1,12 @@
 import logging
 import time
+from pathlib import Path
 
-from script.common import BotState, STATE
+import cv2
+
+from script.common import BotState, STATE, ResourceReadError
 import script.input_utils as input_utils
+from script import resources, hud, template_utils, screen_utils
 
 logger = logging.getLogger(__name__)
 
@@ -18,12 +22,13 @@ def select_idle_villager(delay: float = 0.1, state: BotState = STATE) -> bool:
 
 
 def build_house(state: BotState = STATE):
-    """Constrói uma casa no local predefinido.
+    """Constrói uma casa no local predefinido com confirmação.
 
-    Verifica se há madeira suficiente antes de tentar construir e confirma
-    que a casa foi posicionada checando o aumento do ``POP_CAP``. Caso a
-    construção falhe, tenta novamente em um ponto alternativo (se
-    configurado) ou após reunir mais recursos.
+    Após emitir o comando de construção, a função tenta confirmar o sucesso
+    monitorando os recursos, população e presença do template de uma casa na
+    região clicada. A confirmação exige que pelo menos dois dos seguintes
+    critérios sejam verdadeiros: aumento da população máxima, consumo de
+    ~30 de madeira ou detecção do template da casa.
 
     Returns
     -------
@@ -46,15 +51,131 @@ def build_house(state: BotState = STATE):
     if alt_spot:
         spots.append(alt_spot)
 
+    threshold = state.config.get("threshold", 0.8)
+    tmpl_path = Path("assets/house.png")
+    tmpl = cv2.imread(str(tmpl_path), cv2.IMREAD_GRAYSCALE) if tmpl_path.exists() else None
+
     for hx, hy in spots:
+        wood_before = pop_before = None
+        try:
+            res_vals, (_cur, pop_cap) = resources.reader.read_resources_from_hud(
+                required_icons=["wood_stockpile", "population_limit"],
+                icons_to_read=["wood_stockpile", "population_limit"],
+            )
+            wood_before = res_vals.get("wood_stockpile")
+            pop_before = pop_cap
+        except ResourceReadError:
+            logger.debug("Resource bar missing; proceeding without initial wood/pop readings")
+
+        if pop_before is None:
+            _cur, pop_before, _low = hud.read_population_from_hud()
+
+        x, y = input_utils._to_px(hx, hy)
+        roi_w = roi_h = 80
+        W, H = screen_utils.get_screen_size()
+        rx = max(0, min(x - roi_w // 2, W - roi_w))
+        ry = max(0, min(y - roi_h // 2, H - roi_h))
+        roi_bbox = (rx, ry, roi_w, roi_h)
+
+        ts = time.time()
+        logger.info(
+            "house(cmd): wood_before=%s pop_before=%s roi_bbox=%s ts=%d",
+            wood_before,
+            pop_before,
+            roi_bbox,
+            int(ts * 1000),
+        )
+
         input_utils._press_key_safe(state.config["keys"]["build_menu"], 0.05)
         input_utils._press_key_safe(house_key, 0.15)
         input_utils._click_norm(hx, hy)
         input_utils._click_norm(hx, hy, button="right")
-        time.sleep(0.5)
 
-        state.pop_cap += 4
-        return True
+        state_name = "ISSUED"
+        best_score = -1.0
+        wood_after = pop_after = None
+        queue_val = None
+        deadline = ts + 25.0
+
+        while time.time() < deadline:
+            try:
+                res_vals, (_cur, pop_cap) = resources.reader.read_resources_from_hud(
+                    required_icons=["wood_stockpile", "population_limit"],
+                    icons_to_read=["wood_stockpile", "population_limit"],
+                )
+                wood_after = res_vals.get("wood_stockpile", wood_after)
+                pop_after = pop_cap if pop_cap is not None else pop_after
+            except ResourceReadError:
+                pass
+
+            _cur, pop_cap, _low = hud.read_population_from_hud()
+            if pop_cap is not None:
+                pop_after = pop_cap
+
+            frame = screen_utils.screen_capture.grab_frame()
+            rx, ry, rw, rh = roi_bbox
+            roi = frame[ry : ry + rh, rx : rx + rw]
+            if tmpl is not None:
+                _box, score, _heat = template_utils.find_template(
+                    roi, tmpl, threshold=threshold, scales=state.config.get("scales")
+                )
+                if score is not None and score > best_score:
+                    best_score = score
+            else:
+                score = None
+
+            queue_reader = getattr(hud, "read_villager_build_queue_from_hud", None)
+            if queue_reader:
+                try:
+                    queue_val = queue_reader()
+                except Exception:
+                    queue_val = None
+
+            cond_pop = (
+                pop_before is not None and pop_after is not None and pop_after > pop_before
+            )
+            cond_wood = (
+                wood_before is not None
+                and wood_after is not None
+                and abs((wood_before - wood_after) - 30) <= 5
+            )
+            cond_tmpl = best_score >= threshold if best_score >= 0 else False
+
+            if state_name == "ISSUED" and (cond_pop or cond_wood or cond_tmpl):
+                state_name = "BUILDING_SEEN"
+
+            if state_name == "BUILDING_SEEN" and sum((cond_pop, cond_wood, cond_tmpl)) >= 2:
+                elapsed_ms = int((time.time() - ts) * 1000)
+                logger.info(
+                    "house(confirm): pop %s->%s wood %s->%s score=%.3f roi=%s elapsed_ms=%d queue=%s",
+                    pop_before,
+                    pop_after,
+                    wood_before,
+                    wood_after,
+                    best_score,
+                    roi_bbox,
+                    elapsed_ms,
+                    queue_val,
+                )
+                if pop_after is not None:
+                    state.pop_cap = pop_after
+                else:
+                    state.pop_cap += 4
+                return True
+
+            time.sleep(1.0)
+
+        elapsed_ms = int((time.time() - ts) * 1000)
+        logger.warning(
+            "house(failed-timeout): pop %s->%s wood %s->%s score=%.3f roi=%s elapsed_ms=%d",
+            pop_before,
+            pop_after,
+            wood_before,
+            wood_after,
+            best_score,
+            roi_bbox,
+            elapsed_ms,
+        )
 
     return False
 

--- a/tests/test_missing_resource_bar.py
+++ b/tests/test_missing_resource_bar.py
@@ -50,16 +50,39 @@ class TestMissingResourceBar(TestCase):
         self.assertEqual(state.current_pop, 5)
         read_mock.assert_not_called()
 
-    def test_build_house_does_not_read_missing_bar(self):
+    def test_build_house_handles_missing_bar(self):
         state.pop_cap = 4
+
+        def pop_side_effect(*a, **k):
+            if pop_side_effect.calls == 0:
+                pop_side_effect.calls += 1
+                return (0, 4, False)
+            return (0, 8, False)
+
+        pop_side_effect.calls = 0
+
         with patch(
             "script.resources.reader.read_resources_from_hud",
             side_effect=common.ResourceReadError("missing"),
-        ) as read_mock, \
-             patch("script.input_utils._press_key_safe"), \
-             patch("script.input_utils._click_norm"), \
-             patch("script.units.villager.time.sleep"):
+        ) as read_mock, patch(
+            "script.hud.read_population_from_hud", side_effect=pop_side_effect
+        ), patch(
+            "script.template_utils.find_template", return_value=(None, 0.9, None)
+        ), patch(
+            "pathlib.Path.exists", return_value=True
+        ), patch(
+            "cv2.imread", return_value=np.zeros((10, 10), dtype=np.uint8)
+        ), patch(
+            "script.screen_utils.screen_capture.grab_frame",
+            return_value=np.zeros((200, 200, 3), dtype=np.uint8),
+        ), patch(
+            "script.input_utils._press_key_safe"
+        ), patch(
+            "script.input_utils._click_norm"
+        ), patch(
+            "script.units.villager.time.sleep"
+        ):
             result = villager.build_house(state=state)
         self.assertTrue(result)
         self.assertEqual(state.pop_cap, 8)
-        read_mock.assert_not_called()
+        read_mock.assert_called()


### PR DESCRIPTION
## Summary
- track villager house builds with a ISSUED→BUILDING_SEEN→DONE/FAILED state machine
- log wood/population deltas, ROI and template score before confirming
- add tests for confirmed builds and missing resource bar handling

## Testing
- `pytest`
- `pytest tests/test_build_house.py tests/test_missing_resource_bar.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9fc7d4a488325b0242eb3e421a91c