### PR TITLE
Let build_house handle logging in train_villagers

### DIFF
--- a/script/buildings/town_center.py
+++ b/script/buildings/town_center.py
@@ -26,13 +26,9 @@ def train_villagers(target_pop: int, state: BotState = STATE):
             while time.time() < deadline:
                 if select_idle_villager(state=state):
                     if build_house(state=state):
-                        logger.info("House built to increase population")
                         built_house = True
                         break
-                    else:
-                        logger.warning(
-                            "Failed to build house to increase population"
-                        )
+                    # build_house logs success or failure internally
                 else:
                     logger.warning("No idle villager to build house")
                 time.sleep(1.0)


### PR DESCRIPTION
## Summary
- Remove success/failure logging for house construction in `train_villagers`
- Keep idle villager warning so `build_house` provides the rest

## Testing
- `pytest` *(fails: 46 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ba01ab3cbc832584cc3bbbf3dc3e21