### PR TITLE
Confirm villager training via HUD

### DIFF
--- a/tests/test_internal_population.py
+++ b/tests/test_internal_population.py
@@ -81,12 +81,20 @@ class TestInternalPopulation(TestCase):
             state.pop_cap += 4
             return True
 
+        pop_vals = [
+            (4, 4, False),
+            (5, 8, False),
+            (6, 8, False),
+            (7, 8, False),
+        ]
         with patch("script.resources.reader.read_resources_from_hud") as read_mock, \
              patch("script.buildings.town_center.build_house", side_effect=fake_build_house) as build_house_mock, \
-             patch("script.buildings.town_center.select_idle_villager", return_value=True):
+             patch("script.buildings.town_center.select_idle_villager", return_value=True), \
+             patch("script.hud.read_population_from_hud", side_effect=pop_vals) as pop_mock:
             tc.train_villagers(7, state=state)
             self.assertEqual(state.current_pop, 7)
             self.assertEqual(state.pop_cap, 8)
             build_house_mock.assert_called_once()
             read_mock.assert_not_called()
+            self.assertEqual(pop_mock.call_count, 4)
 


### PR DESCRIPTION
## Summary
- Verify villager training by reading queue or population from HUD
- Update population only after HUD confirmation
- Adapt tests to mock HUD population checks and set Tesseract path

## Testing
- `pytest tests/test_missing_resource_bar.py tests/test_internal_population.py -q`
- `pytest -q` *(fails: Invalid Tesseract OCR path and OpenCV errors, 90 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba02e0ee60832594511e8b6e0ba530