### PR TITLE
Simplify house construction sequence

### DIFF
--- a/script/units/villager.py
+++ b/script/units/villager.py
@@ -86,9 +86,8 @@ def build_house(state: BotState = STATE):
             int(ts * 1000),
         )
 
-        input_utils._press_key_safe(state.config["keys"]["build_menu"], 0.05)
+        select_idle_villager(state=state)
         input_utils._press_key_safe(house_key, 0.15)
-        input_utils._click_norm(hx, hy)
         input_utils._click_norm(hx, hy, button="right")
 
         state_name = "ISSUED"

--- a/tests/test_build_house.py
+++ b/tests/test_build_house.py
@@ -74,7 +74,7 @@ class TestClickAndBuildHouse(TestCase):
             return_value=np.zeros((200, 200, 3), dtype=np.uint8),
         ), patch(
             "script.input_utils._press_key_safe"
-        ), patch(
+        ) as press_mock, patch(
             "script.input_utils._click_norm"
         ) as click_mock, patch(
             "script.units.villager.time.sleep"
@@ -83,10 +83,12 @@ class TestClickAndBuildHouse(TestCase):
 
         self.assertTrue(result)
         self.assertEqual(state.pop_cap, 8)
-        self.assertEqual(click_mock.call_count, 2)
-        self.assertEqual(click_mock.call_args_list[0].args, expected_coords)
-        self.assertEqual(click_mock.call_args_list[1].args, expected_coords)
-        self.assertEqual(click_mock.call_args_list[1].kwargs["button"], "right")
+        self.assertEqual(click_mock.call_count, 1)
+        self.assertEqual(click_mock.call_args[0], expected_coords)
+        self.assertEqual(click_mock.call_args[1]["button"], "right")
+        self.assertEqual(press_mock.call_count, 2)
+        self.assertEqual(press_mock.call_args_list[0].args[0], state.config["keys"]["idle_vill"])
+        self.assertEqual(press_mock.call_args_list[1].args[0], state.config["keys"]["house"])
         self.assertGreaterEqual(read_mock.call_count, 2)
         self.assertGreaterEqual(read_pop_mock.call_count, 1)
         tmpl_mock.assert_called()


### PR DESCRIPTION
## Summary
- Build houses by selecting an idle villager and immediately using the house hotkey
- Place houses with a single right-click instead of left/right combo
- Update tests for new villager house-building behavior

## Testing
- `pytest tests/test_build_house.py -q`
- `pytest -q` *(fails: invalid Tesseract OCR path and numerous resource/ROI assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0c1ef0e8832590e34d866b4a9bb3