### PR TITLE
feat: add foraging mission routine

### DIFF
--- a/script/units/villager.py
+++ b/script/units/villager.py
@@ -213,3 +213,21 @@ def build_storage_pit(state: BotState = STATE):
     sx, sy = spot
     input_utils._click_norm(sx, sy)
     return True
+
+
+def build_dock(state: BotState = STATE):
+    """Posiciona um Dock no ponto configurado."""
+    input_utils._press_key_safe(state.config["keys"]["build_menu"], 0.05)
+    d_key = state.config["keys"].get("dock")
+    if not d_key:
+        logger.warning("Dock build key not configured.")
+        return False
+    areas = state.config.get("areas", {})
+    spot = areas.get("dock_spot")
+    if not spot:
+        logger.warning("Dock spot not configured.")
+        return False
+    input_utils._press_key_safe(d_key, 0.15)
+    dx, dy = spot
+    input_utils._click_norm(dx, dy)
+    return True

--- a/tests/test_foraging_scenario.py
+++ b/tests/test_foraging_scenario.py
@@ -188,6 +188,95 @@ class TestForagingScenario(TestCase):
         self.assertEqual(module.resources.RESOURCE_CACHE.last_resource_values, {})
         self.assertTrue(any("population" in m.lower() for m in log_ctx.output))
 
+    def test_main_invokes_run_mission(self):
+        info = config_utils.ScenarioInfo(
+            starting_villagers=3,
+            starting_idle_villagers=3,
+            population_limit=4,
+            starting_resources={
+                "wood_stockpile": 200,
+                "food_stockpile": 200,
+                "gold_stockpile": 0,
+                "stone_stockpile": 100,
+            },
+            objective_villagers=0,
+            starting_buildings={"Town Center": 1},
+        )
+
+        gathered = dict(info.starting_resources)
+        gathered["idle_villager"] = info.starting_idle_villagers
+
+        import importlib
+
+        module = importlib.import_module(
+            "campaigns.Ascent_of_Egypt.Egypt_2_Foraging"
+        )
+
+        with patch.object(module.hud, "wait_hud", return_value=((0, 0, 0, 0), "asset")), \
+            patch.object(module, "parse_scenario_info", return_value=info), \
+            patch.object(module.resources, "gather_hud_stats", return_value=(gathered, (info.starting_villagers, info.population_limit))), \
+            patch.object(module.resources, "validate_starting_resources"), \
+            patch.object(module, "run_mission") as mission_mock, \
+            patch.object(module.resources, "RESOURCE_CACHE", resources.ResourceCache()):
+            module.main()
+
+        mission_mock.assert_called_once_with(info, state=module.STATE)
+
+    def test_run_mission_calls_build_functions(self):
+        info = config_utils.ScenarioInfo(
+            starting_villagers=3,
+            starting_idle_villagers=2,
+            population_limit=10,
+            starting_resources=None,
+            objective_villagers=5,
+            starting_buildings={"Town Center": 1},
+        )
+
+        import importlib
+
+        module = importlib.import_module(
+            "campaigns.Ascent_of_Egypt.Egypt_2_Foraging"
+        )
+
+        state.current_pop = info.starting_villagers
+        state.target_pop = info.objective_villagers
+
+        calls = []
+
+        def fake_select(*a, **k):
+            return True
+
+        def fake_click(*a, **k):
+            pass
+
+        def fake_granary(*a, **k):
+            calls.append("granary")
+            return True
+
+        def fake_storage(*a, **k):
+            calls.append("storage")
+            return True
+
+        def fake_dock(*a, **k):
+            calls.append("dock")
+            return True
+
+        def fake_train(target_pop, state=state):
+            state.current_pop += 1
+
+        with patch.object(module.villager, "select_idle_villager", side_effect=fake_select), \
+            patch.object(module.input_utils, "_click_norm", side_effect=fake_click), \
+            patch.object(module.villager, "build_granary", side_effect=fake_granary), \
+            patch.object(module.villager, "build_storage_pit", side_effect=fake_storage), \
+            patch.object(module.villager, "build_dock", side_effect=fake_dock), \
+            patch.object(module, "train_villagers", side_effect=fake_train):
+            module.run_mission(info, state=state)
+
+        self.assertIn("granary", calls)
+        self.assertIn("storage", calls)
+        self.assertIn("dock", calls)
+        self.assertGreaterEqual(state.current_pop, state.target_pop)
+
     def test_aborts_on_pop_cap_mismatch(self):
         info = config_utils.ScenarioInfo(
             starting_villagers=3,
@@ -222,3 +311,5 @@ class TestForagingScenario(TestCase):
         gather_mock.assert_called_once()
         self.assertEqual(module.resources.RESOURCE_CACHE.last_resource_values, {})
         self.assertTrue(any("population" in m.lower() for m in log_ctx.output))
+
+


### PR DESCRIPTION
## Summary
- add mission logic for Foraging scenario including food gathering, building construction and villager training
- add dock construction helper
- test run_mission invocation and building actions

## Testing
- `pytest tests/test_foraging_scenario.py::TestForagingScenario::test_main_invokes_run_mission -q`
- `pytest tests/test_foraging_scenario.py::TestForagingScenario::test_run_mission_calls_build_functions -q`
- `pytest -q` *(fails: Invalid Tesseract OCR path and OpenCV errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ba25b3caf08325953cf58467a09737